### PR TITLE
fix: mount only one editor and preview for desktop & mobile view

### DIFF
--- a/ui/leafwiki-ui/src/features/editor/MarkdownEditor.tsx
+++ b/ui/leafwiki-ui/src/features/editor/MarkdownEditor.tsx
@@ -268,9 +268,9 @@ const MarkdownEditor = (
     )
   }, [assetVersion, debouncedPreview, setPreviewRef])
 
-// TODO: Known Issues:
-// * When we resize the window, the preview does not update immediately.
-// * I will leave the issue open for now. (You can validate this by resizing the window in the edit mode)
+  // TODO: Known Issues:
+  // * When we resize the window, the preview does not update immediately.
+  // * I will leave the issue open for now. (You can validate this by resizing the window in the edit mode)
 
   return (
     <div className="flex h-full w-full flex-col overflow-hidden">


### PR DESCRIPTION
This resolves the issue #104.
Now the buttons are also working the mobile UI.