### PR TITLE
fix(tree): materialize section index safely

### DIFF
--- a/internal/core/tree/node_store.go
+++ b/internal/core/tree/node_store.go
@@ -69,6 +69,35 @@ func (f *NodeStore) syncManagedFrontmatter(mdFile *markdown.MarkdownFile, entry 
 	)
 }
 
+func (f *NodeStore) ensureSectionIndex(entry *PageNode) (string, error) {
+	if entry == nil {
+		return "", &InvalidOpError{Op: "ensureSectionIndex", Reason: "an entry is required"}
+	}
+	if entry.Kind != NodeKindSection {
+		return "", &InvalidOpError{Op: "ensureSectionIndex", Reason: "entry must be a section"}
+	}
+
+	filePath, err := f.contentPathForNodeWrite(entry)
+	if err != nil {
+		return "", err
+	}
+
+	mdFile := markdown.NewMarkdownFile(filePath, "", markdown.Frontmatter{})
+	if fileExists(filePath) {
+		mdFile, err = markdown.LoadMarkdownFile(filePath)
+		if err != nil {
+			return "", fmt.Errorf("could not load markdown file: %w", err)
+		}
+	}
+
+	f.syncManagedFrontmatter(mdFile, entry)
+	if err := mdFile.WriteToFile(); err != nil {
+		return "", fmt.Errorf("could not write markdown file: %w", err)
+	}
+
+	return filePath, nil
+}
+
 func fallbackMetadataString(value string) string {
 	if strings.TrimSpace(value) == "" {
 		return reconstructSystemUserID
@@ -264,6 +293,12 @@ func (f *NodeStore) reconstructTreeRecursive(currentPath string, parent *PageNod
 			}
 			parent.Children = append(parent.Children, child)
 
+			if !fileExists(indexPath) {
+				if _, err := f.ensureSectionIndex(child); err != nil {
+					return fmt.Errorf("materialize missing section index for %s: %w", indexPath, err)
+				}
+			}
+
 			if err := f.reconstructTreeRecursive(filepath.Join(currentPath, name), child, reconstructNow); err != nil {
 				return err
 			}
@@ -442,9 +477,13 @@ func (f *NodeStore) CreateSection(parentEntry *PageNode, newEntry *PageNode) err
 		return &PageAlreadyExistsError{Path: destBase}
 	}
 
-	// Create the folder for the section (no index.md by default)
+	// Create the folder for the section and materialize its metadata container.
 	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		return fmt.Errorf("could not create section folder: %w", err)
+	}
+
+	if _, err := f.ensureSectionIndex(newEntry); err != nil {
+		return err
 	}
 
 	return nil
@@ -935,11 +974,19 @@ func (f *NodeStore) ConvertNode(entry *PageNode, target NodeKind) error {
 			if err := os.Rename(filePath, indexPath); err != nil {
 				return fmt.Errorf("could not move page into folder: %w", err)
 			}
+			entry.Kind = NodeKindSection
+			if _, err := f.ensureSectionIndex(entry); err != nil {
+				return err
+			}
 			return nil
 		}
-		// already folder (or missing) -> ensure dir exists
+		// already folder (or missing) -> ensure dir exists and materialize index.md
 		if err := os.MkdirAll(folderPath, 0o755); err != nil {
 			return fmt.Errorf("could not ensure folder exists: %w", err)
+		}
+		entry.Kind = NodeKindSection
+		if _, err := f.ensureSectionIndex(entry); err != nil {
+			return err
 		}
 		return nil
 

--- a/internal/core/tree/node_store_reconstruct_test.go
+++ b/internal/core/tree/node_store_reconstruct_test.go
@@ -140,11 +140,10 @@ leafwiki_title: Readme
 	}
 }
 
-func TestNodeStore_ReconstructTreeFromFS_SectionWithoutIndex_UsesDirNameAsTitle(t *testing.T) {
+func TestNodeStore_ReconstructTreeFromFS_SectionWithoutIndex_UsesDirNameAsTitleAndMaterializesIndex(t *testing.T) {
 	tmp := t.TempDir()
 	store := NewNodeStore(tmp)
 
-	// FS: <tmp>/emptysec/ (no index.md)
 	mustMkdir(t, filepath.Join(tmp, "root", "emptysec"))
 
 	tree, err := store.ReconstructTreeFromFS()
@@ -156,12 +155,30 @@ func TestNodeStore_ReconstructTreeFromFS_SectionWithoutIndex_UsesDirNameAsTitle(
 	if sec.Kind != NodeKindSection {
 		t.Fatalf("expected section, got %q", sec.Kind)
 	}
-	// title defaults to folder name (per your code)
 	if sec.Title != "emptysec" {
 		t.Fatalf("expected title=emptysec, got %q", sec.Title)
 	}
 	if strings.TrimSpace(sec.ID) == "" {
 		t.Fatalf("expected some generated id, got empty")
+	}
+
+	indexPath := filepath.Join(tmp, "root", "emptysec", "index.md")
+	raw, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("expected reconstruct to materialize missing index.md: %v", err)
+	}
+	fm, body, has, err := markdown.ParseFrontmatter(string(raw))
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	if !has {
+		t.Fatalf("expected frontmatter in materialized index")
+	}
+	if fm.LeafWikiID != sec.ID || fm.LeafWikiTitle != sec.Title {
+		t.Fatalf("unexpected frontmatter in materialized index: %#v", fm)
+	}
+	if strings.TrimSpace(body) != "" {
+		t.Fatalf("expected empty body in materialized index, got %q", body)
 	}
 }
 

--- a/internal/core/tree/node_store_test.go
+++ b/internal/core/tree/node_store_test.go
@@ -110,12 +110,24 @@ func TestNodeStore_SaveTree_NilTree_Error(t *testing.T) {
 	}
 }
 
-func TestNodeStore_CreateSection_CreatesFolder_NoIndexByDefault(t *testing.T) {
+func TestNodeStore_CreateSection_CreatesFolderAndIndexWithFrontmatter(t *testing.T) {
 	tmp := t.TempDir()
 	store := NewNodeStore(tmp)
 
 	root := &PageNode{ID: "root", Slug: "root", Title: "root", Kind: NodeKindSection}
-	sec := &PageNode{ID: "sec1", Slug: "docs", Title: "Docs", Kind: NodeKindSection, Parent: root}
+	sec := &PageNode{
+		ID:     "sec1",
+		Slug:   "docs",
+		Title:  "Docs",
+		Kind:   NodeKindSection,
+		Parent: root,
+		Metadata: PageMetadata{
+			CreatedAt:    time.Date(2026, time.March, 22, 10, 15, 30, 0, time.UTC),
+			UpdatedAt:    time.Date(2026, time.March, 22, 11, 16, 31, 0, time.UTC),
+			CreatorID:    "alice",
+			LastAuthorID: "bob",
+		},
+	}
 
 	if err := store.CreateSection(root, sec); err != nil {
 		t.Fatalf("CreateSection: %v", err)
@@ -127,10 +139,26 @@ func TestNodeStore_CreateSection_CreatesFolder_NoIndexByDefault(t *testing.T) {
 		t.Fatalf("expected section folder at %s", dir)
 	}
 
-	// no index.md by default
 	index := filepath.Join(dir, "index.md")
-	if _, err := os.Stat(index); err == nil {
-		t.Fatalf("did not expect index.md to exist by default: %s", index)
+	raw := string(mustRead(t, index))
+	fm, body, has, err := markdown.ParseFrontmatter(raw)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	if !has {
+		t.Fatalf("expected frontmatter in section index")
+	}
+	if fm.LeafWikiID != "sec1" || fm.LeafWikiTitle != "Docs" {
+		t.Fatalf("unexpected section frontmatter: %#v", fm)
+	}
+	if fm.LeafWikiCreatedAt != "2026-03-22T10:15:30Z" || fm.LeafWikiUpdatedAt != "2026-03-22T11:16:31Z" {
+		t.Fatalf("unexpected section timestamp metadata: %#v", fm)
+	}
+	if fm.LeafWikiCreatorID != "alice" || fm.LeafWikiLastAuthorID != "bob" {
+		t.Fatalf("unexpected section author metadata: %#v", fm)
+	}
+	if strings.TrimSpace(body) != "" {
+		t.Fatalf("expected empty section body, got %q", body)
 	}
 }
 
@@ -477,7 +505,6 @@ func TestNodeStore_ReadPageRaw_Section_NoIndex_ReturnsEmptyNil(t *testing.T) {
 	root := &PageNode{ID: "root", Slug: "root", Title: "root", Kind: NodeKindSection}
 	sec := &PageNode{ID: "s1", Slug: "docs", Title: "Docs", Kind: NodeKindSection, Parent: root}
 
-	// folder exists, but no index.md
 	mustMkdir(t, filepath.Join(tmp, "root", "docs"))
 
 	raw, err := store.ReadPageRaw(sec)
@@ -486,6 +513,10 @@ func TestNodeStore_ReadPageRaw_Section_NoIndex_ReturnsEmptyNil(t *testing.T) {
 	}
 	if raw != "" {
 		t.Fatalf("expected empty raw for section without index, got %q", raw)
+	}
+
+	if _, err := os.Stat(filepath.Join(tmp, "root", "docs", "index.md")); err == nil {
+		t.Fatalf("expected no index.md side effect on read")
 	}
 }
 
@@ -754,6 +785,65 @@ func TestNodeStore_ConvertNode_PageToSection_MovesToIndex(t *testing.T) {
 	}
 	if _, err := os.Stat(file); !os.IsNotExist(err) {
 		t.Fatalf("expected old file removed")
+	}
+}
+
+func TestNodeStore_ConvertNode_PageToSection_PreservesExistingMetadataAndBody(t *testing.T) {
+	tmp := t.TempDir()
+	store := NewNodeStore(tmp)
+
+	root := &PageNode{ID: "root", Slug: "root", Title: "root", Kind: NodeKindSection}
+	entry := &PageNode{
+		ID:     "p1",
+		Slug:   "p",
+		Title:  "Section Title",
+		Kind:   NodeKindPage,
+		Parent: root,
+		Metadata: PageMetadata{
+			CreatedAt:    time.Date(2026, time.March, 22, 10, 15, 30, 0, time.UTC),
+			UpdatedAt:    time.Date(2026, time.March, 22, 11, 16, 31, 0, time.UTC),
+			CreatorID:    "alice",
+			LastAuthorID: "bob",
+		},
+	}
+
+	file := filepath.Join(tmp, "root", "p.md")
+	mustWriteFile(t, file, `---
+custom_key: keep-me
+leafwiki_id: legacy-id
+leafwiki_title: Legacy Title
+---
+# hi
+`, 0o644)
+
+	if err := store.ConvertNode(entry, NodeKindSection); err != nil {
+		t.Fatalf("ConvertNode(page->section): %v", err)
+	}
+
+	index := filepath.Join(tmp, "root", "p", "index.md")
+	raw := string(mustRead(t, index))
+	if !strings.Contains(raw, "custom_key: keep-me") {
+		t.Fatalf("expected custom frontmatter to be preserved, got %q", raw)
+	}
+
+	fm, body, has, err := markdown.ParseFrontmatter(raw)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	if !has {
+		t.Fatalf("expected frontmatter after conversion")
+	}
+	if fm.LeafWikiID != "p1" || fm.LeafWikiTitle != "Section Title" {
+		t.Fatalf("expected managed frontmatter from tree metadata, got %#v", fm)
+	}
+	if fm.LeafWikiCreatedAt != "2026-03-22T10:15:30Z" || fm.LeafWikiUpdatedAt != "2026-03-22T11:16:31Z" {
+		t.Fatalf("expected timestamps from tree metadata, got %#v", fm)
+	}
+	if fm.LeafWikiCreatorID != "alice" || fm.LeafWikiLastAuthorID != "bob" {
+		t.Fatalf("expected author metadata from tree metadata, got %#v", fm)
+	}
+	if strings.TrimSpace(body) != "# hi" {
+		t.Fatalf("expected body to be preserved, got %q", body)
 	}
 }
 

--- a/internal/core/tree/schema.go
+++ b/internal/core/tree/schema.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 )
 
-const CurrentSchemaVersion = 3
+const CurrentSchemaVersion = 4
 
 type SchemaInfo struct {
 	Version int `json:"version"`

--- a/internal/core/tree/tree_service.go
+++ b/internal/core/tree/tree_service.go
@@ -88,6 +88,11 @@ func (t *TreeService) migrate(fromVersion int) error {
 				t.log.Error("Error migrating to v3", "error", err)
 				return err
 			}
+		case 3:
+			if err := t.migrateToV4(); err != nil {
+				t.log.Error("Error migrating to v4", "error", err)
+				return err
+			}
 		}
 
 		// Save the tree after each migration step
@@ -210,6 +215,31 @@ func (t *TreeService) migrateToV3() error {
 	}
 
 	return backfillMetadataFrontmatter(t.tree)
+}
+
+func (t *TreeService) migrateToV4() error {
+	if t.tree == nil {
+		return ErrTreeNotLoaded
+	}
+
+	var materializeSectionIndexes func(node *PageNode) error
+	materializeSectionIndexes = func(node *PageNode) error {
+		if node != nil && node.ID != "root" && node.Kind == NodeKindSection {
+			if _, err := t.store.ensureSectionIndex(node); err != nil {
+				return fmt.Errorf("could not materialize section index for node %s: %w", node.ID, err)
+			}
+		}
+
+		for _, child := range node.Children {
+			if err := materializeSectionIndexes(child); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	return materializeSectionIndexes(t.tree)
 }
 
 // migrateToV2 migrates the tree to the v2 schema

--- a/internal/core/tree/tree_service_test.go
+++ b/internal/core/tree/tree_service_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -150,6 +151,44 @@ func TestTreeService_CreateNode_Page_Root_CreatesFileAndFrontmatter(t *testing.T
 	}
 	if fm.LeafWikiCreatorID != "system" || fm.LeafWikiLastAuthorID != "system" {
 		t.Fatalf("expected creator metadata to be set, got %#v", fm)
+	}
+}
+
+func TestTreeService_CreateNode_Section_CreatesIndexWithFrontmatter(t *testing.T) {
+	svc, tmpDir := newLoadedService(t)
+
+	id, err := svc.CreateNode("system", nil, "Docs", "docs", ptrKind(NodeKindSection))
+	if err != nil {
+		t.Fatalf("CreateNode failed: %v", err)
+	}
+
+	index := filepath.Join(tmpDir, "root", "docs", "index.md")
+	raw, err := os.ReadFile(index)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+
+	fm, body, has, err := markdown.ParseFrontmatter(string(raw))
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	if !has {
+		t.Fatalf("expected frontmatter to exist")
+	}
+	if strings.TrimSpace(fm.LeafWikiID) != *id {
+		t.Fatalf("expected leafwiki_id=%q, got %q", *id, fm.LeafWikiID)
+	}
+	if fm.LeafWikiTitle != "Docs" {
+		t.Fatalf("expected leafwiki_title Docs, got %q", fm.LeafWikiTitle)
+	}
+	if fm.LeafWikiCreatedAt == "" || fm.LeafWikiUpdatedAt == "" {
+		t.Fatalf("expected leafwiki timestamps to be set, got %#v", fm)
+	}
+	if fm.LeafWikiCreatorID != "system" || fm.LeafWikiLastAuthorID != "system" {
+		t.Fatalf("expected creator metadata to be set, got %#v", fm)
+	}
+	if strings.TrimSpace(body) != "" {
+		t.Fatalf("expected empty section body, got %q", body)
 	}
 }
 
@@ -578,6 +617,85 @@ func TestTreeService_SortPages_DuplicateID(t *testing.T) {
 
 // --- E) Routing, Lookup, Ensure ---
 
+func TestTreeService_GetPage_SectionWithoutIndex_DoesNotMaterializeIndex(t *testing.T) {
+	svc, tmpDir := newLoadedService(t)
+
+	id, err := svc.CreateNode("system", nil, "Docs", "docs", ptrKind(NodeKindSection))
+	if err != nil {
+		t.Fatalf("CreateNode failed: %v", err)
+	}
+
+	indexPath := filepath.Join(tmpDir, "root", "docs", "index.md")
+	if err := os.Remove(indexPath); err != nil {
+		t.Fatalf("remove index.md: %v", err)
+	}
+
+	page, err := svc.GetPage(*id)
+	if err != nil {
+		t.Fatalf("GetPage failed: %v", err)
+	}
+	if page.ID != *id {
+		t.Fatalf("expected page ID %q, got %q", *id, page.ID)
+	}
+	if page.Content != "" {
+		t.Fatalf("expected empty content for section without index, got %q", page.Content)
+	}
+	if _, err := os.Stat(indexPath); err == nil {
+		t.Fatalf("expected GetPage to avoid materializing index.md")
+	}
+}
+
+func TestTreeService_ConvertNode_PageToSection_MaterializesIndexWithNodeMetadata(t *testing.T) {
+	svc, tmpDir := newLoadedService(t)
+
+	id, err := svc.CreateNode("system", nil, "Docs", "docs", ptrKind(NodeKindPage))
+	if err != nil {
+		t.Fatalf("CreateNode failed: %v", err)
+	}
+
+	node, err := svc.FindPageByID(svc.GetTree().Children, *id)
+	if err != nil {
+		t.Fatalf("FindPageByID failed: %v", err)
+	}
+	node.Metadata.CreatedAt = time.Date(2026, time.March, 22, 10, 15, 30, 0, time.UTC)
+	node.Metadata.UpdatedAt = time.Date(2026, time.March, 22, 11, 16, 31, 0, time.UTC)
+	node.Metadata.CreatorID = "alice"
+	node.Metadata.LastAuthorID = "bob"
+
+	if err := svc.ConvertNode("carol", *id, NodeKindSection); err != nil {
+		t.Fatalf("ConvertNode failed: %v", err)
+	}
+
+	indexPath := filepath.Join(tmpDir, "root", "docs", "index.md")
+	raw, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("read converted index: %v", err)
+	}
+
+	fm, body, has, err := markdown.ParseFrontmatter(string(raw))
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	if !has {
+		t.Fatalf("expected frontmatter after conversion")
+	}
+	if fm.LeafWikiID != *id || fm.LeafWikiTitle != "Docs" {
+		t.Fatalf("unexpected converted frontmatter: %#v", fm)
+	}
+	if fm.LeafWikiCreatedAt != "2026-03-22T10:15:30Z" {
+		t.Fatalf("expected created_at to be preserved after conversion, got %#v", fm)
+	}
+	if fm.LeafWikiUpdatedAt == "" {
+		t.Fatalf("expected updated_at after conversion, got %#v", fm)
+	}
+	if fm.LeafWikiCreatorID != "alice" || fm.LeafWikiLastAuthorID != "carol" {
+		t.Fatalf("expected metadata to be carried over and updated for actor, got %#v", fm)
+	}
+	if !strings.Contains(body, "# Docs") {
+		t.Fatalf("expected converted body to be preserved, got %q", body)
+	}
+}
+
 func TestTreeService_FindPageByRoutePath_ReturnsContent(t *testing.T) {
 	svc, _ := newLoadedService(t)
 
@@ -655,6 +773,81 @@ func TestTreeService_EnsurePagePath_CreatesIntermediateSectionsAndFinalPage(t *t
 }
 
 // --- F) Migration V3 (metadata frontmatter backfill) ---
+func TestTreeService_LoadTree_MigratesToV4_MaterializesMissingSectionIndex(t *testing.T) {
+	if CurrentSchemaVersion < 4 {
+		t.Skip("requires schema v4+")
+	}
+
+	tmpDir := t.TempDir()
+
+	if err := saveSchema(tmpDir, 3); err != nil {
+		t.Fatalf("saveSchema failed: %v", err)
+	}
+
+	svc := NewTreeService(tmpDir)
+	if err := svc.LoadTree(); err != nil {
+		t.Fatalf("LoadTree failed: %v", err)
+	}
+
+	id, err := svc.CreateNode("system", nil, "Docs", "docs", ptrKind(NodeKindSection))
+	if err != nil {
+		t.Fatalf("CreateNode failed: %v", err)
+	}
+
+	node, err := svc.FindPageByID(svc.GetTree().Children, *id)
+	if err != nil {
+		t.Fatalf("FindPageByID failed: %v", err)
+	}
+	node.Metadata = PageMetadata{
+		CreatedAt:    time.Date(2026, time.March, 22, 10, 15, 30, 0, time.UTC),
+		UpdatedAt:    time.Date(2026, time.March, 22, 11, 16, 31, 0, time.UTC),
+		CreatorID:    "alice",
+		LastAuthorID: "bob",
+	}
+
+	if err := svc.SaveTree(); err != nil {
+		t.Fatalf("SaveTree failed: %v", err)
+	}
+
+	indexPath := filepath.Join(tmpDir, "root", "docs", "index.md")
+	if err := os.Remove(indexPath); err != nil {
+		t.Fatalf("remove section index failed: %v", err)
+	}
+
+	if err := saveSchema(tmpDir, 3); err != nil {
+		t.Fatalf("saveSchema failed: %v", err)
+	}
+
+	loaded := NewTreeService(tmpDir)
+	if err := loaded.LoadTree(); err != nil {
+		t.Fatalf("LoadTree (migrating) failed: %v", err)
+	}
+
+	raw, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("read migrated section index: %v", err)
+	}
+	fm, body, has, err := markdown.ParseFrontmatter(string(raw))
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	if !has {
+		t.Fatalf("expected frontmatter after migration")
+	}
+	if fm.LeafWikiID != *id || fm.LeafWikiTitle != "Docs" {
+		t.Fatalf("expected section frontmatter to be materialized, got %#v", fm)
+	}
+	if fm.LeafWikiCreatedAt != "2026-03-22T10:15:30Z" || fm.LeafWikiUpdatedAt != "2026-03-22T11:16:31Z" {
+		t.Fatalf("expected timestamps to be materialized, got %#v", fm)
+	}
+	if fm.LeafWikiCreatorID != "alice" || fm.LeafWikiLastAuthorID != "bob" {
+		t.Fatalf("expected author metadata to be materialized, got %#v", fm)
+	}
+	if strings.TrimSpace(body) != "" {
+		t.Fatalf("expected empty section body after migration, got %q", body)
+	}
+}
+
 func TestTreeService_LoadTree_MigratesToV3_BackfillsMetadataFrontmatter(t *testing.T) {
 	if CurrentSchemaVersion < 3 {
 		t.Skip("requires schema v3+")
@@ -1449,3 +1642,68 @@ leafwiki_title: New Page
 // --- small util ---
 
 func ptrKind(k NodeKind) *NodeKind { return &k }
+
+func TestTreeService_LoadTree_MigratesToV4_ReturnsErrorWhenSectionIndexCannotBeWritten(t *testing.T) {
+	if CurrentSchemaVersion < 4 {
+		t.Skip("requires schema v4+")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("permission-based migration failure test is not reliable on Windows")
+	}
+
+	tmpDir := t.TempDir()
+
+	if err := saveSchema(tmpDir, 3); err != nil {
+		t.Fatalf("saveSchema failed: %v", err)
+	}
+
+	svc := NewTreeService(tmpDir)
+	if err := svc.LoadTree(); err != nil {
+		t.Fatalf("LoadTree failed: %v", err)
+	}
+
+	id, err := svc.CreateNode("system", nil, "Docs", "docs", ptrKind(NodeKindSection))
+	if err != nil {
+		t.Fatalf("CreateNode failed: %v", err)
+	}
+
+	node, err := svc.FindPageByID(svc.GetTree().Children, *id)
+	if err != nil {
+		t.Fatalf("FindPageByID failed: %v", err)
+	}
+	node.Metadata = PageMetadata{
+		CreatedAt:    time.Date(2026, time.March, 22, 10, 15, 30, 0, time.UTC),
+		UpdatedAt:    time.Date(2026, time.March, 22, 11, 16, 31, 0, time.UTC),
+		CreatorID:    "alice",
+		LastAuthorID: "bob",
+	}
+
+	if err := svc.SaveTree(); err != nil {
+		t.Fatalf("SaveTree failed: %v", err)
+	}
+
+	sectionDir := filepath.Join(tmpDir, "root", "docs")
+	indexPath := filepath.Join(sectionDir, "index.md")
+	if err := os.Remove(indexPath); err != nil {
+		t.Fatalf("remove section index failed: %v", err)
+	}
+	if err := os.Chmod(sectionDir, 0o555); err != nil {
+		t.Fatalf("chmod section dir failed: %v", err)
+	}
+	defer func() {
+		_ = os.Chmod(sectionDir, 0o755)
+	}()
+
+	if err := saveSchema(tmpDir, 3); err != nil {
+		t.Fatalf("saveSchema failed: %v", err)
+	}
+
+	loaded := NewTreeService(tmpDir)
+	err = loaded.LoadTree()
+	if err == nil {
+		t.Fatalf("expected migration error when section index cannot be written")
+	}
+	if !strings.Contains(err.Error(), "materialize section index") {
+		t.Fatalf("expected migration error to mention section index materialization, got: %v", err)
+	}
+}

--- a/internal/importer/executor_test.go
+++ b/internal/importer/executor_test.go
@@ -21,6 +21,9 @@ type fakeExecWiki struct {
 	updateFn func(userID, id, title, slug string, content *string, kind *tree.NodeKind) (*tree.Page, error)
 
 	lastUpdatedContent *string
+	ensureTargets      []string
+	ensureKinds        []tree.NodeKind
+	updateTitles       []string
 }
 
 func (f *fakeExecWiki) TreeHash() string { return f.hash }
@@ -31,6 +34,10 @@ func (f *fakeExecWiki) LookupPagePath(path string) (*tree.PathLookup, error) {
 
 func (f *fakeExecWiki) EnsurePath(userID string, targetPath string, title string, kind *tree.NodeKind) (*tree.Page, error) {
 	f.ensureCalls++
+	f.ensureTargets = append(f.ensureTargets, targetPath)
+	if kind != nil {
+		f.ensureKinds = append(f.ensureKinds, *kind)
+	}
 	if f.ensureFn != nil {
 		return f.ensureFn(userID, targetPath, title, kind)
 	}
@@ -40,6 +47,7 @@ func (f *fakeExecWiki) EnsurePath(userID string, targetPath string, title string
 func (f *fakeExecWiki) UpdatePage(userID string, id, title, slug string, content *string, kind *tree.NodeKind) (*tree.Page, error) {
 	f.updateCalls++
 	f.lastUpdatedContent = content
+	f.updateTitles = append(f.updateTitles, title)
 	if f.updateFn != nil {
 		return f.updateFn(userID, id, title, slug, content, kind)
 	}
@@ -202,5 +210,46 @@ func TestExecutor_UnknownAction_SkipsItem(t *testing.T) {
 	}
 	if res.Items[0].Error == nil || *res.Items[0].Error != "unknown action" {
 		t.Fatalf("Error=%#v", res.Items[0].Error)
+	}
+}
+
+func TestExecutor_Create_FolderIndexAndSiblingPage_ImportsSectionThenNestedPage(t *testing.T) {
+	tmp := t.TempDir()
+	writeTmp(t, tmp, "Ordner/index.md", `---
+title: Ordner
+---
+
+# Ordner`)
+	writeTmp(t, tmp, "Ordner/Ordner.md", "# Unterseite")
+
+	w := &fakeExecWiki{hash: "h1"}
+	plan := &PlanResult{
+		TreeHash: "h1",
+		Items: []PlanItem{
+			{SourcePath: "Ordner/index.md", TargetPath: "ordner", Title: "Ordner", Kind: tree.NodeKindSection, Action: PlanActionCreate},
+			{SourcePath: "Ordner/Ordner.md", TargetPath: "ordner/ordner", Title: "Unterseite", Kind: tree.NodeKindPage, Action: PlanActionCreate},
+		},
+	}
+	opts := &PlanOptions{SourceBasePath: tmp}
+
+	ex := NewExecutor(plan, opts, w, slog.Default())
+	res, err := ex.Execute("user1")
+	if err != nil {
+		t.Fatalf("Execute err: %v", err)
+	}
+	if res.ImportedCount != 2 || res.SkippedCount != 0 {
+		t.Fatalf("counts imported=%d skipped=%d", res.ImportedCount, res.SkippedCount)
+	}
+	if w.ensureCalls != 2 || w.updateCalls != 2 {
+		t.Fatalf("calls ensure=%d update=%d", w.ensureCalls, w.updateCalls)
+	}
+	if len(w.ensureTargets) != 2 || w.ensureTargets[0] != "ordner" || w.ensureTargets[1] != "ordner/ordner" {
+		t.Fatalf("unexpected ensure targets: %#v", w.ensureTargets)
+	}
+	if len(w.ensureKinds) != 2 || w.ensureKinds[0] != tree.NodeKindSection || w.ensureKinds[1] != tree.NodeKindPage {
+		t.Fatalf("unexpected ensure kinds: %#v", w.ensureKinds)
+	}
+	if len(w.updateTitles) != 2 || w.updateTitles[0] != "Ordner" || w.updateTitles[1] != "Unterseite" {
+		t.Fatalf("unexpected update titles: %#v", w.updateTitles)
 	}
 }

--- a/internal/importer/importer_service_test.go
+++ b/internal/importer/importer_service_test.go
@@ -267,3 +267,28 @@ func TestImporterService_createImportPlanFromFolder_UsesTargetBasePath(t *testin
 		t.Fatalf("expected TargetBasePath 'docs/imports', got %q", sp.PlanOptions.TargetBasePath)
 	}
 }
+
+func TestFindMarkdownEntries_FindsMixedCaseMdExtensions(t *testing.T) {
+	base := t.TempDir()
+	mustWrite(t, base, "a.MD", "x")
+	mustWrite(t, base, "b.mD", "x")
+	mustWrite(t, base, "c.Md", "x")
+	mustWrite(t, base, "d.txt", "x")
+
+	got, err := FindMarkdownEntries(base)
+	if err != nil {
+		t.Fatalf("FindMarkdownEntries err: %v", err)
+	}
+
+	set := map[string]bool{}
+	for _, e := range got {
+		set[e.SourcePath] = true
+	}
+
+	if !set["a.MD"] || !set["b.mD"] || !set["c.Md"] {
+		t.Fatalf("expected mixed-case markdown files to be included, got %#v", set)
+	}
+	if set["d.txt"] {
+		t.Fatalf("should not include non-markdown files")
+	}
+}

--- a/internal/importer/planner_test.go
+++ b/internal/importer/planner_test.go
@@ -432,3 +432,100 @@ func TestPlanner_CreatePlan_RootIndexMd_EmptyWikiPath_UsesFallbackTitle(t *testi
 		t.Fatalf("Note = %q (should contain 'Failed to load markdown file for title extraction')", it.Notes[0])
 	}
 }
+
+func TestPlanner_CreatePlan_FolderIndexAndSiblingPage_MapToSectionAndNestedPage(t *testing.T) {
+	tmp := t.TempDir()
+	test_utils.WriteFile(t, tmp, "Ordner/index.md", `---
+title: Ordner
+---
+
+# Ordner`)
+	test_utils.WriteFile(t, tmp, "Ordner/Ordner.md", "# Unterseite")
+
+	wiki := &fakeWiki{treeHash: "h", lookups: map[string]*tree.PathLookup{}}
+	p := newPlannerWithFake(wiki)
+
+	res, err := p.CreatePlan([]ImportMDFile{
+		{SourcePath: "Ordner/index.md"},
+		{SourcePath: "Ordner/Ordner.md"},
+	}, PlanOptions{
+		SourceBasePath: tmp,
+		TargetBasePath: "",
+	})
+	if err != nil {
+		t.Fatalf("CreatePlan err: %v", err)
+	}
+	if len(res.Errors) != 0 {
+		t.Fatalf("Errors = %#v", res.Errors)
+	}
+	if len(res.Items) != 2 {
+		t.Fatalf("Items len = %d (want 2)", len(res.Items))
+	}
+
+	section := res.Items[0]
+	page := res.Items[1]
+
+	if section.SourcePath != "Ordner/index.md" || section.Kind != tree.NodeKindSection || section.TargetPath != "ordner" {
+		t.Fatalf("unexpected section item: %#v", section)
+	}
+	if page.SourcePath != "Ordner/Ordner.md" || page.Kind != tree.NodeKindPage || page.TargetPath != "ordner/ordner" {
+		t.Fatalf("unexpected nested page item: %#v", page)
+	}
+}
+
+func TestPlanner_CreatePlan_FolderMarkdownWithoutIndex_RemainsNestedPage(t *testing.T) {
+	tmp := t.TempDir()
+	test_utils.WriteFile(t, tmp, "Ordner/Ordner.md", "# Unterseite")
+
+	wiki := &fakeWiki{treeHash: "h", lookups: map[string]*tree.PathLookup{}}
+	p := newPlannerWithFake(wiki)
+
+	res, err := p.CreatePlan([]ImportMDFile{{SourcePath: "Ordner/Ordner.md"}}, PlanOptions{
+		SourceBasePath: tmp,
+		TargetBasePath: "wiki",
+	})
+	if err != nil {
+		t.Fatalf("CreatePlan err: %v", err)
+	}
+	if len(res.Errors) != 0 {
+		t.Fatalf("Errors = %#v", res.Errors)
+	}
+	if len(res.Items) != 1 {
+		t.Fatalf("Items len = %d (want 1)", len(res.Items))
+	}
+
+	it := res.Items[0]
+	if it.Kind != tree.NodeKindPage {
+		t.Fatalf("Kind = %v (want Page)", it.Kind)
+	}
+	if it.TargetPath != "wiki/ordner/ordner" {
+		t.Fatalf("TargetPath = %q (want wiki/ordner/ordner)", it.TargetPath)
+	}
+}
+
+func TestPlanner_CreatePlan_CreateNewSection_IndexUppercaseMD(t *testing.T) {
+	tmp := t.TempDir()
+	test_utils.WriteFile(t, tmp, "Guides/index.MD", `---
+title: Guides
+---
+
+# Ignored`)
+
+	wiki := &fakeWiki{treeHash: "h", lookups: map[string]*tree.PathLookup{}}
+	p := newPlannerWithFake(wiki)
+
+	res, err := p.CreatePlan([]ImportMDFile{{SourcePath: "Guides/index.MD"}}, PlanOptions{
+		SourceBasePath: tmp,
+		TargetBasePath: "docs",
+	})
+	if err != nil {
+		t.Fatalf("CreatePlan err: %v", err)
+	}
+	it := res.Items[0]
+	if it.Kind != tree.NodeKindSection {
+		t.Fatalf("Kind = %v", it.Kind)
+	}
+	if it.TargetPath != "docs/guides" {
+		t.Fatalf("TargetPath = %q (want docs/guides)", it.TargetPath)
+	}
+}


### PR DESCRIPTION
Keep read paths side-effect free by moving missing section index.md materialization into schema migration v4 and filesystem reconstruction.

Add importer coverage for section/page path mapping and mixed-case markdown extensions, plus migration failure tests for unwritable section indexes.