### PR TITLE
feat: add linux/arm64 build and release support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,8 @@ jobs:
           files: |
             releases/leafwiki-${{ github.ref_name }}-linux-amd64
             releases/leafwiki-${{ github.ref_name }}-linux-amd64.sha256
+            releases/leafwiki-${{ github.ref_name }}-linux-arm64
+            releases/leafwiki-${{ github.ref_name }}-linux-arm64.sha256
             releases/leafwiki-${{ github.ref_name }}-windows-amd64.exe
             releases/leafwiki-${{ github.ref_name }}-windows-amd64.exe.sha256
         env:

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ DOCKER_BUILDER := Dockerfile.builder
 # At the moment we only can test it on linux/amd64 and windows/amd64
 PLATFORMS := \
   linux/amd64 \
+  linux/arm64 \
   windows/amd64
 
 all: build

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ VERSION ?= v0.1.0
 RELEASE_DIR := releases
 DOCKER_BUILDER := Dockerfile.builder
 
-# At the moment we only can test it on linux/amd64 and windows/amd64
+# At the moment we can test on linux/amd64, linux/arm64, and windows/amd64
 PLATFORMS := \
   linux/amd64 \
   linux/arm64 \


### PR DESCRIPTION
Issue: #71 

## Feature change:
* Added linux/arm64 to the Makefile’s PLATFORMS so make release now builds an ARM64 binary.
* Updated the release workflow to upload the ARM64 binary and its checksum to GitHub Releases.
* ARM64 binary can be tested using Docker.

## How to test:
* Run make release locally (requires Docker) — check that releases/leafwiki-<version>-linux-arm64 and its checksum are produced.
* (optional) enable the buildx `docker buildx create --use --name multiarch`.
*  Verify with the target build 
`docker run --rm -it --platform linux/arm64 \
  -v "$(pwd)":/app \
  ubuntu:22.04 \
  /app/releases/leafwiki-v0.1.0-linux-arm64 --help`

Feel free to review and test .