### PR TITLE
fix(preview): support nested list indentation

### DIFF
--- a/e2e/tests/page.spec.ts
+++ b/e2e/tests/page.spec.ts
@@ -879,6 +879,125 @@ graph TD;
     test.expect(mermaidStyles.stroke).not.toBe('rgb(231, 231, 231)');
   });
 
+  test('nested lists support 2 and 4 space indentation outside fences', async ({ page }) => {
+    const timestamp = Date.now();
+    const title = `Nested List Support ${timestamp}`;
+    const slug = `nested-list-support-${timestamp}`;
+    const content = `1. Ordered top
+  1. Ordered nested with two spaces
+2. Ordered top again
+    1. Ordered nested with four spaces
+
+- Unordered top
+  - Unordered nested with two spaces
+- Unordered top again
+    - Unordered nested with four spaces
+
+\`\`\`md
+1. Fence ordered top
+  1. Fence ordered nested with two spaces
+- Fence unordered top
+  - Fence unordered nested with two spaces
+\`\`\`
+`;
+
+    await createPageWithContent(page, { title, slug, content });
+
+    const viewPage = new ViewPage(page);
+    await viewPage.goto(`/${slug}`);
+
+    await page
+      .locator('article ol ol li')
+      .filter({ hasText: 'Ordered nested with two spaces' })
+      .waitFor({ state: 'visible' });
+    await page
+      .locator('article ol ol li')
+      .filter({ hasText: 'Ordered nested with four spaces' })
+      .waitFor({ state: 'visible' });
+    await page
+      .locator('article ul ul li')
+      .filter({ hasText: 'Unordered nested with two spaces' })
+      .waitFor({ state: 'visible' });
+    await page
+      .locator('article ul ul li')
+      .filter({ hasText: 'Unordered nested with four spaces' })
+      .waitFor({ state: 'visible' });
+
+    const codeBlockText = await page.locator('article pre code').textContent();
+    test.expect(codeBlockText).toContain('  1. Fence ordered nested with two spaces');
+    test.expect(codeBlockText).toContain('  - Fence unordered nested with two spaces');
+  });
+
+  test('nested list normalization does not leak across later paragraphs', async ({ page }) => {
+    const timestamp = Date.now();
+    const title = `Nested List Reset ${timestamp}`;
+    const slug = `nested-list-reset-${timestamp}`;
+    const content = `1. Parent item
+  1. Nested child
+
+Paragraph outside the list.
+
+  1. Restarted top-level item
+  2. Restarted top-level item two
+`;
+
+    await createPageWithContent(page, { title, slug, content });
+
+    const viewPage = new ViewPage(page);
+    await viewPage.goto(`/${slug}`);
+
+    await page.getByText('Paragraph outside the list.').waitFor({ state: 'visible' });
+
+    const topLevelLists = page.locator('article > ol');
+    await test.expect(topLevelLists).toHaveCount(2);
+
+    await page
+      .locator('article > ol > li')
+      .getByText('Restarted top-level item', { exact: true })
+      .waitFor({ state: 'visible' });
+
+    await test
+      .expect(page.locator('article ol ol li').filter({ hasText: 'Restarted top-level item' }))
+      .toHaveCount(0);
+  });
+
+  test('nested fenced code in lists stays untouched', async ({ page }) => {
+    const timestamp = Date.now();
+    const title = `Nested Fence List ${timestamp}`;
+    const slug = `nested-fence-list-${timestamp}`;
+    const content = `1. Parent item
+
+   \`\`\`md
+   1. fenced ordered line
+     1. still fenced ordered line
+   - fenced unordered line
+     - still fenced unordered line
+   \`\`\`
+
+2. Sibling item
+`;
+
+    await createPageWithContent(page, { title, slug, content });
+
+    const viewPage = new ViewPage(page);
+    await viewPage.goto(`/${slug}`);
+
+    await page
+      .locator('article > ol > li')
+      .filter({ hasText: 'Sibling item' })
+      .waitFor({ state: 'visible' });
+
+    const codeBlockText = await page.locator('article pre code').textContent();
+    test.expect(codeBlockText).toContain('1. fenced ordered line');
+    test.expect(codeBlockText).toContain('  1. still fenced ordered line');
+    test.expect(codeBlockText).toContain('- fenced unordered line');
+    test.expect(codeBlockText).toContain('  - still fenced unordered line');
+    test.expect(codeBlockText).not.toContain('    1. still fenced ordered line');
+    test.expect(codeBlockText).not.toContain('    - still fenced unordered line');
+
+    await test.expect(page.locator('article pre')).toHaveCount(1);
+  });
+
   test('create-page-on-not-found-page', async ({ page }) => {
     const slug = `page-from-not-found-${Date.now()}`;
     const pagePath = `/${slug}`;

--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
@@ -26,6 +26,7 @@ import MarkdownCodeBlock from './MarkdownCodeBlock'
 import { MarkdownImage } from './MarkdownImage'
 import { MarkdownLink } from './MarkdownLink'
 import MermaidBlock from './MermaidBlock'
+import { normalizeMarkdownListIndentation } from './normalizeMarkdownListIndentation'
 import { rehypeLineNumber } from './rehypeLineNumber'
 import { rehypeWhitelistStyles } from './rehypeWhitelistStyles'
 
@@ -286,6 +287,11 @@ export default function MarkdownPreview({ content, path }: Props) {
     [markdownLink, resolvedMode],
   )
 
+  const normalizedContent = useMemo(
+    () => normalizeMarkdownListIndentation(content),
+    [content],
+  )
+
   return (
     <MarkdownPreviewErrorBoundary resetKey={`${path ?? ''}:${content}`}>
       <>
@@ -300,7 +306,7 @@ export default function MarkdownPreview({ content, path }: Props) {
           ]}
           components={components}
         >
-          {content}
+          {normalizedContent}
         </ReactMarkdown>
         <div id="mermaid-renderer"></div>
       </>

--- a/ui/leafwiki-ui/src/features/preview/normalizeMarkdownListIndentation.ts
+++ b/ui/leafwiki-ui/src/features/preview/normalizeMarkdownListIndentation.ts
@@ -1,0 +1,196 @@
+type FenceState = {
+  marker: '`' | '~'
+  length: number
+}
+
+type ListContext = {
+  effectiveIndent: number
+  rawIndent: number
+}
+
+type ParsedListLine = {
+  containerPrefix: string
+  indent: string
+  listMarker: string
+  rest: string
+  spacing: string
+}
+
+type ParsedLinePrefix = {
+  containerPrefix: string
+  indent: number
+}
+
+const fencePattern =
+  /^(?<containerPrefix>(?: {0,3}>\s*)*)(?<indent> *)(?<marker>`{3,}|~{3,})(?<rest>.*)$/
+const listPattern =
+  /^(?<containerPrefix>(?: {0,3}>\s*)*)(?<indent> *)(?<listMarker>(?:[-+*])|(?:\d+[.)]))(?<spacing>\s+)(?<rest>.*)$/
+const linePrefixPattern = /^(?<containerPrefix>(?: {0,3}>\s*)*)(?<indent> *)/
+
+function parseListLine(line: string): ParsedListLine | null {
+  const match = listPattern.exec(line)
+  if (!match?.groups) {
+    return null
+  }
+
+  return {
+    containerPrefix: match.groups.containerPrefix ?? '',
+    indent: match.groups.indent ?? '',
+    listMarker: match.groups.listMarker ?? '',
+    spacing: match.groups.spacing ?? ' ',
+    rest: match.groups.rest ?? '',
+  }
+}
+
+function parseLinePrefix(line: string): ParsedLinePrefix | null {
+  const match = linePrefixPattern.exec(line)
+  if (!match?.groups) {
+    return null
+  }
+
+  return {
+    containerPrefix: match.groups.containerPrefix ?? '',
+    indent: (match.groups.indent ?? '').length,
+  }
+}
+
+function getNextFenceState(
+  line: string,
+  currentFence: FenceState | null,
+): FenceState | null {
+  const match = fencePattern.exec(line)
+  if (!match?.groups) {
+    return currentFence
+  }
+
+  const markerRun = match.groups.marker
+  const marker = markerRun[0] as FenceState['marker']
+
+  if (!currentFence) {
+    return {
+      marker,
+      length: markerRun.length,
+    }
+  }
+
+  if (
+    marker !== currentFence.marker ||
+    markerRun.length < currentFence.length
+  ) {
+    return currentFence
+  }
+
+  return null
+}
+
+function clearCompletedContexts(
+  line: string,
+  listContexts: Map<string, ListContext[]>,
+) {
+  if (line.trim() === '') {
+    return
+  }
+
+  const parsedPrefix = parseLinePrefix(line)
+  if (!parsedPrefix) {
+    listContexts.clear()
+    return
+  }
+
+  for (const [containerKey, stack] of listContexts) {
+    if (containerKey !== parsedPrefix.containerPrefix) {
+      listContexts.delete(containerKey)
+      continue
+    }
+
+    const nextStack = stack.filter(
+      (context) => parsedPrefix.indent > context.rawIndent,
+    )
+
+    if (nextStack.length === 0) {
+      listContexts.delete(containerKey)
+      continue
+    }
+
+    listContexts.set(containerKey, nextStack)
+  }
+}
+
+function normalizeListItemIndentation(
+  line: string,
+  listContexts: Map<string, ListContext[]>,
+): string {
+  const parsed = parseListLine(line)
+  if (!parsed) {
+    clearCompletedContexts(line, listContexts)
+    return line
+  }
+
+  const rawIndent = parsed.indent.length
+  const containerKey = parsed.containerPrefix
+  const contextStack = [...(listContexts.get(containerKey) ?? [])]
+
+  while (
+    contextStack.length > 0 &&
+    rawIndent < contextStack[contextStack.length - 1].rawIndent
+  ) {
+    contextStack.pop()
+  }
+
+  let effectiveIndent = rawIndent
+
+  if (contextStack.length > 0) {
+    const previousContext = contextStack[contextStack.length - 1]
+
+    if (rawIndent === previousContext.rawIndent) {
+      effectiveIndent = previousContext.effectiveIndent
+    } else if (rawIndent > previousContext.rawIndent) {
+      const indentStep = rawIndent - previousContext.rawIndent
+      effectiveIndent =
+        previousContext.effectiveIndent +
+        (indentStep === 2 || indentStep === 4 ? 4 : indentStep)
+    }
+  }
+
+  if (
+    contextStack.length === 0 ||
+    rawIndent !== contextStack[contextStack.length - 1]?.rawIndent
+  ) {
+    contextStack.push({
+      rawIndent,
+      effectiveIndent,
+    })
+  } else {
+    contextStack[contextStack.length - 1] = {
+      rawIndent,
+      effectiveIndent,
+    }
+  }
+
+  listContexts.set(containerKey, contextStack)
+
+  if (effectiveIndent === rawIndent) {
+    return line
+  }
+
+  return `${parsed.containerPrefix}${' '.repeat(effectiveIndent)}${parsed.listMarker}${parsed.spacing}${parsed.rest}`
+}
+
+export function normalizeMarkdownListIndentation(content: string) {
+  const lines = content.split('\n')
+  let fenceState: FenceState | null = null
+  const listContexts = new Map<string, ListContext[]>()
+
+  return lines
+    .map((line) => {
+      const activeFence = fenceState
+      fenceState = getNextFenceState(line, fenceState)
+
+      if (activeFence) {
+        return line
+      }
+
+      return normalizeListItemIndentation(line, listContexts)
+    })
+    .join('\n')
+}

--- a/ui/leafwiki-ui/src/features/preview/normalizeMarkdownListIndentation.ts
+++ b/ui/leafwiki-ui/src/features/preview/normalizeMarkdownListIndentation.ts
@@ -17,7 +17,7 @@ type ParsedListLine = {
 }
 
 type ParsedLinePrefix = {
-  containerPrefix: string
+  containerKey: string
   indent: number
 }
 
@@ -26,6 +26,11 @@ const fencePattern =
 const listPattern =
   /^(?<containerPrefix>(?: {0,3}>\s*)*)(?<indent> *)(?<listMarker>(?:[-+*])|(?:\d+[.)]))(?<spacing>\s+)(?<rest>.*)$/
 const linePrefixPattern = /^(?<containerPrefix>(?: {0,3}>\s*)*)(?<indent> *)/
+
+function getContainerKey(containerPrefix: string) {
+  const quoteDepth = (containerPrefix.match(/>/g) ?? []).length
+  return `blockquote:${quoteDepth}`
+}
 
 function parseListLine(line: string): ParsedListLine | null {
   const match = listPattern.exec(line)
@@ -42,15 +47,13 @@ function parseListLine(line: string): ParsedListLine | null {
   }
 }
 
-function parseLinePrefix(line: string): ParsedLinePrefix | null {
+function parseLinePrefix(line: string): ParsedLinePrefix {
   const match = linePrefixPattern.exec(line)
-  if (!match?.groups) {
-    return null
-  }
+  const containerPrefix = match?.groups?.containerPrefix ?? ''
 
   return {
-    containerPrefix: match.groups.containerPrefix ?? '',
-    indent: (match.groups.indent ?? '').length,
+    containerKey: getContainerKey(containerPrefix),
+    indent: (match?.groups?.indent ?? '').length,
   }
 }
 
@@ -92,13 +95,9 @@ function clearCompletedContexts(
   }
 
   const parsedPrefix = parseLinePrefix(line)
-  if (!parsedPrefix) {
-    listContexts.clear()
-    return
-  }
 
   for (const [containerKey, stack] of listContexts) {
-    if (containerKey !== parsedPrefix.containerPrefix) {
+    if (containerKey !== parsedPrefix.containerKey) {
       listContexts.delete(containerKey)
       continue
     }
@@ -127,7 +126,7 @@ function normalizeListItemIndentation(
   }
 
   const rawIndent = parsed.indent.length
-  const containerKey = parsed.containerPrefix
+  const containerKey = getContainerKey(parsed.containerPrefix)
   const contextStack = [...(listContexts.get(containerKey) ?? [])]
 
   while (


### PR DESCRIPTION
Normalize nested list indentation in markdown preview so ordered and unordered lists accept 2-space and 4-space nesting without touching fenced code blocks. Add E2E coverage for the happy path and bad-path regressions around stale list state and nested fences.