### PR TITLE
fix(preview): remove anchor id prefix

### DIFF
--- a/e2e/tests/page.spec.ts
+++ b/e2e/tests/page.spec.ts
@@ -476,7 +476,7 @@ Target content`;
       .poll(async () => page.evaluate(() => window.location.hash), {
         timeout: 5000,
       })
-      .toBe('#leafwiki-intro');
+      .toBe('#intro');
   });
 
   test('headline anchor supports non-ascii headings', async ({ page }) => {
@@ -502,7 +502,7 @@ Target content`;
       .poll(async () => page.evaluate(() => decodeURIComponent(window.location.hash)), {
         timeout: 5000,
       })
-      .toBe('#leafwiki-привет-мир');
+      .toBe('#привет-мир');
 
     const latinHeading = page.locator('article h2').getByText('Café Überblick');
     await latinHeading.waitFor({ state: 'visible' });
@@ -512,7 +512,7 @@ Target content`;
       .poll(async () => page.evaluate(() => decodeURIComponent(window.location.hash)), {
         timeout: 5000,
       })
-      .toBe('#leafwiki-cafe-uberblick');
+      .toBe('#cafe-uberblick');
 
     const hanHeading = page.locator('article h3').getByText('你好 世界');
     await hanHeading.waitFor({ state: 'visible' });
@@ -522,7 +522,7 @@ Target content`;
       .poll(async () => page.evaluate(() => decodeURIComponent(window.location.hash)), {
         timeout: 5000,
       })
-      .toBe('#leafwiki-你好-世界');
+      .toBe('#你好-世界');
   });
 
   test('navigating away from page with footnote headline stays responsive', async ({ page }) => {
@@ -603,28 +603,28 @@ This paragraph creates a footnote reference.[^leafwiki]
     await test.expect(footnoteReference).not.toHaveAttribute('node', /.+/);
     await test
       .expect(footnoteReference)
-      .toHaveAttribute('href', /#leafwiki-user-content-fn-leafwiki$/);
+      .toHaveAttribute('href', /#user-content-fn-leafwiki$/);
     await footnoteReference.click();
 
     await test.expect
       .poll(async () => page.evaluate(() => decodeURIComponent(window.location.hash)), {
         timeout: 5000,
       })
-      .toBe('#leafwiki-user-content-fn-leafwiki');
+      .toBe('#user-content-fn-leafwiki');
 
     const footnoteBacklink = page.locator('article a[data-footnote-backref]');
     await footnoteBacklink.waitFor({ state: 'visible' });
     await test.expect(footnoteBacklink).not.toHaveAttribute('node', /.+/);
     await test
       .expect(footnoteBacklink)
-      .toHaveAttribute('href', /#leafwiki-user-content-fnref-leafwiki$/);
+      .toHaveAttribute('href', /#user-content-fnref-leafwiki$/);
     await footnoteBacklink.click();
 
     await test.expect
       .poll(async () => page.evaluate(() => decodeURIComponent(window.location.hash)), {
         timeout: 5000,
       })
-      .toBe('#leafwiki-user-content-fnref-leafwiki');
+      .toBe('#user-content-fnref-leafwiki');
 
     await test.expect(page.locator('article .footnotes')).not.toHaveAttribute('node', /.+/);
 
@@ -657,19 +657,19 @@ First reference[^leafwiki] and second reference[^leafwiki]
     await test.expect(footnoteReferences.nth(1)).not.toHaveAttribute('node', /.+/);
     await test
       .expect(footnoteReferences.nth(0))
-      .toHaveAttribute('href', /#leafwiki-user-content-fn-leafwiki$/);
+      .toHaveAttribute('href', /#user-content-fn-leafwiki$/);
     await test
       .expect(footnoteReferences.nth(1))
-      .toHaveAttribute('href', /#leafwiki-user-content-fn-leafwiki$/);
+      .toHaveAttribute('href', /#user-content-fn-leafwiki$/);
 
     const footnoteBacklinks = page.locator('article a[data-footnote-backref]');
     await test.expect(footnoteBacklinks).toHaveCount(2);
     await test
       .expect(footnoteBacklinks.nth(0))
-      .toHaveAttribute('href', /#leafwiki-user-content-fnref-leafwiki$/);
+      .toHaveAttribute('href', /#user-content-fnref-leafwiki$/);
     await test
       .expect(footnoteBacklinks.nth(1))
-      .toHaveAttribute('href', /#leafwiki-user-content-fnref-leafwiki-2$/);
+      .toHaveAttribute('href', /#user-content-fnref-leafwiki-2$/);
     await test.expect(footnoteBacklinks.nth(1)).not.toHaveAttribute('node', /.+/);
 
     await footnoteBacklinks.nth(1).click();
@@ -678,7 +678,7 @@ First reference[^leafwiki] and second reference[^leafwiki]
       .poll(async () => page.evaluate(() => decodeURIComponent(window.location.hash)), {
         timeout: 5000,
       })
-      .toBe('#leafwiki-user-content-fnref-leafwiki-2');
+      .toBe('#user-content-fnref-leafwiki-2');
   });
 
   test('navigating away from markdown-it sample stays responsive', async ({ page }) => {

--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
@@ -36,7 +36,7 @@ import { rehypeWhitelistStyles } from './rehypeWhitelistStyles'
 
 const schema = {
   ...defaultSchema,
-  clobberPrefix: 'leafwiki-',
+  clobberPrefix: '',
   tagNames: [...(defaultSchema.tagNames || []), 'audio', 'video'],
   attributes: {
     ...defaultSchema.attributes,
@@ -65,7 +65,7 @@ type MarkdownPreviewErrorBoundaryState = {
   hasError: boolean
 }
 
-const CLOBBER_PREFIX = 'leafwiki-'
+const CLOBBER_PREFIX = ''
 const FOOTNOTE_TARGET_PREFIX = '#user-content-fn'
 
 type MarkdownNodeProp = {


### PR DESCRIPTION
Remove the leafwiki clobber prefix from markdown preview heading and footnote anchors so preview hash links keep the classic ids. Update the E2E expectations to match the restored hash format.