### PR TITLE
Add Railway deployment instructions to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -261,7 +261,7 @@ You can change the data directory with the `--data-dir` flag.
 The JWT secret is required for authentication and should be kept secure.
 
 ### Deploy on Railway
-Leafwiki can be deployed in one click on Railway, all the necessary config are already taken care of. 
+Leafwiki can be deployed in one click on Railway, all the necessary configs are already taken care of. 
 Make sure to change `LEAFWIKI_ADMIN_PASSWORD` when deploying as the default value otherwise will be `admin`
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/leafwiki?referralCode=iz4oG7&utm_medium=integration&utm_source=template&utm_campaign=generic)


### PR DESCRIPTION
## Add Railway Deployment Instructions

This PR adds a **"Deploy on Railway"** section to the README to make it easier for users to launch Leafwiki with minimal setup.

Railway provides a simple way to deploy the application without manual server configuration, handling provisioning and scaling automatically. With this addition, users can deploy Leafwiki in just a few clicks.

I also added a note reminding users to change the `LEAFWIKI_ADMIN_PASSWORD` during deployment, since the default value would otherwise remain `admin`.

> **Note:** The deploy link currently includes my Railway referral code. I’m happy to switch it to a neutral link if preferred - just let me know.