### PR TITLE
fix: cursor jumps to first line after saving

### DIFF
--- a/ui/leafwiki-ui/src/features/editor/MarkdownEditor.tsx
+++ b/ui/leafwiki-ui/src/features/editor/MarkdownEditor.tsx
@@ -58,8 +58,10 @@ const MarkdownEditor = (
 
   const [activeTab, setActiveTab] = useState<'editor' | 'preview'>('editor')
 
+  // Set initial markdown value when component mounts
+  // This sets the initial value only once
   useEffect(() => {
-    setMarkdown(initialValue)
+    setMarkdown((prev) => (prev === '' ? initialValue : prev))
   }, [initialValue])
 
   const handleEditorChange = useCallback(

--- a/ui/leafwiki-ui/src/features/page/PageEditor.tsx
+++ b/ui/leafwiki-ui/src/features/page/PageEditor.tsx
@@ -179,8 +179,9 @@ export default function PageEditor() {
   }, [parentPath, slug, handleNavigateAway, reloadTree, showUnsavedDialog])
 
   // We set the initial content of the page editor
+  // This is only done once when the page is loaded
   useEffect(() => {
-    if (page) {
+    if (page && initialContentRef.current === null) {
       initialContentRef.current = page.content
       initialSlugRef.current = page.slug
       setMarkdown(page.content)


### PR DESCRIPTION
-  Set initial value only on startup (markdownEditor & PageEditor)