### PR TITLE
fix(preview): render shoutouts with type-specific colors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,16 +85,25 @@ run-e2e-local:
 	@echo "⚡ Starting end-to-end tests (local fast path)..."
 	@E2E_RUN_MODE=local ./e2e/run.sh
 
+# Skip the Vite build when dist/ is already up to date; useful when iterating
+# on tests without changing the frontend. Pass GREP=<pattern> to filter tests,
+# e.g.: make run-e2e-local-fast GREP="shoutout"
+run-e2e-local-fast:
+	@echo "⚡ Starting end-to-end tests (local, skip UI build)..."
+	@E2E_RUN_MODE=local E2E_SKIP_UI_BUILD=1 ./e2e/run.sh $(if $(GREP),--grep "$(GREP)",)
+
 help:
 	@echo "Available commands:"
-	@echo "  make build      – Build binary for current system"
-	@echo "  make release    – Cross-compile binaries for all platforms (via Docker)"
-	@echo "  make clean      – Clean all generated files"
-	@echo "  make test       – Run all Go tests"
-	@echo "  make run-e2e    – Run end-to-end tests (using Docker)"
-	@echo "  make run-e2e-local – Run end-to-end tests via local fast path"
-	@echo "  make run        – Run development server"
-	@echo "  make docker-build-publish    – Build and push multi-arch Docker image"
-	@echo "  make changelog – Generate changelog"
+	@echo "  make build                – Build binary for current system"
+	@echo "  make release              – Cross-compile binaries for all platforms (via Docker)"
+	@echo "  make clean                – Clean all generated files"
+	@echo "  make test                 – Run all Go tests"
+	@echo "  make run-e2e              – Run end-to-end tests (using Docker)"
+	@echo "  make run-e2e-local        – Run end-to-end tests via local fast path"
+	@echo "  make run-e2e-local-fast   – Run E2E tests locally, skip UI build (use when dist/ is current)"
+	@echo "                              Optional: GREP=<pattern> to filter tests"
+	@echo "  make run                  – Run development server"
+	@echo "  make docker-build-publish – Build and push multi-arch Docker image"
+	@echo "  make changelog            – Generate changelog"
 
-.PHONY: all build run clean test fmt lint help docker-build-publish changelog run-e2e run-e2e-local
+.PHONY: all build run clean test fmt lint help docker-build-publish changelog run-e2e run-e2e-local run-e2e-local-fast

--- a/e2e/tests/page.spec.ts
+++ b/e2e/tests/page.spec.ts
@@ -1496,4 +1496,98 @@ Paragraph outside the list.
       test.expect(count).toBeGreaterThan(0);
     });
   });
+
+  test('markdown shoutouts render with type-specific classes and content', async ({ page }) => {
+    const timestamp = Date.now();
+    const slug = `shoutouts-${timestamp}`;
+    const title = `Shoutouts ${timestamp}`;
+    const content = `:::info
+Info content
+:::
+
+:::success
+Success content
+:::
+
+:::warning
+Warning content
+:::
+
+:::error
+Error content
+:::
+
+:::note
+Note alias content
+:::`;
+
+    await createPageWithContent(page, { title, slug, content });
+
+    const viewPage = new ViewPage(page);
+    await viewPage.goto(`/${slug}`);
+
+    const infoShoutout = page.locator('article aside.markdown-shoutout--info');
+    const successShoutout = page.locator('article aside.markdown-shoutout--success');
+    const warningShoutout = page.locator('article aside.markdown-shoutout--warning');
+    const errorShoutout = page.locator('article aside.markdown-shoutout--error');
+
+    await infoShoutout.first().waitFor({ state: 'visible' });
+    await successShoutout.waitFor({ state: 'visible' });
+    await warningShoutout.waitFor({ state: 'visible' });
+    await errorShoutout.waitFor({ state: 'visible' });
+
+    // note is an alias for info, so there should be two info shoutouts
+    await test.expect(page.locator('article aside.markdown-shoutout--info')).toHaveCount(2);
+
+    await test.expect(infoShoutout.first().locator('.markdown-shoutout__title')).toHaveText('Info');
+    await test.expect(successShoutout.locator('.markdown-shoutout__title')).toHaveText('Success');
+    await test.expect(warningShoutout.locator('.markdown-shoutout__title')).toHaveText('Warning');
+    await test.expect(errorShoutout.locator('.markdown-shoutout__title')).toHaveText('Error');
+
+    await test
+      .expect(infoShoutout.first().locator('.markdown-shoutout__content'))
+      .toContainText('Info content');
+    await test
+      .expect(successShoutout.locator('.markdown-shoutout__content'))
+      .toContainText('Success content');
+    await test
+      .expect(warningShoutout.locator('.markdown-shoutout__content'))
+      .toContainText('Warning content');
+    await test
+      .expect(errorShoutout.locator('.markdown-shoutout__content'))
+      .toContainText('Error content');
+    await test
+      .expect(infoShoutout.last().locator('.markdown-shoutout__content'))
+      .toContainText('Note alias content');
+
+    // verify each shoutout has a non-transparent background (CSS color classes applied)
+    const infoBackground = await infoShoutout.first().evaluate((el) => {
+      return window.getComputedStyle(el).backgroundColor;
+    });
+    test.expect(infoBackground).not.toBe('rgba(0, 0, 0, 0)');
+
+    const successBackground = await successShoutout.evaluate((el) => {
+      return window.getComputedStyle(el).backgroundColor;
+    });
+    test.expect(successBackground).not.toBe('rgba(0, 0, 0, 0)');
+
+    const warningBackground = await warningShoutout.evaluate((el) => {
+      return window.getComputedStyle(el).backgroundColor;
+    });
+    test.expect(warningBackground).not.toBe('rgba(0, 0, 0, 0)');
+
+    const errorBackground = await errorShoutout.evaluate((el) => {
+      return window.getComputedStyle(el).backgroundColor;
+    });
+    test.expect(errorBackground).not.toBe('rgba(0, 0, 0, 0)');
+
+    // the four variant backgrounds must be distinct from each other
+    const backgrounds = new Set([
+      infoBackground,
+      successBackground,
+      warningBackground,
+      errorBackground,
+    ]);
+    test.expect(backgrounds.size).toBe(4);
+  });
 });

--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
@@ -325,11 +325,13 @@ export default function MarkdownPreview({ content, path }: Props) {
         const markerIndex = childArray.findIndex(
           (child) => isValidElement(child) && child.type === 'p',
         )
-        const contentChildren =
+        const contentChildren = (
           markerIndex >= 0 ? childArray.slice(markerIndex + 1) : []
+        ).filter((child) => typeof child !== 'string' || child.trim() !== '')
 
         return (
           <aside
+            {...props}
             data-line={dataLine}
             className={`markdown-shoutout markdown-shoutout--${alertKind} ${className ?? ''}`.trim()}
           >

--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
@@ -2,8 +2,10 @@ import './markdownPreviewCodeTheme.css'
 import { useDesignModeStore } from '@/features/designtoggle/designmode'
 import { withBasePath } from '@/lib/routePath'
 import {
+  Children,
   AnchorHTMLAttributes,
   AudioHTMLAttributes,
+  BlockquoteHTMLAttributes,
   ClassAttributes,
   Component,
   ErrorInfo,
@@ -28,6 +30,7 @@ import { MarkdownImage } from './MarkdownImage'
 import { MarkdownLink } from './MarkdownLink'
 import MermaidBlock from './MermaidBlock'
 import { normalizeMarkdownListIndentation } from './normalizeMarkdownListIndentation'
+import { normalizeMarkdownShoutouts } from './normalizeMarkdownShoutouts'
 import { rehypeLineNumber } from './rehypeLineNumber'
 import { rehypeWhitelistStyles } from './rehypeWhitelistStyles'
 
@@ -67,6 +70,54 @@ const FOOTNOTE_TARGET_PREFIX = '#user-content-fn'
 
 type MarkdownNodeProp = {
   node?: unknown
+}
+
+type AlertKind = 'info' | 'success' | 'warning' | 'error'
+
+function getTextContent(node: ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node)
+  }
+
+  if (Array.isArray(node)) {
+    return node.map(getTextContent).join('')
+  }
+
+  if (isValidElement<{ children?: ReactNode }>(node)) {
+    return getTextContent(node.props.children)
+  }
+
+  return ''
+}
+
+function getAlertKind(children: ReactNode): AlertKind | null {
+  const childArray = Children.toArray(children)
+  // HAST includes whitespace text nodes between block elements; skip them
+  const firstChild = childArray.find(
+    (child) => typeof child !== 'string' || child.trim() !== '',
+  )
+
+  if (!isValidElement<{ children?: ReactNode }>(firstChild)) {
+    return null
+  }
+
+  if (firstChild.type !== 'p') {
+    return null
+  }
+
+  const marker = getTextContent(firstChild.props.children).trim()
+  if (marker === '[!INFO]') return 'info'
+  if (marker === '[!SUCCESS]') return 'success'
+  if (marker === '[!WARNING]') return 'warning'
+  if (marker === '[!ERROR]') return 'error'
+  return null
+}
+
+function getAlertLabel(kind: AlertKind) {
+  if (kind === 'info') return 'Info'
+  if (kind === 'success') return 'Success'
+  if (kind === 'warning') return 'Warning'
+  return 'Error'
 }
 
 class MarkdownPreviewErrorBoundary extends Component<
@@ -246,6 +297,49 @@ export default function MarkdownPreview({ content, path }: Props) {
 
         return <li {...props}>{children}</li>
       },
+      blockquote: ({
+        children,
+        node,
+        className,
+        'data-line': dataLine,
+        ...props
+      }: MarkdownNodeProp &
+        ClassAttributes<HTMLQuoteElement> &
+        BlockquoteHTMLAttributes<HTMLQuoteElement> & {
+          'data-line'?: string
+        }) => {
+        void node
+        const alertKind = getAlertKind(children)
+
+        if (!alertKind) {
+          return (
+            <blockquote {...props} data-line={dataLine} className={className}>
+              {children}
+            </blockquote>
+          )
+        }
+
+        const childArray = Children.toArray(children)
+        // Find the marker paragraph index so content starts after it,
+        // accounting for leading whitespace text nodes
+        const markerIndex = childArray.findIndex(
+          (child) => isValidElement(child) && child.type === 'p',
+        )
+        const contentChildren =
+          markerIndex >= 0 ? childArray.slice(markerIndex + 1) : []
+
+        return (
+          <aside
+            data-line={dataLine}
+            className={`markdown-shoutout markdown-shoutout--${alertKind} ${className ?? ''}`.trim()}
+          >
+            <p className="markdown-shoutout__title">
+              {getAlertLabel(alertKind)}
+            </p>
+            <div className="markdown-shoutout__content">{contentChildren}</div>
+          </aside>
+        )
+      },
       h1: ({
         children,
         node,
@@ -392,7 +486,7 @@ export default function MarkdownPreview({ content, path }: Props) {
   )
 
   const normalizedContent = useMemo(
-    () => normalizeMarkdownListIndentation(content),
+    () => normalizeMarkdownListIndentation(normalizeMarkdownShoutouts(content)),
     [content],
   )
 

--- a/ui/leafwiki-ui/src/features/preview/normalizeMarkdownShoutouts.ts
+++ b/ui/leafwiki-ui/src/features/preview/normalizeMarkdownShoutouts.ts
@@ -1,0 +1,153 @@
+const shoutoutOpenPattern =
+  /^(?<indent> {0,3}):::\s*(?<type>[A-Za-z][\w-]*)\s*$/
+const shoutoutClosePattern = /^(?<indent> {0,3}):::\s*$/
+const fencedCodePattern = /^(?<indent> {0,3})(?<marker>`{3,}|~{3,})(?<rest>.*)$/
+
+const shoutoutTypeMap: Record<string, string> = {
+  caution: 'warning',
+  danger: 'error',
+  error: 'error',
+  fail: 'error',
+  failed: 'error',
+  failure: 'error',
+  info: 'info',
+  note: 'info',
+  success: 'success',
+  tip: 'info',
+  warn: 'warning',
+  warning: 'warning',
+}
+
+function normalizeShoutoutType(rawType: string) {
+  return shoutoutTypeMap[rawType.toLowerCase()] ?? 'info'
+}
+
+function prefixQuoteLine(indent: string, line: string) {
+  return `${indent}>${line ? ` ${line}` : ''}`
+}
+
+type FenceState = {
+  markerChar: '`' | '~'
+  markerLength: number
+}
+
+function getFenceInfo(line: string): FenceState | null {
+  const match = line.match(fencedCodePattern)
+  if (!match?.groups) {
+    return null
+  }
+
+  const marker = match.groups.marker ?? ''
+  const markerChar = marker[0]
+  if (markerChar !== '`' && markerChar !== '~') {
+    return null
+  }
+
+  return {
+    markerChar,
+    markerLength: marker.length,
+  }
+}
+
+function getNextFenceState(line: string, currentFence: FenceState | null) {
+  const nextFence = getFenceInfo(line)
+
+  if (!currentFence) {
+    return nextFence
+  }
+
+  if (
+    nextFence &&
+    nextFence.markerChar === currentFence.markerChar &&
+    nextFence.markerLength >= currentFence.markerLength
+  ) {
+    return null
+  }
+
+  return currentFence
+}
+
+export function normalizeMarkdownShoutouts(content: string) {
+  const normalizedContent = content.replace(/\r\n/g, '\n')
+  const lines = normalizedContent.split('\n')
+  const output: string[] = []
+  let outerFence: FenceState | null = null
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+    const openMatch = line.match(shoutoutOpenPattern)
+
+    if (!openMatch?.groups || outerFence) {
+      output.push(line)
+      outerFence = getNextFenceState(line, outerFence)
+      continue
+    }
+
+    const indent = openMatch.groups.indent ?? ''
+    const variant = normalizeShoutoutType(openMatch.groups.type ?? 'info')
+    const originalBlockLines = [line]
+    const blockLines: string[] = []
+    let closingIndex = index + 1
+    let innerFence: FenceState | null = null
+    let nestedDepth = 1
+    let isMalformed = false
+
+    for (; closingIndex < lines.length; closingIndex += 1) {
+      const candidateLine = lines[closingIndex]
+      originalBlockLines.push(candidateLine)
+
+      if (!innerFence) {
+        if (shoutoutOpenPattern.test(candidateLine)) {
+          nestedDepth += 1
+          isMalformed = true
+          continue
+        }
+
+        if (shoutoutClosePattern.test(candidateLine)) {
+          nestedDepth -= 1
+          if (nestedDepth === 0) {
+            break
+          }
+          continue
+        }
+      }
+
+      if (!isMalformed) {
+        blockLines.push(candidateLine)
+      }
+      innerFence = getNextFenceState(candidateLine, innerFence)
+    }
+
+    if (closingIndex >= lines.length || isMalformed) {
+      output.push(...originalBlockLines)
+      if (closingIndex < lines.length) {
+        index = closingIndex
+      }
+      continue
+    }
+
+    if (output.length > 0 && output[output.length - 1] !== '') {
+      output.push('')
+    }
+
+    output.push(prefixQuoteLine(indent, `[!${variant.toUpperCase()}]`))
+    output.push(prefixQuoteLine(indent, ''))
+
+    if (blockLines.length === 0) {
+      output.push(prefixQuoteLine(indent, ''))
+    } else {
+      for (const blockLine of blockLines) {
+        output.push(prefixQuoteLine(indent, blockLine))
+      }
+    }
+
+    const nextLine = lines[closingIndex + 1]
+    if (nextLine !== undefined && nextLine !== '') {
+      output.push('')
+    }
+
+    index = closingIndex
+  }
+
+  return output.join('\n')
+}

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -1199,6 +1199,76 @@
     @apply ml-0.5 text-[0.7em];
   }
 
+  .markdown-editor__preview-container .markdown-shoutout,
+  .page-viewer__content .markdown-shoutout {
+    @apply border-border/70 bg-surface-alt text-page-text my-6 rounded-lg border px-4 py-3;
+  }
+
+  .markdown-editor__preview-container .markdown-shoutout__title,
+  .page-viewer__content .markdown-shoutout__title {
+    @apply mb-2 text-sm font-semibold tracking-[0.08em] uppercase;
+  }
+
+  .markdown-editor__preview-container
+    .markdown-shoutout__content
+    > :first-child,
+  .page-viewer__content .markdown-shoutout__content > :first-child {
+    @apply mt-0;
+  }
+
+  .markdown-editor__preview-container .markdown-shoutout__content > :last-child,
+  .page-viewer__content .markdown-shoutout__content > :last-child {
+    @apply mb-0;
+  }
+
+  .markdown-editor__preview-container .markdown-shoutout--info,
+  .page-viewer__content .markdown-shoutout--info {
+    @apply border-brand/30 bg-brand/5;
+  }
+
+  .markdown-editor__preview-container
+    .markdown-shoutout--info
+    .markdown-shoutout__title,
+  .page-viewer__content .markdown-shoutout--info .markdown-shoutout__title {
+    @apply text-brand;
+  }
+
+  .markdown-editor__preview-container .markdown-shoutout--success,
+  .page-viewer__content .markdown-shoutout--success {
+    @apply border-success/30 bg-success/5;
+  }
+
+  .markdown-editor__preview-container
+    .markdown-shoutout--success
+    .markdown-shoutout__title,
+  .page-viewer__content .markdown-shoutout--success .markdown-shoutout__title {
+    @apply text-success;
+  }
+
+  .markdown-editor__preview-container .markdown-shoutout--warning,
+  .page-viewer__content .markdown-shoutout--warning {
+    @apply border-warning/30 bg-warning/10;
+  }
+
+  .markdown-editor__preview-container
+    .markdown-shoutout--warning
+    .markdown-shoutout__title,
+  .page-viewer__content .markdown-shoutout--warning .markdown-shoutout__title {
+    @apply text-warning;
+  }
+
+  .markdown-editor__preview-container .markdown-shoutout--error,
+  .page-viewer__content .markdown-shoutout--error {
+    @apply border-error/30 bg-error/5;
+  }
+
+  .markdown-editor__preview-container
+    .markdown-shoutout--error
+    .markdown-shoutout__title,
+  .page-viewer__content .markdown-shoutout--error .markdown-shoutout__title {
+    @apply text-error;
+  }
+
   .tree-view {
     @apply w-full;
   }


### PR DESCRIPTION
HAST produces whitespace text nodes between block elements, so Children.toArray(children)[0] was '\n' instead of the marker <p>. getAlertKind returned null for every blockquote, causing all shoutouts to fall back to plain <blockquote> without styling.

Fix getAlertKind to skip whitespace-only strings when searching for the first child, and derive contentChildren by findIndex on the first <p> so content starts correctly after the marker regardless of leading nodes.

Also adds:
- normalizeMarkdownShoutouts: converts :::type blocks to GH-style alerts
- index.css: shoutout variant styles (info/success/warning/error)
- E2E test covering all four variants plus the note alias
- Makefile: run-e2e-local-fast target (skip UI build, optional GREP filter)