### PR TITLE
feat(Docker): Add Label, and annotation in docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,10 @@ EXPOSE 8080
 
 RUN mkdir -p /app/data && chmod 777 /app/data
 
+LABEL org.opencontainers.image.title="LeafWiki" \
+      org.opencontainers.image.description="A lightweight, self-hosted wiki built in Go - tree-based, fast, and storing content in plain Markdown." \
+      org.opencontainers.image.url="https://demo.leafwiki.com" \
+      org.opencontainers.image.source="https://github.com/perber/leafwiki" \
+      org.opencontainers.image.licenses="MIT"
+
 ENTRYPOINT ["/app/leafwiki"]

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ endif
 		--target final \
 		--tag ghcr.io/$(REPO_OWNER)/leafwiki:$(VERSION) \
 		--tag ghcr.io/$(REPO_OWNER)/leafwiki:latest \
+		--annotation "org.opencontainers.image.description=A lightweight, self-hosted wiki built in Go - tree-based, fast, and storing content in plain Markdown." \
 		--push .
 
 # Generate markdown changelog between two tags


### PR DESCRIPTION
This PR follows Issue #305 

Resume:

- add docker label in Dockerfile
- add annotation in manifest