### PR TITLE
fix: the sidebar was taking space in the printview

### DIFF
--- a/ui/leafwiki-ui/src/features/sidebar/Sidebar.tsx
+++ b/ui/leafwiki-ui/src/features/sidebar/Sidebar.tsx
@@ -18,7 +18,8 @@ export default function Sidebar() {
     <aside
       key={'sidebar'}
       data-testid="sidebar"
-      className="sidebar-container flex h-full w-full flex-col overflow-hidden bg-white"
+      id="sidebar"
+      className="flex h-full w-full flex-col overflow-hidden bg-white"
     >
       {/*
         The actual width is controlled by the parent container (AppLayout)

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -297,8 +297,12 @@ Highlight styles
     margin-top: 20px;
   }
 
+  #sidebar-container {
+    width: 0 !important;
+  }
+
   header,
-  aside,
+  #sidebar-container,
   .sidebar-wrapper {
     display: none;
   }

--- a/ui/leafwiki-ui/src/layout/AppLayout.tsx
+++ b/ui/leafwiki-ui/src/layout/AppLayout.tsx
@@ -171,6 +171,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
       <div className="content-wrapper flex h-[calc(100dvh-85px)] transition-all duration-200">
         <div
           ref={sidebarContainerRef}
+          id="sidebar-container"
           className={
             'custom-scrollbar relative z-20 box-border h-full overflow-auto bg-white pr-1 max-sm:fixed max-sm:h-[calc(100dvh-85px)]' +
             (resizing ? '' : ' transition-[width] duration-200')


### PR DESCRIPTION
This problem happend, because we changed the sidebar width directly in the dom.
