### PR TITLE
fix(ui): harden config load errors

### DIFF
--- a/ui/leafwiki-ui/src/App.tsx
+++ b/ui/leafwiki-ui/src/App.tsx
@@ -38,7 +38,12 @@ function App() {
   }, [loadBranding])
 
   useEffect(() => {
-    if (!configError || lastConfigErrorRef.current === configError) return
+    if (!configError) {
+      lastConfigErrorRef.current = null
+      return
+    }
+
+    if (lastConfigErrorRef.current === configError) return
 
     lastConfigErrorRef.current = configError
     toast.error(configError)
@@ -54,17 +59,12 @@ function App() {
     [isReadOnlyViewer, authDisabled],
   )
 
-  if (!configHasLoaded) return <Toaster richColors position="bottom-right" />
-
-  // Avoid router flicker before bootstrapping finished, show loading state if auth is enabled and still refreshing session
-  if (isRefreshing && !authDisabled) {
-    return <Toaster richColors position="bottom-right" /> // avoid router flicker before bootstrapping finished
-  }
-
   return (
     <>
       <Toaster richColors position="bottom-right" />
-      <RouterProvider router={router} />
+      {configHasLoaded && !(isRefreshing && !authDisabled) ? (
+        <RouterProvider router={router} />
+      ) : null}
     </>
   )
 }

--- a/ui/leafwiki-ui/src/App.tsx
+++ b/ui/leafwiki-ui/src/App.tsx
@@ -4,18 +4,20 @@ import { BASE_PATH } from '@/lib/config'
 import { useIsReadOnly } from '@/lib/useIsReadOnly'
 import { useSessionStore } from '@/stores/session'
 import useApplyDesignMode from '@/useApplyDesignMode'
-import { useEffect, useLayoutEffect, useMemo } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef } from 'react'
 import { RouterProvider } from 'react-router-dom'
-import { Toaster } from 'sonner'
+import { toast, Toaster } from 'sonner'
 import './App.css'
 import { useBrandingStore } from './stores/branding'
 import { useConfigStore } from './stores/config'
 
 function App() {
   const configHasLoaded = useConfigStore((s) => s.hasLoaded)
+  const configError = useConfigStore((s) => s.error)
   const loadConfig = useConfigStore((s) => s.loadConfig)
   const authDisabled = useConfigStore((s) => s.authDisabled)
   const loadBranding = useBrandingStore((s) => s.loadBranding)
+  const lastConfigErrorRef = useRef<string | null>(null)
 
   // bootstrap authentication on app start -> session store
   useBootstrapAuth(configHasLoaded && !authDisabled)
@@ -35,6 +37,13 @@ function App() {
     loadBranding()
   }, [loadBranding])
 
+  useEffect(() => {
+    if (!configError || lastConfigErrorRef.current === configError) return
+
+    lastConfigErrorRef.current = configError
+    toast.error(configError)
+  }, [configError])
+
   const router = useMemo(
     () =>
       createLeafWikiRouter(
@@ -45,10 +54,11 @@ function App() {
     [isReadOnlyViewer, authDisabled],
   )
 
-  if (!configHasLoaded) return null // Config not loaded yet. Show nothing meanwhile or maybe a loading spinner
+  if (!configHasLoaded) return <Toaster richColors position="bottom-right" />
 
+  // Avoid router flicker before bootstrapping finished, show loading state if auth is enabled and still refreshing session
   if (isRefreshing && !authDisabled) {
-    return null // avoid router flicker before bootstrapping finished
+    return <Toaster richColors position="bottom-right" /> // avoid router flicker before bootstrapping finished
   }
 
   return (

--- a/ui/leafwiki-ui/src/lib/api/config.ts
+++ b/ui/leafwiki-ui/src/lib/api/config.ts
@@ -1,5 +1,10 @@
 import { API_BASE_URL } from '../config'
 
+type ConfigErrorResponse = {
+  error?: string
+  message?: string
+}
+
 export type Config = {
   publicAccess: boolean
   hideLinkMetadataSection: boolean
@@ -9,7 +14,25 @@ export type Config = {
 
 export async function getConfig(): Promise<Config> {
   const res = await fetch(`${API_BASE_URL}/api/config`)
-  if (!res.ok)
-    throw new Error(`Could not load config: ${res.status} ${res.statusText}`)
+  if (!res.ok) {
+    const errorText = await res.text()
+    const fallbackMessage = `Could not load config: ${res.status} ${res.statusText}`
+
+    try {
+      const errorBody: ConfigErrorResponse | null = errorText
+        ? (JSON.parse(errorText) as ConfigErrorResponse)
+        : null
+      if (errorBody?.error || errorBody?.message) {
+        throw new Error(errorBody.error || errorBody.message)
+      }
+
+      throw new Error(fallbackMessage)
+    } catch (error) {
+      if (error instanceof Error) {
+        throw error
+      }
+      throw new Error(fallbackMessage)
+    }
+  }
   return await res.json()
 }

--- a/ui/leafwiki-ui/src/lib/api/config.ts
+++ b/ui/leafwiki-ui/src/lib/api/config.ts
@@ -17,22 +17,21 @@ export async function getConfig(): Promise<Config> {
   if (!res.ok) {
     const errorText = await res.text()
     const fallbackMessage = `Could not load config: ${res.status} ${res.statusText}`
+    let errorBody: ConfigErrorResponse | null = null
 
     try {
-      const errorBody: ConfigErrorResponse | null = errorText
+      errorBody = errorText
         ? (JSON.parse(errorText) as ConfigErrorResponse)
         : null
-      if (errorBody?.error || errorBody?.message) {
-        throw new Error(errorBody.error || errorBody.message)
-      }
-
-      throw new Error(fallbackMessage)
-    } catch (error) {
-      if (error instanceof Error) {
-        throw error
-      }
+    } catch {
       throw new Error(fallbackMessage)
     }
+
+    if (errorBody?.error || errorBody?.message) {
+      throw new Error(errorBody.error || errorBody.message)
+    }
+
+    throw new Error(fallbackMessage)
   }
   return await res.json()
 }

--- a/ui/leafwiki-ui/src/stores/config.ts
+++ b/ui/leafwiki-ui/src/stores/config.ts
@@ -7,6 +7,7 @@ type ConfigStore = {
   hideLinkMetadataSection: boolean
   authDisabled: boolean
   maxAssetUploadSizeBytes: number
+  error: string | null
   loading: boolean
   hasLoaded: boolean
   loadConfig: () => Promise<void>
@@ -17,11 +18,12 @@ export const useConfigStore = create<ConfigStore>((set) => ({
   hideLinkMetadataSection: false,
   authDisabled: false,
   maxAssetUploadSizeBytes: DEFAULT_MAX_ASSET_UPLOAD_SIZE_BYTES,
+  error: null,
   loading: false,
   hasLoaded: false,
 
   loadConfig: async () => {
-    set({ loading: true })
+    set({ loading: true, error: null })
     try {
       const config = await getConfig()
       const maxAssetUploadSizeBytes = Number.isFinite(
@@ -35,11 +37,18 @@ export const useConfigStore = create<ConfigStore>((set) => ({
         hideLinkMetadataSection: config.hideLinkMetadataSection,
         authDisabled: config.authDisabled,
         maxAssetUploadSizeBytes,
+        error: null,
         hasLoaded: true,
       })
     } catch (error) {
       console.warn('Error loading configuration:', error)
-      set({ hasLoaded: true })
+      set({
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Could not load configuration',
+        hasLoaded: true,
+      })
     } finally {
       set({ loading: false })
     }


### PR DESCRIPTION
Show config load failures in the UI without exposing arbitrary non-JSON response bodies. Preserve structured API error messages such as the insecure HTTP guidance while falling back to generic status errors for unexpected responses.