### PR TITLE
fix(ui): improve markdown footnotes

### DIFF
--- a/e2e/tests/page.spec.ts
+++ b/e2e/tests/page.spec.ts
@@ -583,6 +583,104 @@ This paragraph creates a footnote reference.[^leafwiki]
     test.expect(pageErrors).toEqual([]);
   });
 
+  test('footnote reference and backlink navigate to matching anchors', async ({ page }) => {
+    const timestamp = Date.now();
+    const slug = `footnotes-links-${timestamp}`;
+    const title = `Footnotes Links ${timestamp}`;
+    const content = `# Footnotes
+
+This paragraph creates a footnote reference.[^leafwiki]
+
+[^leafwiki]: This is the matching footnote definition.`;
+
+    await createPageWithContent(page, { title, slug, content });
+
+    const viewPage = new ViewPage(page);
+    await viewPage.goto(`/${slug}`);
+
+    const footnoteReference = page.locator('article sup a[data-footnote-ref]');
+    await footnoteReference.waitFor({ state: 'visible' });
+    await test.expect(footnoteReference).not.toHaveAttribute('node', /.+/);
+    await test
+      .expect(footnoteReference)
+      .toHaveAttribute('href', /#leafwiki-user-content-fn-leafwiki$/);
+    await footnoteReference.click();
+
+    await test.expect
+      .poll(async () => page.evaluate(() => decodeURIComponent(window.location.hash)), {
+        timeout: 5000,
+      })
+      .toBe('#leafwiki-user-content-fn-leafwiki');
+
+    const footnoteBacklink = page.locator('article a[data-footnote-backref]');
+    await footnoteBacklink.waitFor({ state: 'visible' });
+    await test.expect(footnoteBacklink).not.toHaveAttribute('node', /.+/);
+    await test
+      .expect(footnoteBacklink)
+      .toHaveAttribute('href', /#leafwiki-user-content-fnref-leafwiki$/);
+    await footnoteBacklink.click();
+
+    await test.expect
+      .poll(async () => page.evaluate(() => decodeURIComponent(window.location.hash)), {
+        timeout: 5000,
+      })
+      .toBe('#leafwiki-user-content-fnref-leafwiki');
+
+    await test.expect(page.locator('article .footnotes')).not.toHaveAttribute('node', /.+/);
+
+    const footnoteContainer = page.locator('article .markdown-footnotes');
+    await footnoteContainer.waitFor({ state: 'visible' });
+    await test.expect(footnoteContainer).toHaveClass(/footnotes/);
+    await test.expect(footnoteContainer).toHaveJSProperty('tagName', 'DIV');
+  });
+
+  test('duplicate footnote references keep distinct backlinks without leaked node attributes', async ({
+    page,
+  }) => {
+    const timestamp = Date.now();
+    const slug = `footnotes-duplicate-links-${timestamp}`;
+    const title = `Footnotes Duplicate Links ${timestamp}`;
+    const content = `# Footnotes
+
+First reference[^leafwiki] and second reference[^leafwiki]
+
+[^leafwiki]: This is the matching footnote definition.`;
+
+    await createPageWithContent(page, { title, slug, content });
+
+    const viewPage = new ViewPage(page);
+    await viewPage.goto(`/${slug}`);
+
+    const footnoteReferences = page.locator('article sup a[data-footnote-ref]');
+    await test.expect(footnoteReferences).toHaveCount(2);
+    await test.expect(footnoteReferences.nth(0)).not.toHaveAttribute('node', /.+/);
+    await test.expect(footnoteReferences.nth(1)).not.toHaveAttribute('node', /.+/);
+    await test
+      .expect(footnoteReferences.nth(0))
+      .toHaveAttribute('href', /#leafwiki-user-content-fn-leafwiki$/);
+    await test
+      .expect(footnoteReferences.nth(1))
+      .toHaveAttribute('href', /#leafwiki-user-content-fn-leafwiki$/);
+
+    const footnoteBacklinks = page.locator('article a[data-footnote-backref]');
+    await test.expect(footnoteBacklinks).toHaveCount(2);
+    await test
+      .expect(footnoteBacklinks.nth(0))
+      .toHaveAttribute('href', /#leafwiki-user-content-fnref-leafwiki$/);
+    await test
+      .expect(footnoteBacklinks.nth(1))
+      .toHaveAttribute('href', /#leafwiki-user-content-fnref-leafwiki-2$/);
+    await test.expect(footnoteBacklinks.nth(1)).not.toHaveAttribute('node', /.+/);
+
+    await footnoteBacklinks.nth(1).click();
+
+    await test.expect
+      .poll(async () => page.evaluate(() => decodeURIComponent(window.location.hash)), {
+        timeout: 5000,
+      })
+      .toBe('#leafwiki-user-content-fnref-leafwiki-2');
+  });
+
   test('navigating away from markdown-it sample stays responsive', async ({ page }) => {
     const timestamp = Date.now();
     const slug = `markdown-it-sample-${timestamp}`;

--- a/ui/leafwiki-ui/src/features/preview/Headline.tsx
+++ b/ui/leafwiki-ui/src/features/preview/Headline.tsx
@@ -27,6 +27,7 @@ export type HeadlineProps = HTMLAttributes<HTMLHeadingElement> & {
   children: ReactNode
   'data-line'?: string
   'data-leafwiki-generated-id'?: string
+  node?: unknown
 }
 
 export default function Headline({
@@ -36,8 +37,10 @@ export default function Headline({
   id,
   'data-line': dataLine,
   'data-leafwiki-generated-id': hasGeneratedId,
+  node,
   ...props
 }: HeadlineProps) {
+  void node
   const tagName = `h${level}` as keyof HTMLElementTagNameMap
   const shouldRenderAnchor = hasGeneratedId === 'true' && !!id
   const hasNestedLink = containsLink(children)

--- a/ui/leafwiki-ui/src/features/preview/MarkdownCodeBlock.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownCodeBlock.tsx
@@ -35,9 +35,10 @@ function readTextContent(node: ReactNode): string {
 
 export default function MarkdownCodeBlock(
   props: ClassAttributes<HTMLPreElement> &
-    HTMLAttributes<HTMLPreElement> & { children?: ReactNode },
+    HTMLAttributes<HTMLPreElement> & { children?: ReactNode; node?: unknown },
 ) {
-  const { children, ...preProps } = props
+  const { children, node, ...preProps } = props
+  void node
   const [copied, setCopied] = useState(false)
   const child = Array.isArray(children) ? children[0] : children
 

--- a/ui/leafwiki-ui/src/features/preview/MarkdownImage.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownImage.tsx
@@ -4,7 +4,7 @@ import { withBasePath } from '@/lib/routePath'
 import { useDialogsStore } from '@/stores/dialogs'
 import { useEffect, useState } from 'react'
 
-type Props = React.ImgHTMLAttributes<HTMLImageElement>
+type Props = React.ImgHTMLAttributes<HTMLImageElement> & { node?: unknown }
 
 function shouldOpenPreview(e: React.MouseEvent<HTMLImageElement>) {
   if (e.button !== 0) return false
@@ -16,7 +16,8 @@ function shouldOpenInNewTab(e: React.MouseEvent<HTMLImageElement>) {
   return e.button === 0 && (e.metaKey || e.ctrlKey)
 }
 
-export function MarkdownImage({ src = '', style, alt, ...rest }: Props) {
+export function MarkdownImage({ src = '', style, alt, node, ...rest }: Props) {
+  void node
   const [versionedSrc, setVersionedSrc] = useState(src)
   const openDialog = useDialogsStore((s) => s.openDialog)
 

--- a/ui/leafwiki-ui/src/features/preview/MarkdownLink.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownLink.tsx
@@ -19,9 +19,16 @@ interface MarkdownLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   href?: string
   children?: ReactNode
   path?: string
+  node?: unknown
 }
 
-export function MarkdownLink({ href, children, ...props }: MarkdownLinkProps) {
+export function MarkdownLink({
+  href,
+  children,
+  node,
+  ...props
+}: MarkdownLinkProps) {
+  void node
   const openDialog = useDialogsStore((s) => s.openDialog)
   const getPageByPath = useTreeStore((s) => s.getPageByPath)
   const user = useSessionStore((s) => s.user)

--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
@@ -118,10 +118,6 @@ function normalizeFootnoteHref(href?: string) {
     return href
   }
 
-  if (href.startsWith(`#${CLOBBER_PREFIX}`)) {
-    return href
-  }
-
   return `#${CLOBBER_PREFIX}${href.slice(1)}`
 }
 
@@ -186,12 +182,20 @@ export default function MarkdownPreview({ content, path }: Props) {
     () => ({
       a: markdownLink,
       img: MarkdownImage,
-      audio: (props: AudioHTMLAttributes<HTMLAudioElement>) => (
-        <audio {...props} src={normalizeAssetMediaSrc(props.src)} />
-      ),
-      video: (props: VideoHTMLAttributes<HTMLVideoElement>) => (
-        <video {...props} src={normalizeAssetMediaSrc(props.src)} />
-      ),
+      audio: ({
+        node,
+        ...props
+      }: MarkdownNodeProp & AudioHTMLAttributes<HTMLAudioElement>) => {
+        void node
+        return <audio {...props} src={normalizeAssetMediaSrc(props.src)} />
+      },
+      video: ({
+        node,
+        ...props
+      }: MarkdownNodeProp & VideoHTMLAttributes<HTMLVideoElement>) => {
+        void node
+        return <video {...props} src={normalizeAssetMediaSrc(props.src)} />
+      },
       section: ({
         children,
         node,

--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
@@ -2,6 +2,7 @@ import './markdownPreviewCodeTheme.css'
 import { useDesignModeStore } from '@/features/designtoggle/designmode'
 import { withBasePath } from '@/lib/routePath'
 import {
+  AnchorHTMLAttributes,
   AudioHTMLAttributes,
   ClassAttributes,
   Component,
@@ -61,6 +62,13 @@ type MarkdownPreviewErrorBoundaryState = {
   hasError: boolean
 }
 
+const CLOBBER_PREFIX = 'leafwiki-'
+const FOOTNOTE_TARGET_PREFIX = '#user-content-fn'
+
+type MarkdownNodeProp = {
+  node?: unknown
+}
+
 class MarkdownPreviewErrorBoundary extends Component<
   { children: ReactNode; resetKey: string },
   MarkdownPreviewErrorBoundaryState
@@ -105,6 +113,18 @@ function normalizeAssetMediaSrc(src?: string) {
   return src
 }
 
+function normalizeFootnoteHref(href?: string) {
+  if (!href?.startsWith(FOOTNOTE_TARGET_PREFIX)) {
+    return href
+  }
+
+  if (href.startsWith(`#${CLOBBER_PREFIX}`)) {
+    return href
+  }
+
+  return `#${CLOBBER_PREFIX}${href.slice(1)}`
+}
+
 function isPlainListParagraph(
   child: ReactNode,
 ): child is ReactElement<{ children?: ReactNode; 'data-line'?: string }> {
@@ -144,10 +164,21 @@ export default function MarkdownPreview({ content, path }: Props) {
     designMode === 'system' ? (prefersLight ? 'light' : 'dark') : designMode
 
   const markdownLink = useCallback(
-    (
-      props: ClassAttributes<HTMLAnchorElement> &
-        HTMLAttributes<HTMLAnchorElement>,
-    ) => <MarkdownLink path={path} {...props} />,
+    ({
+      node,
+      ...props
+    }: MarkdownNodeProp &
+      ClassAttributes<HTMLAnchorElement> &
+      AnchorHTMLAttributes<HTMLAnchorElement>) => {
+      void node
+      return (
+        <MarkdownLink
+          path={path}
+          {...props}
+          href={normalizeFootnoteHref(props.href)}
+        />
+      )
+    },
     [path],
   )
 
@@ -161,10 +192,41 @@ export default function MarkdownPreview({ content, path }: Props) {
       video: (props: VideoHTMLAttributes<HTMLVideoElement>) => (
         <video {...props} src={normalizeAssetMediaSrc(props.src)} />
       ),
+      section: ({
+        children,
+        node,
+        className,
+        ...props
+      }: MarkdownNodeProp &
+        HTMLAttributes<HTMLElement> & {
+          'data-footnotes'?: boolean | string
+        }) => {
+        void node
+        if ('data-footnotes' in props) {
+          return (
+            <div
+              {...props}
+              className={`markdown-footnotes ${className ?? ''}`.trim()}
+            >
+              {children}
+            </div>
+          )
+        }
+
+        return (
+          <section {...props} className={className}>
+            {children}
+          </section>
+        )
+      },
       li: ({
         children,
+        node,
         ...props
-      }: ClassAttributes<HTMLLIElement> & HTMLAttributes<HTMLLIElement>) => {
+      }: MarkdownNodeProp &
+        ClassAttributes<HTMLLIElement> &
+        HTMLAttributes<HTMLLIElement>) => {
+        void node
         const childArray = Array.isArray(children) ? children : [children]
         const meaningfulChildren = childArray.filter(
           (child) => child !== null && child !== undefined && child !== false,
@@ -182,75 +244,113 @@ export default function MarkdownPreview({ content, path }: Props) {
       },
       h1: ({
         children,
+        node,
         ...props
-      }: ClassAttributes<HTMLHeadingElement> &
-        HTMLAttributes<HTMLHeadingElement>) => (
-        <Headline level={1} {...props}>
-          {children}
-        </Headline>
-      ),
+      }: MarkdownNodeProp &
+        ClassAttributes<HTMLHeadingElement> &
+        HTMLAttributes<HTMLHeadingElement>) => {
+        void node
+        return (
+          <Headline level={1} {...props}>
+            {children}
+          </Headline>
+        )
+      },
       h2: ({
         children,
+        node,
         ...props
-      }: ClassAttributes<HTMLHeadingElement> &
-        HTMLAttributes<HTMLHeadingElement>) => (
-        <Headline level={2} {...props}>
-          {children}
-        </Headline>
-      ),
+      }: MarkdownNodeProp &
+        ClassAttributes<HTMLHeadingElement> &
+        HTMLAttributes<HTMLHeadingElement>) => {
+        void node
+        return (
+          <Headline level={2} {...props}>
+            {children}
+          </Headline>
+        )
+      },
       h3: ({
         children,
+        node,
         ...props
-      }: ClassAttributes<HTMLHeadingElement> &
-        HTMLAttributes<HTMLHeadingElement>) => (
-        <Headline level={3} {...props}>
-          {children}
-        </Headline>
-      ),
+      }: MarkdownNodeProp &
+        ClassAttributes<HTMLHeadingElement> &
+        HTMLAttributes<HTMLHeadingElement>) => {
+        void node
+        return (
+          <Headline level={3} {...props}>
+            {children}
+          </Headline>
+        )
+      },
       h4: ({
         children,
+        node,
         ...props
-      }: ClassAttributes<HTMLHeadingElement> &
-        HTMLAttributes<HTMLHeadingElement>) => (
-        <Headline level={4} {...props}>
-          {children}
-        </Headline>
-      ),
+      }: MarkdownNodeProp &
+        ClassAttributes<HTMLHeadingElement> &
+        HTMLAttributes<HTMLHeadingElement>) => {
+        void node
+        return (
+          <Headline level={4} {...props}>
+            {children}
+          </Headline>
+        )
+      },
       h5: ({
         children,
+        node,
         ...props
-      }: ClassAttributes<HTMLHeadingElement> &
-        HTMLAttributes<HTMLHeadingElement>) => (
-        <Headline level={5} {...props}>
-          {children}
-        </Headline>
-      ),
+      }: MarkdownNodeProp &
+        ClassAttributes<HTMLHeadingElement> &
+        HTMLAttributes<HTMLHeadingElement>) => {
+        void node
+        return (
+          <Headline level={5} {...props}>
+            {children}
+          </Headline>
+        )
+      },
       h6: ({
         children,
+        node,
         ...props
-      }: ClassAttributes<HTMLHeadingElement> &
-        HTMLAttributes<HTMLHeadingElement>) => (
-        <Headline level={6} {...props}>
-          {children}
-        </Headline>
-      ),
-      table: (
-        props: ClassAttributes<HTMLTableElement> &
-          HTMLAttributes<HTMLTableElement>,
-      ) => (
-        <div className="table-wrapper custom-scrollbar">
-          <table
-            {...props}
-            className={`custom-scrollbar ${props.className ?? ''}`.trim()}
-          />
-        </div>
-      ),
+      }: MarkdownNodeProp &
+        ClassAttributes<HTMLHeadingElement> &
+        HTMLAttributes<HTMLHeadingElement>) => {
+        void node
+        return (
+          <Headline level={6} {...props}>
+            {children}
+          </Headline>
+        )
+      },
+      table: ({
+        node,
+        ...props
+      }: MarkdownNodeProp &
+        ClassAttributes<HTMLTableElement> &
+        HTMLAttributes<HTMLTableElement>) => {
+        void node
+        return (
+          <div className="table-wrapper custom-scrollbar">
+            <table
+              {...props}
+              className={`custom-scrollbar ${props.className ?? ''}`.trim()}
+            />
+          </div>
+        )
+      },
       pre: MarkdownCodeBlock,
-      code: (
-        props: JSX.IntrinsicAttributes &
-          ClassAttributes<HTMLElement> &
-          HTMLAttributes<HTMLElement> & { 'data-line'?: string },
-      ) => {
+      code: ({
+        node,
+        ...props
+      }: MarkdownNodeProp &
+        JSX.IntrinsicAttributes &
+        ClassAttributes<HTMLElement> &
+        HTMLAttributes<HTMLElement> & { 'data-line'?: string }) => {
+        void node
         const { className, children, 'data-line': dataLine } = props
         if (className?.includes('language-mermaid')) {
           const code = String(children ?? '').trim()

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -1141,7 +1141,7 @@
 
   .markdown-editor__preview-container .markdown-footnotes,
   .page-viewer__content .markdown-footnotes {
-    @apply border-border/70 mt-10 border-t pt-6 text-sm;
+    @apply border-border/70 relative mt-10 overflow-x-hidden border-t pt-6 text-sm;
   }
 
   .markdown-editor__preview-container .markdown-footnotes > ol,
@@ -1171,7 +1171,17 @@
 
   .markdown-editor__preview-container .markdown-footnotes > .sr-only,
   .page-viewer__content .markdown-footnotes > .sr-only {
-    display: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   .markdown-editor__preview-container a[data-footnote-ref],

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -87,6 +87,18 @@
    BASE LAYER — global defaults, Shadcn theme, dark mode
 ------------------------------------------------------- */
 @layer base {
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
   :root {
     --background: 0 0% 100%;
     --foreground: 222 47% 11%;
@@ -1125,6 +1137,56 @@
   .markdown-editor__preview-container ul li,
   .page-viewer__content ul li {
     @apply list-disc;
+  }
+
+  .markdown-editor__preview-container .markdown-footnotes,
+  .page-viewer__content .markdown-footnotes {
+    @apply border-border/70 mt-10 border-t pt-6 text-sm;
+  }
+
+  .markdown-editor__preview-container .markdown-footnotes > ol,
+  .page-viewer__content .markdown-footnotes > ol {
+    @apply my-0 pl-6;
+  }
+
+  .markdown-editor__preview-container .markdown-footnotes > ol > li,
+  .page-viewer__content .markdown-footnotes > ol > li {
+    @apply mb-4 pl-1;
+  }
+
+  .markdown-editor__preview-container .markdown-footnotes > ol > li:last-child,
+  .page-viewer__content .markdown-footnotes > ol > li:last-child {
+    @apply mb-0;
+  }
+
+  .markdown-editor__preview-container .markdown-footnotes > ol > li > p,
+  .page-viewer__content .markdown-footnotes > ol > li > p {
+    @apply my-0;
+  }
+
+  .markdown-editor__preview-container .markdown-footnotes > ol > li > p + p,
+  .page-viewer__content .markdown-footnotes > ol > li > p + p {
+    @apply mt-3;
+  }
+
+  .markdown-editor__preview-container .markdown-footnotes > .sr-only,
+  .page-viewer__content .markdown-footnotes > .sr-only {
+    display: none;
+  }
+
+  .markdown-editor__preview-container a[data-footnote-ref],
+  .page-viewer__content a[data-footnote-ref] {
+    @apply text-brand font-semibold no-underline;
+  }
+
+  .markdown-editor__preview-container a[data-footnote-backref],
+  .page-viewer__content a[data-footnote-backref] {
+    @apply text-brand ml-1 inline-flex items-center no-underline;
+  }
+
+  .markdown-editor__preview-container a[data-footnote-backref] sup,
+  .page-viewer__content a[data-footnote-backref] sup {
+    @apply ml-0.5 text-[0.7em];
   }
 
   .tree-view {


### PR DESCRIPTION
Improve markdown footnote rendering and navigation in the preview.

Strip react-markdown node props from rendered DOM output, normalize footnote anchors, add browser regressions, and style footnotes in index.css to avoid layout issues and accidental scrollbars.