### PR TITLE
Fix/add labels to theme button

### DIFF
--- a/ui/leafwiki-ui/src/features/designtoggle/DesignToggle.tsx
+++ b/ui/leafwiki-ui/src/features/designtoggle/DesignToggle.tsx
@@ -26,7 +26,9 @@ export default function DesignToggle() {
         }}
       >
         <Moon
-          className={mode === 'light' || mode === 'system' ? 'visible' : 'hidden'}
+          className={
+            mode === 'light' || mode === 'system' ? 'visible' : 'hidden'
+          }
         />
         <Sun className={mode === 'dark' ? 'visible' : 'hidden'} />
       </Button>


### PR DESCRIPTION
### What:  
Added a tooltip to the button that toggles between light and dark themes.

### Why:   
* Consistency with the other buttons in the toolbar
* Accessibility

### How:   
Wrapped the button with the existing `<TooltipWrapper>` and reused the aria-label for the tooltip.

### Tested on:
* Firefox (149.0) (windows)
* Chrome (146.0)  (windows)

### Additional checks:
* Made sure that the tooltip dose not interfere with the existing aria-label  
 (tested with Windows 10 Narrator, and NVDA 2025.3.3)

### Screenshots
<img width="488" height="97" alt="image" src="https://github.com/user-attachments/assets/368b45f9-8590-4109-8ebd-7c008f10fa00" />
<img width="509" height="91" alt="image" src="https://github.com/user-attachments/assets/3dbf503a-170b-4f5e-bfff-0590f5b62162" />
