### PR TITLE
fix(revision): improve history behavior

### DIFF
--- a/e2e/pages/EditPageMetadataDialog.ts
+++ b/e2e/pages/EditPageMetadataDialog.ts
@@ -20,6 +20,11 @@ export default class EditPageMetadataDialog {
     await input.fill(title);
   }
 
+  async fillSlug(slug: string) {
+    const input = await this.slugInput();
+    await input.fill(slug);
+  }
+
   async expectPath(path: string) {
     await expect(await this.pathDisplay()).toHaveText(`Path: ${path}`);
   }

--- a/e2e/tests/history.spec.ts
+++ b/e2e/tests/history.spec.ts
@@ -1,6 +1,7 @@
 import test, { expect } from '@playwright/test';
 import AddPageDialog from '../pages/AddPageDialog';
 import EditPage from '../pages/EditPage';
+import EditPageMetadataDialog from '../pages/EditPageMetadataDialog';
 import LoginPage from '../pages/LoginPage';
 import TreeView from '../pages/TreeView';
 import ViewPage from '../pages/ViewPage';
@@ -65,6 +66,25 @@ test.describe('History', () => {
     await expect(page.locator('[data-testid^="history-sidebar-revision-"]').first()).toBeVisible();
   });
 
+  test('current-revision-is-visible-and-badged', async ({ page }) => {
+    const title = `History Current Badge ${Date.now()}`;
+    const viewPage = await createPageWithRevisions(page, title, [
+      'First revision content',
+      '\nSecond revision content',
+    ]);
+
+    await viewPage.openCurrentPageHistory();
+    await viewPage.expectRevisionListVisible();
+
+    const currentBadge = page.locator('[data-testid^="history-sidebar-revision-current-badge-"]');
+    await expect(currentBadge).toHaveCount(1);
+    await expect(currentBadge).toHaveText('Active version');
+
+    const currentRevision = currentBadge.locator('xpath=ancestor::button[1]');
+    await currentRevision.click();
+    await expect(page.getByTestId('page-history-page-restore')).toBeDisabled();
+  });
+
   test('revision-list-stays-visible-after-selecting-revision', async ({ page }) => {
     // Regression for: revision list disappearing when a revision is opened.
     const title = `History Stays Visible ${Date.now()}`;
@@ -123,6 +143,97 @@ test.describe('History', () => {
     );
   });
 
+  test('active-revision-shows-no-diff', async ({ page }) => {
+    const title = `History Active Diff ${Date.now()}`;
+    const viewPage = await createPageWithRevisions(page, title, [
+      'First revision content',
+      '\nSecond revision content',
+    ]);
+
+    await viewPage.openCurrentPageHistory();
+
+    const currentBadge = page.locator(
+      '[data-testid^="history-sidebar-revision-current-badge-"]',
+    );
+    const currentRevision = currentBadge.locator('xpath=ancestor::button[1]');
+    await currentRevision.click();
+
+    await page.locator('[data-testid="page-history-page-changes-tab"]').click();
+    await expect(page.getByTestId('page-history-page-content')).toContainText(
+      'No differences from the current version.',
+    );
+  });
+
+  test('structure-changes-are-visible-in-history-header', async ({ page }) => {
+    const suffix = Date.now();
+    const originalTitle = `History Structure ${suffix}`;
+    const renamedTitle = `History Structure Renamed ${suffix}`;
+    const renamedSlug = `history-structure-renamed-${suffix}`;
+    const viewPage = await createPageWithRevisions(page, originalTitle, [
+      'First revision content',
+      '\nSecond revision content',
+    ]);
+
+    await viewPage.clickEditPageButton();
+
+    const editPage = new EditPage(page);
+    await editPage.openMetadataDialog();
+
+    const metadataDialog = new EditPageMetadataDialog(page);
+    await metadataDialog.fillTitle(renamedTitle);
+    await metadataDialog.fillSlug(renamedSlug);
+    await metadataDialog.submit();
+
+    await editPage.closeEditor();
+    await viewPage.openCurrentPageHistory();
+    await page.locator('[data-testid="page-history-page-changes-tab"]').click();
+
+    const structureChanges = page.getByTestId(
+      'page-history-page-structure-changes',
+    );
+    await expect(structureChanges).toContainText('Title');
+    await expect(structureChanges).toContainText(originalTitle);
+    await expect(structureChanges).toContainText(renamedTitle);
+    await expect(structureChanges).toContainText('Slug');
+    await expect(structureChanges).toContainText(`history-structure-${suffix}`);
+    await expect(structureChanges).toContainText(renamedSlug);
+  });
+
+  test('selecting-a-revision-keeps-current-history-route-after-rename', async ({
+    page,
+  }) => {
+    const suffix = Date.now();
+    const originalTitle = `History Route ${suffix}`;
+    const renamedTitle = `history-route-renamed-${suffix}`;
+    const viewPage = await createPageWithRevisions(page, originalTitle, [
+      'First revision content',
+      '\nSecond revision content',
+    ]);
+
+    await viewPage.clickEditPageButton();
+
+    const editPage = new EditPage(page);
+    await editPage.openMetadataDialog();
+
+    const metadataDialog = new EditPageMetadataDialog(page);
+    await metadataDialog.fillTitle(renamedTitle);
+    await metadataDialog.expectSlug(renamedTitle);
+    await metadataDialog.submit();
+
+    await editPage.closeEditor();
+
+    await viewPage.openCurrentPageHistory();
+
+    const historyPathBeforeSelection = new URL(page.url()).pathname;
+
+    await viewPage.openRevisionAt(0);
+
+    await expect.poll(() => new URL(page.url()).pathname).toBe(
+      historyPathBeforeSelection,
+    );
+    await expect(page.getByTestId('page-history-page-content')).toBeVisible();
+  });
+
   test('revision-title-shows-timestamp-not-type-label', async ({ page }) => {
     // Revision list items should show a formatted timestamp, not generic
     // type labels like "Content changed" or "Assets changed".
@@ -174,11 +285,23 @@ test.describe('History', () => {
   test('restore-revision', async ({ page }) => {
     const originalContent = `Original ${Date.now()}`;
     const updatedContent = `Updated ${Date.now()}`;
-    const title = `History Restore ${Date.now()}`;
+    const title = `history-restore-${Date.now()}`;
+    const renamedTitle = `history-restore-renamed-${Date.now()}`;
     const viewPage = await createPageWithRevisions(page, title, [
       originalContent,
       `\n${updatedContent}`,
     ]);
+
+    await viewPage.clickEditPageButton();
+
+    const editPage = new EditPage(page);
+    await editPage.openMetadataDialog();
+
+    const metadataDialog = new EditPageMetadataDialog(page);
+    await metadataDialog.fillTitle(renamedTitle);
+    await metadataDialog.expectSlug(renamedTitle);
+    await metadataDialog.submit();
+    await editPage.closeEditor();
 
     await viewPage.openCurrentPageHistory();
     await viewPage.openRevisionAt(0);
@@ -190,5 +313,7 @@ test.describe('History', () => {
     // After restore the history page should reload and show the restored state.
     await page.getByTestId('page-history-page-content').waitFor({ state: 'visible' });
     await expect(page.locator('[data-testid^="history-sidebar-revision-"]').first()).toBeVisible();
+    await expect(page.locator('article > h1')).toHaveText(title);
+    await expect.poll(() => new URL(page.url()).pathname).toContain(`/history/${title}`);
   });
 });

--- a/e2e/tests/page.spec.ts
+++ b/e2e/tests/page.spec.ts
@@ -1851,6 +1851,12 @@ Note alias content
     await expect(page.getByTestId('page-history-page-content')).toBeVisible();
     await page.getByTestId('page-history-page-assets-tab').click();
     await expect(page.getByTestId('page-history-page-content')).toContainText('upload-test.png');
+    await expect(page.getByTestId('page-history-page-content')).not.toContainText('Removed');
+    await expect(page.getByTestId('history-asset-open-upload-test.png')).toBeVisible();
+    await expect(page.getByTestId('history-asset-download-upload-test.png')).toBeVisible();
+
+    await viewPage.openRevisionAt(0);
+    await page.getByTestId('page-history-page-changes-tab').click();
     await expect(page.getByTestId('page-history-page-content')).toContainText('Removed');
   });
 

--- a/internal/core/revision/service.go
+++ b/internal/core/revision/service.go
@@ -769,8 +769,7 @@ func (s *Service) RestoreRevision(pageID, revisionID, authorID string) error {
 		)
 	}
 
-	page, err := s.pages.GetPage(pageID)
-	if err != nil {
+	if _, err := s.pages.GetPage(pageID); err != nil {
 		if errors.Is(err, tree.ErrPageNotFound) {
 			return sharederrors.NewLocalizedError(
 				"revision_restore_page_not_found",
@@ -801,7 +800,7 @@ func (s *Service) RestoreRevision(pageID, revisionID, authorID string) error {
 	}
 
 	restoredContent := string(content)
-	if err := s.pages.UpdateNode(authorID, pageID, page.Title, page.Slug, &restoredContent); err != nil {
+	if err := s.pages.UpdateNode(authorID, pageID, rev.Title, rev.Slug, &restoredContent); err != nil {
 		return sharederrors.NewLocalizedError(
 			"revision_restore_failed",
 			"Failed to restore page",
@@ -813,7 +812,7 @@ func (s *Service) RestoreRevision(pageID, revisionID, authorID string) error {
 
 	if err := s.restoreAssets(pageID, assets); err != nil {
 		restoreRollbackContent := beforeState.Content
-		if rollbackErr := s.pages.UpdateNode(authorID, pageID, page.Title, page.Slug, &restoreRollbackContent); rollbackErr != nil {
+		if rollbackErr := s.pages.UpdateNode(authorID, pageID, beforeState.Title, beforeState.Slug, &restoreRollbackContent); rollbackErr != nil {
 			s.log.Warn("failed to rollback restored content", "pageID", pageID, "error", rollbackErr)
 		}
 		if rollbackErr := s.restoreAssets(pageID, beforeState.Assets); rollbackErr != nil {
@@ -830,7 +829,7 @@ func (s *Service) RestoreRevision(pageID, revisionID, authorID string) error {
 
 	if err := s.recordRestoreRevision(pageID, authorID); err != nil {
 		restoreRollbackContent := beforeState.Content
-		if rollbackErr := s.pages.UpdateNode(authorID, pageID, page.Title, page.Slug, &restoreRollbackContent); rollbackErr != nil {
+		if rollbackErr := s.pages.UpdateNode(authorID, pageID, beforeState.Title, beforeState.Slug, &restoreRollbackContent); rollbackErr != nil {
 			s.log.Warn("failed to rollback restored content", "pageID", pageID, "error", rollbackErr)
 		}
 		if rollbackErr := s.restoreAssets(pageID, beforeState.Assets); rollbackErr != nil {

--- a/internal/core/revision/service_test.go
+++ b/internal/core/revision/service_test.go
@@ -948,13 +948,13 @@ func TestRestoreRevisionRehydratesLivePageState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetPage failed: %v", err)
 	}
-	if page.Title != "Changed" || page.Slug != "changed" {
+	if page.Title != "Original" || page.Slug != "original" {
 		t.Fatalf("restored page identity = (%q,%q)", page.Title, page.Slug)
 	}
 	if page.Content != originalContent {
 		t.Fatalf("restored content = %q, want %q", page.Content, originalContent)
 	}
-	if got := page.CalculatePath(); got != "/archive/changed" {
+	if got := page.CalculatePath(); got != "/archive/original" {
 		t.Fatalf("restored path = %q", got)
 	}
 

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -399,6 +399,7 @@ func (w *Wiki) UpdatePage(userID string, id, title, slug string, content *string
 	if err != nil {
 		return nil, err
 	}
+	oldTitle := before.Title
 	oldPrefix := before.CalculatePath()
 	renameOrPathChange := (slug != before.Slug)
 
@@ -459,7 +460,7 @@ func (w *Wiki) UpdatePage(userID string, id, title, slug string, content *string
 			}
 			w.recordStructureRevision(pid, userID, "")
 		}
-	} else if content == nil && before.Title != after.Title {
+	} else if content == nil && oldTitle != after.Title {
 		w.recordStructureRevision(id, userID, "")
 	}
 
@@ -532,7 +533,7 @@ func (w *Wiki) CopyPage(userID string, currentPageID string, targetParentID *str
 		}
 	}
 
-	w.recordAssetRevision(copy.ID, userID, "page copied")
+	w.recordContentRevision(copy.ID, userID, "page copied")
 
 	return copy, nil
 }

--- a/internal/wiki/wiki_test.go
+++ b/internal/wiki/wiki_test.go
@@ -778,6 +778,43 @@ func TestWiki_CopyPages_WithAssets(t *testing.T) {
 	}
 }
 
+func TestWiki_CopyPages_RecordsContentRevision(t *testing.T) {
+	w := createWikiTestInstance(t)
+	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
+
+	original, err := w.CreatePage("system", nil, "Original", "original", pageNodeKind())
+	if err != nil {
+		t.Fatalf("CreatePage failed: %v", err)
+	}
+
+	content := "original content"
+	if _, err := w.UpdatePage("system", original.ID, original.Title, original.Slug, &content, pageNodeKind()); err != nil {
+		t.Fatalf("UpdatePage failed: %v", err)
+	}
+
+	copied, err := w.CopyPage("editor", original.ID, nil, "Copy of Original", "copy-of-original")
+	if err != nil {
+		t.Fatalf("CopyPage failed: %v", err)
+	}
+
+	latest, err := w.GetLatestRevision(copied.ID)
+	if err != nil {
+		t.Fatalf("GetLatestRevision failed: %v", err)
+	}
+	if latest == nil {
+		t.Fatal("expected latest revision for copied page")
+	}
+	if latest.Type != revision.RevisionTypeContentUpdate {
+		t.Fatalf("latest revision type = %q, want %q", latest.Type, revision.RevisionTypeContentUpdate)
+	}
+	if latest.AuthorID != "editor" {
+		t.Fatalf("latest author = %q, want %q", latest.AuthorID, "editor")
+	}
+	if latest.Summary != "page copied" {
+		t.Fatalf("latest summary = %q, want %q", latest.Summary, "page copied")
+	}
+}
+
 func TestWiki_InitDefaultAdmin_UsesGivenPassword(t *testing.T) {
 	w := createWikiTestInstance(t)
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
@@ -1813,10 +1850,10 @@ func TestWiki_RestoreRevisionRestoresAssetsAndStructure(t *testing.T) {
 		t.Fatalf("RestoreRevision failed: %v", err)
 	}
 
-	if restored.Title != "Changed" || restored.Slug != "changed" {
+	if restored.Title != "Original" || restored.Slug != "original" {
 		t.Fatalf("restored identity = (%q,%q)", restored.Title, restored.Slug)
 	}
-	if restored.CalculatePath() != "/archive/changed" {
+	if restored.CalculatePath() != "/archive/original" {
 		t.Fatalf("restored path = %q", restored.CalculatePath())
 	}
 	if restored.Content != originalContent {
@@ -1861,6 +1898,60 @@ func TestWiki_MovePageRecordsStructureRevision(t *testing.T) {
 	}
 	if latest.ParentID != dest.ID {
 		t.Fatalf("latest parent id = %q, want %q", latest.ParentID, dest.ID)
+	}
+}
+
+func TestWiki_UpdatePage_TitleOnlyCreatesStructureRevision(t *testing.T) {
+	w := createWikiTestInstance(t)
+	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
+
+	page, err := w.CreatePage("system", nil, "Original", "original", pageNodeKind())
+	if err != nil {
+		t.Fatalf("CreatePage failed: %v", err)
+	}
+
+	content := "same content"
+	page, err = w.UpdatePage("system", page.ID, page.Title, page.Slug, &content, pageNodeKind())
+	if err != nil {
+		t.Fatalf("UpdatePage(initial content) failed: %v", err)
+	}
+
+	beforeLatest, err := w.GetLatestRevision(page.ID)
+	if err != nil {
+		t.Fatalf("GetLatestRevision(before rename) failed: %v", err)
+	}
+	if beforeLatest == nil {
+		t.Fatal("expected initial content revision")
+	}
+
+	updatedPage, err := w.UpdatePage("system", page.ID, "Renamed Title", page.Slug, nil, pageNodeKind())
+	if err != nil {
+		t.Fatalf("UpdatePage(title only) failed: %v", err)
+	}
+	if updatedPage.Title != "Renamed Title" {
+		t.Fatalf("updated title = %q", updatedPage.Title)
+	}
+
+	afterLatest, err := w.GetLatestRevision(page.ID)
+	if err != nil {
+		t.Fatalf("GetLatestRevision(after rename) failed: %v", err)
+	}
+	if afterLatest == nil {
+		t.Fatal("expected latest revision after title update")
+	}
+	if afterLatest.ID == beforeLatest.ID {
+		t.Fatalf("expected new revision for title-only change")
+	}
+	if afterLatest.Type != revision.RevisionTypeStructureUpdate {
+		t.Fatalf("latest revision type = %q", afterLatest.Type)
+	}
+
+	revisions, err := w.ListRevisions(page.ID)
+	if err != nil {
+		t.Fatalf("ListRevisions failed: %v", err)
+	}
+	if len(revisions) != 2 {
+		t.Fatalf("revision count = %d, want 2", len(revisions))
 	}
 }
 

--- a/ui/leafwiki-ui/src/features/history/PageHistoryContent.tsx
+++ b/ui/leafwiki-ui/src/features/history/PageHistoryContent.tsx
@@ -11,7 +11,7 @@ import {
   type RevisionSnapshot,
 } from '@/lib/api/revisions'
 import { formatRelativeTime } from '@/lib/formatDate'
-import { buildHistoryUrl } from '@/lib/routePath'
+import { buildHistoryUrl, withBasePath } from '@/lib/routePath'
 import { useIsMobile } from '@/lib/useIsMobile'
 import { useTreeStore } from '@/stores/tree'
 import {
@@ -24,8 +24,16 @@ import {
 } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
-import { History, Loader2, PanelLeftOpen } from 'lucide-react'
+import {
+  Download,
+  ExternalLink,
+  FileText,
+  History,
+  Loader2,
+  PanelLeftOpen,
+} from 'lucide-react'
 import { useLinkStatusStore } from '../links/linkstatus_store'
+import { AssetPreviewTooltip } from '../assets/AssetPreviewTooltip'
 import MarkdownPreview from '../preview/MarkdownPreview'
 import { useViewerStore } from '../viewer/viewer'
 import {
@@ -108,6 +116,11 @@ function revisionTitle(revision: Revision) {
 
 function revisionMeta(revision: Revision) {
   return revision.author?.username || revision.authorId || 'Unknown'
+}
+
+function getPathLeaf(path: string) {
+  const segments = path.split('/').filter(Boolean)
+  return (segments[segments.length - 1] ?? path) || '/'
 }
 
 // --- Diff / detail helpers ---
@@ -290,6 +303,43 @@ function MetaChip({ children }: { children: ReactNode }) {
   return <span className="page-history__meta-chip">{children}</span>
 }
 
+function ChangeChip({
+  label,
+  from,
+  to,
+}: {
+  label: string
+  from: string
+  to: string
+}) {
+  return (
+    <div className="page-history__change-chip">
+      <span className="page-history__change-chip-label">{label}</span>
+      <span className="page-history__change-chip-value">
+        <span className="page-history__change-chip-from">{from}</span>
+        <span className="page-history__change-chip-arrow" aria-hidden="true">
+          →
+        </span>
+        <span className="page-history__change-chip-to">{to}</span>
+      </span>
+    </div>
+  )
+}
+
+function RevisionBadge({
+  children,
+  testId,
+}: {
+  children: ReactNode
+  testId?: string
+}) {
+  return (
+    <span className="history-sidebar__badge" data-testid={testId}>
+      {children}
+    </span>
+  )
+}
+
 function EmptyState({ title, message }: { title: string; message: string }) {
   return (
     <div className="page-history__empty-state">
@@ -303,14 +353,16 @@ function SummaryStat({
   label,
   value,
   emphasized = false,
+  tone = 'default',
 }: {
   label: string
   value: string
   emphasized?: boolean
+  tone?: 'default' | 'added' | 'removed'
 }) {
   return (
     <div
-      className={`page-history__summary-stat ${
+      className={`page-history__summary-stat page-history__summary-stat--${tone} ${
         emphasized ? 'page-history__summary-stat--emphasized' : ''
       }`.trim()}
     >
@@ -382,11 +434,13 @@ function ChangesPanel({ comparison }: { comparison: RevisionComparison }) {
             label="Lines added"
             value={String(diff.summary.addedLines)}
             emphasized={diff.summary.addedLines > 0}
+            tone="added"
           />
           <SummaryStat
             label="Lines removed"
             value={String(diff.summary.removedLines)}
             emphasized={diff.summary.removedLines > 0}
+            tone="removed"
           />
           <SummaryStat
             label="Assets changed"
@@ -476,42 +530,111 @@ function RawTextPanel({ snapshot }: { snapshot: RevisionSnapshot }) {
     <div className="page-history__detail-stack">
       <section className="page-history__section">
         <div className="page-history__section-heading">Raw Text</div>
-        <pre className="page-history__snapshot-content">
-          {snapshot.content || '(empty)'}
-        </pre>
+        <div className="custom-scrollbar markdown-code-block page-history__raw-text-block">
+          <pre className="custom-scrollbar page-history__snapshot-content">
+            <code>{snapshot.content || '(empty)'}</code>
+          </pre>
+        </div>
       </section>
     </div>
   )
 }
 
-function AssetsPanel({ comparison }: { comparison: RevisionComparison }) {
+function HistoryAssetItem({
+  asset,
+  pageId,
+  revisionId,
+}: {
+  asset: RevisionSnapshot['assets'][number]
+  pageId: string
+  revisionId: string
+}) {
+  const assetUrl = withBasePath(
+    buildRevisionAssetUrl(pageId, revisionId, asset.name),
+  )
+  const baseName = asset.name.split('/').pop() ?? asset.name
+
+  return (
+    <li className="group asset-item page-history__asset-item">
+      <div className="flex min-w-0 flex-1 items-center gap-1">
+        <AssetPreviewTooltip url={assetUrl} name={baseName}>
+          {asset.mimeType?.startsWith('image/') ? (
+            <img
+              src={assetUrl}
+              alt={baseName}
+              className="asset-item__preview-image"
+            />
+          ) : (
+            <div className="asset-item__preview-file">
+              <FileText size={18} />
+            </div>
+          )}
+        </AssetPreviewTooltip>
+
+        <div className="page-history__asset-copy">
+          <span className="asset-item__filename">{baseName}</span>
+          <span className="page-history__asset-copy-meta">
+            {asset.mimeType || 'application/octet-stream'} ·{' '}
+            {Intl.NumberFormat().format(asset.sizeBytes)} bytes
+          </span>
+        </div>
+      </div>
+
+      <Button
+        asChild
+        variant="outline"
+        size="icon"
+        className="asset-item__action-button"
+      >
+        <a
+          href={assetUrl}
+          target="_blank"
+          rel="noreferrer"
+          title="Open asset"
+          data-testid={`history-asset-open-${baseName}`}
+        >
+          <ExternalLink size={16} />
+        </a>
+      </Button>
+      <Button
+        asChild
+        variant="outline"
+        size="icon"
+        className="asset-item__action-button"
+      >
+        <a
+          href={assetUrl}
+          download={baseName}
+          title="Download asset"
+          data-testid={`history-asset-download-${baseName}`}
+        >
+          <Download size={16} />
+        </a>
+      </Button>
+    </li>
+  )
+}
+
+function AssetsPanel({ snapshot }: { snapshot: RevisionSnapshot }) {
   return (
     <div className="page-history__detail-stack">
       <section className="page-history__section">
-        <div className="page-history__section-heading">
-          Asset Changes{' '}
-          <span className="page-history__section-heading-note">
-            compared to the active version
-          </span>
-        </div>
-        {comparison.assetChanges.length === 0 ? (
+        <div className="page-history__section-heading">Assets</div>
+        {snapshot.assets.length === 0 ? (
           <div className="page-history__empty-message">
-            No asset changes between this revision and the active version.
+            No assets were stored with this revision.
           </div>
         ) : (
-          <div className="page-history__asset-list">
-            {comparison.assetChanges.map((change) => (
-              <div
-                key={`${change.name}-${change.status}`}
-                className="page-history__asset-change"
-              >
-                <span className="page-history__asset-name">{change.name}</span>
-                <span className="page-history__asset-meta">
-                  {assetChangeLabel(change.status)}
-                </span>
-              </div>
+          <ul className="page-history__asset-list">
+            {snapshot.assets.map((asset) => (
+              <HistoryAssetItem
+                key={`${asset.name}-${asset.sha256}`}
+                asset={asset}
+                pageId={snapshot.revision.pageId}
+                revisionId={snapshot.revision.id}
+              />
             ))}
-          </div>
+          </ul>
         )}
       </section>
     </div>
@@ -561,12 +684,14 @@ export function PageHistoryContent({
   )
 
   const groupedRevisions = useMemo(() => groupRevisions(revisions), [revisions])
+  const isSelectedRevisionLatest =
+    !!selectedRevision && selectedRevision.id === latestRevisionId
 
   const chips = useMemo(() => {
     if (!selectedRevision) return []
 
     const result = [
-      selectedRevision.path,
+      getPathLeaf(selectedRevision.path),
       revisionTriggerLabel(selectedRevision.type),
     ]
 
@@ -578,6 +703,30 @@ export function PageHistoryContent({
 
     return result
   }, [comparison, selectedRevision, snapshot])
+
+  const structureChanges = useMemo(() => {
+    if (!comparison) return []
+
+    const changes: Array<{ label: string; from: string; to: string }> = []
+
+    if (comparison.base.revision?.title !== comparison.target.revision?.title) {
+      changes.push({
+        label: 'Title',
+        from: comparison.base.revision?.title || '(empty)',
+        to: comparison.target.revision?.title || '(empty)',
+      })
+    }
+
+    if (comparison.base.revision?.slug !== comparison.target.revision?.slug) {
+      changes.push({
+        label: 'Slug',
+        from: comparison.base.revision?.slug || '(empty)',
+        to: comparison.target.revision?.slug || '(empty)',
+      })
+    }
+
+    return changes
+  }, [comparison])
 
   // Preview is first and the default active tab so users immediately see the
   // rendered content of the selected revision without an extra click.
@@ -641,7 +790,7 @@ export function PageHistoryContent({
   )
 
   const handleRestore = async () => {
-    if (!selectedRevision || restoreLoading) return
+    if (!selectedRevision || isSelectedRevisionLatest || restoreLoading) return
 
     setRestoreLoading(true)
     try {
@@ -748,6 +897,14 @@ export function PageHistoryContent({
     }
 
     if (activeTab === 'changes') {
+      if (isSelectedRevisionLatest) {
+        return (
+          <div className="page-history__empty-message page-history__empty-message--padded">
+            No differences from the current version.
+          </div>
+        )
+      }
+
       return comparison ? (
         <ChangesPanel comparison={comparison} />
       ) : (
@@ -767,8 +924,8 @@ export function PageHistoryContent({
       )
     }
 
-    return comparison ? (
-      <AssetsPanel comparison={comparison} />
+    return snapshot ? (
+      <AssetsPanel snapshot={snapshot} />
     ) : (
       <div className="page-history__empty-message page-history__empty-message--padded">
         No asset data available.
@@ -822,12 +979,20 @@ export function PageHistoryContent({
                     if (isMobile) {
                       setMobileListVisible(false)
                     }
-                    navigate(buildHistoryUrl(revision.path))
                   }}
                   testId={`history-sidebar-revision-${revision.id}`}
                 >
-                  <div className="history-sidebar__item-title">
-                    {revisionTitle(revision)}
+                  <div className="history-sidebar__item-heading">
+                    <div className="history-sidebar__item-title">
+                      {revisionTitle(revision)}
+                    </div>
+                    {revision.id === latestRevisionId ? (
+                      <RevisionBadge
+                        testId={`history-sidebar-revision-current-badge-${revision.id}`}
+                      >
+                        Active version
+                      </RevisionBadge>
+                    ) : null}
                   </div>
                   <div className="history-sidebar__item-meta">
                     {revisionMeta(revision)}
@@ -935,6 +1100,21 @@ export function PageHistoryContent({
                   ))}
                 </div>
               ) : null}
+              {structureChanges.length > 0 ? (
+                <div
+                  className="page-history__change-chips"
+                  data-testid={`${testidPrefix}-structure-changes`}
+                >
+                  {structureChanges.map((change) => (
+                    <ChangeChip
+                      key={change.label}
+                      label={change.label}
+                      from={change.from}
+                      to={change.to}
+                    />
+                  ))}
+                </div>
+              ) : null}
             </div>
 
             <div className="page-history__actions">
@@ -951,11 +1131,19 @@ export function PageHistoryContent({
               ) : null}
               <Button
                 variant="default"
-                disabled={!selectedRevision || restoreLoading}
+                disabled={
+                  !selectedRevision ||
+                  isSelectedRevisionLatest ||
+                  restoreLoading
+                }
                 onClick={() => void handleRestore()}
                 data-testid={`${testidPrefix}-restore`}
               >
-                {restoreLoading ? 'Restoring...' : 'Restore'}
+                {restoreLoading
+                  ? 'Restoring...'
+                  : isSelectedRevisionLatest
+                    ? 'Current version'
+                    : 'Restore'}
               </Button>
             </div>
           </div>

--- a/ui/leafwiki-ui/src/features/history/pageHistory.ts
+++ b/ui/leafwiki-ui/src/features/history/pageHistory.ts
@@ -95,18 +95,17 @@ async function loadPageHistoryState(
     }
 
     const latestRevision = await getLatestRevision(pageId)
-
-    const visibleRevisions = excludeLatestRevision(
-      historyData.revisions,
-      latestRevision.id,
-    )
-    const firstVisibleRevision = visibleRevisions[0] ?? null
+    const revisions = historyData.revisions
+    const firstHistoricalRevision =
+      revisions.find((revision) => revision.id !== latestRevision.id) ?? null
+    const initialSelectedRevision =
+      firstHistoricalRevision ?? revisions[0] ?? null
 
     update({
-      revisions: visibleRevisions,
+      revisions,
       nextCursor: historyData.nextCursor,
       latestRevisionId: latestRevision.id,
-      selectedRevisionId: firstVisibleRevision?.id ?? null,
+      selectedRevisionId: initialSelectedRevision?.id ?? null,
     })
   } catch (err) {
     update({
@@ -142,15 +141,6 @@ export const usePageHistoryStore = create<PageHistoryStore>((set) => ({
     }),
   setActiveTab: (activeTab) => set({ activeTab }),
 }))
-
-function excludeLatestRevision(
-  revisions: Revision[],
-  latestRevisionId: string | null,
-): Revision[] {
-  if (!latestRevisionId) return revisions
-
-  return revisions.filter((revision) => revision.id !== latestRevisionId)
-}
 
 export function usePageHistory(pageId: string | null, enabled = true) {
   const update = usePageHistoryStore((state) => state.update)
@@ -194,7 +184,7 @@ export function usePageHistory(pageId: string | null, enabled = true) {
     if (
       !pageId ||
       !selectedRevisionId ||
-      (activeTab !== 'preview' && activeTab !== 'raw')
+      (activeTab !== 'preview' && activeTab !== 'raw' && activeTab !== 'assets')
     ) {
       return
     }
@@ -237,7 +227,7 @@ export function usePageHistory(pageId: string | null, enabled = true) {
       !pageId ||
       !selectedRevisionId ||
       !latestRevisionId ||
-      (activeTab !== 'changes' && activeTab !== 'assets')
+      activeTab !== 'changes'
     ) {
       return
     }
@@ -292,12 +282,8 @@ export async function loadMorePageHistory() {
   try {
     const data = await listRevisions(state.pageId, state.nextCursor)
     const currentRevisions = usePageHistoryStore.getState().revisions
-    const visibleRevisions = excludeLatestRevision(
-      data.revisions,
-      usePageHistoryStore.getState().latestRevisionId,
-    )
     usePageHistoryStore.getState().update({
-      revisions: [...currentRevisions, ...visibleRevisions],
+      revisions: [...currentRevisions, ...data.revisions],
       nextCursor: data.nextCursor,
     })
   } catch (err) {

--- a/ui/leafwiki-ui/src/features/preview/markdownPreviewCodeTheme.css
+++ b/ui/leafwiki-ui/src/features/preview/markdownPreviewCodeTheme.css
@@ -69,6 +69,16 @@
   --hljs-deletion-bg: #67060c;
 }
 
+:root:not(.dark) .page-history {
+  --hljs-foreground: #24292e;
+  --hljs-background: #f8fafc;
+}
+
+.dark .page-history {
+  --hljs-foreground: #c9d1d9;
+  --hljs-background: #111827;
+}
+
 .page-viewer__content code.hljs,
 .markdown-editor__preview code.hljs {
   padding-left: 0 !important;
@@ -77,6 +87,10 @@
 
 .page-viewer__content .markdown-code-block,
 .markdown-editor__preview .markdown-code-block {
+  position: relative;
+}
+
+.page-history .markdown-code-block {
   position: relative;
 }
 
@@ -120,6 +134,18 @@
   background: var(--hljs-background) !important;
   color: var(--hljs-foreground) !important;
   border: 1px solid color-mix(in oklab, var(--hljs-foreground) 10%, transparent);
+}
+
+.page-history .markdown-code-block pre {
+  background: var(--hljs-background) !important;
+  color: var(--hljs-foreground) !important;
+  border: 1px solid color-mix(in oklab, var(--hljs-foreground) 10%, transparent);
+}
+
+.page-history .markdown-code-block pre code {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
 }
 
 .page-viewer__content .hljs,

--- a/ui/leafwiki-ui/src/features/viewer/useToolbarActions.tsx
+++ b/ui/leafwiki-ui/src/features/viewer/useToolbarActions.tsx
@@ -3,10 +3,11 @@
 import { NODE_KIND_PAGE, type Page } from '@/lib/api/pages'
 import { useAppMode } from '@/lib/useAppMode'
 import { useIsReadOnly } from '@/lib/useIsReadOnly'
+import { useConfigStore } from '@/stores/config'
 import { HotKeyDefinition, useHotKeysStore } from '@/stores/hotkeys'
 import { Copy, History, Pencil, Printer, Trash2 } from 'lucide-react'
 import { useEffect } from 'react'
-import { useToolbarStore } from '../toolbar/toolbar'
+import { type ToolbarButton, useToolbarStore } from '../toolbar/toolbar'
 
 export interface ToolbarActionsOptions {
   pageKind?: Page['kind']
@@ -28,6 +29,7 @@ export function useToolbarActions({
   const setButtons = useToolbarStore((state) => state.setButtons)
   const appMode = useAppMode()
   const readOnlyMode = useIsReadOnly()
+  const enableRevision = useConfigStore((state) => state.enableRevision)
   const registerHotkey = useHotKeysStore((s) => s.registerHotkey)
   const unregisterHotkey = useHotKeysStore((s) => s.unregisterHotkey)
   const itemLabel = pageKind === NODE_KIND_PAGE ? 'Page' : 'Section'
@@ -38,7 +40,7 @@ export function useToolbarActions({
       return
     }
 
-    setButtons([
+    const toolbarButtons: ToolbarButton[] = [
       {
         id: 'edit-page',
         label: `Edit ${itemLabel}`,
@@ -52,14 +54,6 @@ export function useToolbarActions({
         hotkey: 'Ctrl+P',
         icon: <Printer size={18} />,
         action: printPage,
-      },
-      {
-        id: 'page-history',
-        label: `${itemLabel} History`,
-        hotkey: 'Ctrl+H',
-        icon: <History size={18} />,
-        variant: 'outline',
-        action: showHistory,
       },
       {
         id: 'copy-page',
@@ -79,7 +73,20 @@ export function useToolbarActions({
         className: 'hover:text-red-600 hover:bg-red-100 hover:border-red-300',
         action: deletePage,
       },
-    ])
+    ]
+
+    if (enableRevision) {
+      toolbarButtons.splice(2, 0, {
+        id: 'page-history',
+        label: `${itemLabel} History`,
+        hotkey: 'Ctrl+H',
+        icon: <History size={18} />,
+        variant: 'outline',
+        action: showHistory,
+      })
+    }
+
+    setButtons(toolbarButtons)
 
     const copyHotkey: HotKeyDefinition = {
       keyCombo: 'Mod+Shift+KeyS',
@@ -119,19 +126,24 @@ export function useToolbarActions({
     registerHotkey(editHotkey)
     registerHotkey(copyHotkey)
     registerHotkey(printHotkey)
-    registerHotkey(historyHotkey)
+    if (enableRevision) {
+      registerHotkey(historyHotkey)
+    }
     registerHotkey(deleteHotkey)
 
     return () => {
       unregisterHotkey(editHotkey.keyCombo)
       unregisterHotkey(copyHotkey.keyCombo)
       unregisterHotkey(printHotkey.keyCombo)
-      unregisterHotkey(historyHotkey.keyCombo)
+      if (enableRevision) {
+        unregisterHotkey(historyHotkey.keyCombo)
+      }
       unregisterHotkey(deleteHotkey.keyCombo)
     }
   }, [
     appMode,
     readOnlyMode,
+    enableRevision,
     setButtons,
     deletePage,
     copyPage,

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -437,8 +437,16 @@
     @apply border-surface-border bg-surface-alt;
   }
 
+  .history-sidebar__item-heading {
+    @apply flex items-center justify-between gap-2;
+  }
+
   .history-sidebar__item-title {
     @apply text-sm leading-5 font-medium;
+  }
+
+  .history-sidebar__badge {
+    @apply bg-brand/10 text-brand inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[11px] font-semibold;
   }
 
   .history-sidebar__item-meta {
@@ -1286,8 +1294,36 @@
     @apply mt-3 flex flex-wrap gap-2;
   }
 
+  .page-history__change-chips {
+    @apply mt-3 flex flex-wrap gap-2;
+  }
+
   .page-history__meta-chip {
     @apply bg-surface-alt text-interface-text inline-flex items-center rounded-full px-3 py-1 text-xs font-medium;
+  }
+
+  .page-history__change-chip {
+    @apply border-surface-border bg-surface-alt text-interface-text inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-xs;
+  }
+
+  .page-history__change-chip-label {
+    @apply text-muted-foreground font-medium;
+  }
+
+  .page-history__change-chip-value {
+    @apply inline-flex items-center gap-2 font-mono;
+  }
+
+  .page-history__change-chip-from {
+    @apply text-muted-foreground line-through;
+  }
+
+  .page-history__change-chip-arrow {
+    @apply text-muted-foreground;
+  }
+
+  .page-history__change-chip-to {
+    @apply text-interface-text font-semibold;
   }
 
   .page-history__actions {
@@ -1329,7 +1365,7 @@
   }
 
   .page-history__list-title {
-    @apply text-interface-text flex items-center gap-2 text-sm font-medium;
+    @apply text-interface-text flex items-center gap-2 text-sm;
   }
 
   .page-history__list-scroll {
@@ -1468,6 +1504,14 @@
     @apply border-brand-light bg-brand-light/10;
   }
 
+  .page-history__summary-stat--added.page-history__summary-stat--emphasized {
+    @apply border-success/30 bg-success/10;
+  }
+
+  .page-history__summary-stat--removed.page-history__summary-stat--emphasized {
+    @apply border-destructive/30 bg-destructive/10;
+  }
+
   .page-history__summary-stat-value {
     @apply text-lg font-semibold;
   }
@@ -1548,11 +1592,23 @@
   }
 
   .page-history__snapshot-content {
-    @apply border-surface-border max-h-[60vh] overflow-auto rounded-xl border bg-[#202735] p-4 font-mono text-sm break-words whitespace-pre-wrap text-white;
+    @apply max-h-[60vh] overflow-auto rounded-xl p-0 font-mono text-sm break-words whitespace-pre-wrap;
   }
 
   .page-history__asset-list {
     @apply flex flex-col gap-2;
+  }
+
+  .page-history__asset-item {
+    @apply gap-2;
+  }
+
+  .page-history__asset-copy {
+    @apply flex min-w-0 flex-1 flex-col;
+  }
+
+  .page-history__asset-copy-meta {
+    @apply text-muted-foreground truncate text-xs;
   }
 
   .page-history__asset-change {


### PR DESCRIPTION
Restore page title and slug from the selected revision instead of keeping the live page identity. Show the active revision in history, improve revision asset viewing, and cover the flow with backend and E2E tests.