### PR TITLE
fix: gh-release issue by using a pinned version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,9 @@ jobs:
           dueTag: ${{ github.ref_name }}
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        # use pinned version because of issue described here:
+        # https://github.com/softprops/action-gh-release/issues/628
+        uses: softprops/action-gh-release@v2.2.2
         if: github.ref_type == 'tag'
         with:
           tag_name: ${{ github.ref_name }}


### PR DESCRIPTION
Error Message:
> 1: 0xcc7f77 node::Assert(node::AssertionInfo const&) [/home/runner/runners/2.325.0/externals/node20/bin/node]
> 2: 0xcd24fa node::fs::FileHandle::ClosePromise() [/home/runner/runners/2.325.0/externals/node20/bin/node]
> 3: 0xcd2666 node::fs::FileHandle::Close(v8::FunctionCallbackInfov8::Value const&) [/home/runner/runners/2.325.0/externals/node20/bin/node]
> 4: 0xf6c56f v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo) [/home/runner/runners/2.325.0/externals/node20/bin/node]
> 5: 0xf6cddd [/home/runner/runners/2.325.0/externals/node20/bin/node]
> 6: 0xf6d2a5 v8::internal::Builtin_HandleApiCall(int, unsigned long*, v8::internal::Isolate*) [/home/runner/runners/2.325.0/externals/node20/bin/node]
> 7: 0x1977df6 [/home/runner/runners/2.325.0/externals/node20/bin/node]
>----- JavaScript stack trace -----
>1: close (node:internal/fs/promises:250:23)
>2: upload (/home/runner/work/_actions/softprops/action-gh-release/v2/dist/index.js:16:16275)