### PR TITLE
Smaller UI Improvements

### DIFF
--- a/ui/leafwiki-ui/src/features/editor/MarkdownToolbar.tsx
+++ b/ui/leafwiki-ui/src/features/editor/MarkdownToolbar.tsx
@@ -67,7 +67,7 @@ export default function MarkdownToolbar({
 
   return (
     <>
-      <div className="sticky top-0 z-10 flex gap-1.5 border-b border-zinc-700 bg-zinc-900 p-2 shadow-xs">
+      <div className="sticky top-0 z-10 flex flex-wrap gap-1.5 border-b border-zinc-700 bg-zinc-900 p-2 shadow-xs">
         <TooltipWrapper label="Bold (Ctrl+B)" side="top" align="center">
           <Button
             variant="ghost"

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -213,7 +213,7 @@
 
 @layer content {
   main a {
-    @apply text-green-600 hover:text-green-800 no-underline;
+    @apply text-green-600 no-underline hover:text-green-800;
   }
 }
 

--- a/ui/leafwiki-ui/src/layout/AppLayout.tsx
+++ b/ui/leafwiki-ui/src/layout/AppLayout.tsx
@@ -73,8 +73,9 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
       </header>
       <div className="h-[85px] w-full" />
       <div className="flex h-[calc(100vh-85px)] transition-all duration-200">
+        {/* ml-[-1px] is used to prevent a border when the sidebar is closed */}
         <div
-          className={`z-20 h-full overflow-auto border-r border-gray-200 bg-white transition-all duration-200 max-sm:fixed max-sm:h-[calc(100vh-85px)] ${
+          className={`z-20 ml-[-1px] h-full overflow-auto border-r border-l-0 border-gray-200 bg-white transition-all duration-200 max-sm:fixed max-sm:h-[calc(100vh-85px)] ${
             sidebarVisible ? 'w-96' : 'w-0'
           }`}
         >


### PR DESCRIPTION
- Using green links in the content container
- Remove ugly border from the left side of the code mirror editor (This happend because of the border of the sidebar)
- Markdown Toolbar should break in mobile view. Otherwise the redo button is not visible