### PR TITLE
fix: handle auth and rate limit edges

### DIFF
--- a/internal/core/auth/auth_service.go
+++ b/internal/core/auth/auth_service.go
@@ -131,7 +131,6 @@ func (a *AuthService) RefreshToken(refreshToken string) (*AuthToken, error) {
 	err = a.sessionStore.RevokeSession(jti)
 	if err != nil {
 		log.Printf("Warning: failed to revoke used refresh token session: %v", err)
-    return nil, errors.New("failed to revoke refresh token session")
 	}
 
 	return &AuthToken{

--- a/internal/http/middleware/security/rate_limiter.go
+++ b/internal/http/middleware/security/rate_limiter.go
@@ -71,6 +71,7 @@ func NewRateLimiter(limit int, window time.Duration, resetOnSuccess bool) gin.Ha
 			}
 		}
 		if len(events) >= rl.limit {
+			rl.mu.Unlock()
 			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
 				"error": "Too many requests, please try again later",
 			})

--- a/internal/http/middleware/security/rate_limiter_test.go
+++ b/internal/http/middleware/security/rate_limiter_test.go
@@ -70,6 +70,55 @@ func TestRateLimiter_ExceedsLimit(t *testing.T) {
 	}
 }
 
+func TestRateLimiter_ReleasesLockAfterLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	limiter := NewRateLimiter(1, time.Minute, false)
+
+	router := gin.New()
+	router.Use(limiter)
+	router.GET("/test", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "192.168.1.4:1234"
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d", w.Code)
+	}
+
+	req = httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "192.168.1.4:1234"
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("Expected status 429, got %d", w.Code)
+	}
+
+	done := make(chan int, 1)
+
+	go func() {
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.RemoteAddr = "192.168.1.5:1234"
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		done <- w.Code
+	}()
+
+	select {
+	case code := <-done:
+		if code != http.StatusOK {
+			t.Fatalf("Expected status 200 for different key after limit hit, got %d", code)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Request blocked after limit hit; mutex was not released")
+	}
+}
+
 func TestRateLimiter_WindowExpires(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/http/middleware/security/rate_limiter_test.go
+++ b/internal/http/middleware/security/rate_limiter_test.go
@@ -109,12 +109,20 @@ func TestRateLimiter_ReleasesLockAfterLimit(t *testing.T) {
 		done <- w.Code
 	}()
 
+	timeout := 2 * time.Second
+	if deadline, ok := t.Deadline(); ok {
+		if remaining := time.Until(deadline) / 2; remaining > 0 && remaining < timeout {
+			timeout = remaining
+		}
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 	select {
 	case code := <-done:
 		if code != http.StatusOK {
 			t.Fatalf("Expected status 200 for different key after limit hit, got %d", code)
 		}
-	case <-time.After(500 * time.Millisecond):
+	case <-timer.C:
 		t.Fatal("Request blocked after limit hit; mutex was not released")
 	}
 }


### PR DESCRIPTION
Avoid failing token refresh when session revoke logging is enough. Release the rate limiter mutex before returning 429 and cover it with a regression test.