### PR TITLE
fix(ui): ensures consistant rendering for emojis over the whole application.

### DIFF
--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -247,6 +247,7 @@
 
   body {
     @apply bg-page-bg text-page-text font-sans;
+    font-variant-emoji: emoji;
   }
 
   button:not(:disabled),


### PR DESCRIPTION
Related issue: https://github.com/perber/leafwiki/issues/748

### What:
Force the rendering of all emojis to show the actual images from the OS, not a font representation.

### Why:   
* Make the UI consistent, since not all emoji icons have corresponding font versions. 
* Ensures that the icons have the correct color, and do not rely on the text color.

### How:   
Apply global style to all elements that will ensure icon enforcement.  
It is done in the global style not to specific elements, to make sure that this issue will not come up in future features. 

### Tested on:
* Firefox (149.0) (windows)
* Chrome (146.0)  (windows)

### Tested in: 
* Edit page area
* Preview page area
* Page title 
* Edit page title modal
* Sidebar
* Move page modal

### Screenshots
#### Before:
<img width="1099" height="539" alt="image" src="https://github.com/user-attachments/assets/d8f5bac9-431d-4567-954f-842ab6255034" />

#### After: 
<img width="1113" height="554" alt="image" src="https://github.com/user-attachments/assets/9927cd8d-a80c-4bd1-8b14-ca8e1e89093b" />
