### PR TITLE
fix(preview): unwrap plain list paragraphs

### DIFF
--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
@@ -7,6 +7,7 @@ import {
   Component,
   ErrorInfo,
   HTMLAttributes,
+  isValidElement,
   ReactNode,
   useCallback,
   useMemo,
@@ -102,6 +103,15 @@ function normalizeAssetMediaSrc(src?: string) {
   return src
 }
 
+function isPlainListParagraph(child: ReactNode) {
+  if (!isValidElement<{ children?: ReactNode }>(child) || child.type !== 'p') {
+    return false
+  }
+
+  const propKeys = Object.keys(child.props)
+  return propKeys.every((key) => key === 'children' || key === 'data-line')
+}
+
 export default function MarkdownPreview({ content, path }: Props) {
   const designMode = useDesignModeStore((state) => state.mode)
   const prefersLight = useSyncExternalStore(
@@ -144,6 +154,22 @@ export default function MarkdownPreview({ content, path }: Props) {
       video: (props: VideoHTMLAttributes<HTMLVideoElement>) => (
         <video {...props} src={normalizeAssetMediaSrc(props.src)} />
       ),
+      li: ({
+        children,
+        ...props
+      }: ClassAttributes<HTMLLIElement> & HTMLAttributes<HTMLLIElement>) => {
+        const childArray = Array.isArray(children) ? children : [children]
+        const meaningfulChildren = childArray.filter(
+          (child) => child !== null && child !== undefined && child !== false,
+        )
+        const onlyChild = meaningfulChildren[0]
+
+        if (meaningfulChildren.length === 1 && isPlainListParagraph(onlyChild)) {
+          return <li {...props}>{onlyChild.props.children}</li>
+        }
+
+        return <li {...props}>{children}</li>
+      },
       h1: ({
         children,
         ...props

--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
@@ -7,6 +7,7 @@ import {
   Component,
   ErrorInfo,
   HTMLAttributes,
+  ReactElement,
   isValidElement,
   ReactNode,
   useCallback,
@@ -103,8 +104,13 @@ function normalizeAssetMediaSrc(src?: string) {
   return src
 }
 
-function isPlainListParagraph(child: ReactNode) {
-  if (!isValidElement<{ children?: ReactNode }>(child) || child.type !== 'p') {
+function isPlainListParagraph(
+  child: ReactNode,
+): child is ReactElement<{ children?: ReactNode; 'data-line'?: string }> {
+  if (
+    !isValidElement<{ children?: ReactNode; 'data-line'?: string }>(child) ||
+    child.type !== 'p'
+  ) {
     return false
   }
 
@@ -164,7 +170,10 @@ export default function MarkdownPreview({ content, path }: Props) {
         )
         const onlyChild = meaningfulChildren[0]
 
-        if (meaningfulChildren.length === 1 && isPlainListParagraph(onlyChild)) {
+        if (
+          meaningfulChildren.length === 1 &&
+          isPlainListParagraph(onlyChild)
+        ) {
           return <li {...props}>{onlyChild.props.children}</li>
         }
 


### PR DESCRIPTION
Only unwrap markdown-generated paragraph wrappers inside list items in the preview. Preserve paragraph attributes so embedded HTML content keeps its metadata and styling.