### PR TITLE
fix(ui): centralize not-found flow

### DIFF
--- a/e2e/pages/NotFoundPage.ts
+++ b/e2e/pages/NotFoundPage.ts
@@ -1,4 +1,5 @@
 import { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { toAppPath } from './appPath';
 
 export default class NotFoundPage {
@@ -9,19 +10,27 @@ export default class NotFoundPage {
   }
 
   async isNotFoundPage() {
-    // h1 selector text "Page Not Found"
-    const notFoundHeader = this.page.locator('h1');
-    const text = await notFoundHeader.innerText();
-    return text.includes('Page Not Found');
+    return this.page.getByTestId('page404').isVisible();
   }
 
-  async getCreatePageButton() {
-    // main button selector
-    return this.page.locator('main button').first();
+  async expectVisible() {
+    await expect(this.page.getByTestId('page404')).toBeVisible();
+  }
+
+  getCreatePageButton() {
+    return this.page.getByTestId('page404-create-page-button');
   }
 
   async clickCreatePageButton() {
-    const createPageButton = await this.getCreatePageButton();
+    const createPageButton = this.getCreatePageButton();
     await createPageButton.click();
+  }
+
+  async expectCreatePageButtonVisible() {
+    await expect(this.getCreatePageButton()).toBeVisible();
+  }
+
+  async expectCreatePageButtonHidden() {
+    await expect(this.getCreatePageButton()).toHaveCount(0);
   }
 }

--- a/e2e/tests/page.spec.ts
+++ b/e2e/tests/page.spec.ts
@@ -135,6 +135,13 @@ async function createPageWithContent(
   }, input);
 }
 
+async function navigateWithinApp(page: import('@playwright/test').Page, path: string) {
+  await page.evaluate((nextPath) => {
+    window.history.pushState({}, '', nextPath);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  }, path);
+}
+
 async function expectEditAndSaveShortcutWorks(
   page: import('@playwright/test').Page,
   shortcutKeys: { editKey: string; saveKey: string },
@@ -1242,7 +1249,8 @@ Paragraph outside the list.
     const notfoundPage = new NotFoundPage(page);
     await notfoundPage.goto(pagePath);
 
-    test.expect(await notfoundPage.isNotFoundPage()).toBeTruthy();
+    await notfoundPage.expectVisible();
+    await notfoundPage.expectCreatePageButtonVisible();
 
     await notfoundPage.clickCreatePageButton();
     const createPageByPathDialog = new CreatePageByPathDialog(page);
@@ -1256,6 +1264,50 @@ Paragraph outside the list.
     const viewPage = new ViewPage(page);
     const pageTitle = await viewPage.getTitle();
     test.expect(pageTitle).toBe(slug);
+  });
+
+  test('not-found-on-edit-page-hides-create-page-cta', async ({ page }) => {
+    const slug = `missing-edit-${Date.now()}`;
+    const notfoundPage = new NotFoundPage(page);
+    const viewPage = new ViewPage(page);
+
+    await viewPage.goto('/welcome-to-leafwiki');
+    await navigateWithinApp(page, `/e/${slug}`);
+
+    await notfoundPage.expectVisible();
+    await notfoundPage.expectCreatePageButtonHidden();
+  });
+
+  test('not-found-on-history-page-hides-create-page-cta', async ({ page }) => {
+    const slug = `missing-history-${Date.now()}`;
+    const notfoundPage = new NotFoundPage(page);
+    const viewPage = new ViewPage(page);
+
+    await viewPage.goto('/welcome-to-leafwiki');
+    await navigateWithinApp(page, `/history/${slug}`);
+
+    await notfoundPage.expectVisible();
+    await notfoundPage.expectCreatePageButtonHidden();
+    await expect(page.getByTestId('page404')).toBeVisible();
+  });
+
+  test('not-found-on-permalink-page-hides-create-page-cta', async ({ page }) => {
+    const notfoundPage = new NotFoundPage(page);
+    const missingId = `missing-permalink-${Date.now()}`;
+
+    await page.goto(toAppPath(`/p/${missingId}`));
+
+    await notfoundPage.expectVisible();
+    await notfoundPage.expectCreatePageButtonHidden();
+  });
+
+  test('not-found-for-reserved-slug-hides-create-page-cta', async ({ page }) => {
+    const notfoundPage = new NotFoundPage(page);
+
+    await notfoundPage.goto('/settings');
+
+    await notfoundPage.expectVisible();
+    await notfoundPage.expectCreatePageButtonHidden();
   });
 
   // test move

--- a/internal/core/tree/path_lookup.go
+++ b/internal/core/tree/path_lookup.go
@@ -10,7 +10,8 @@ type PathSegment struct {
 }
 
 type PathLookup struct {
-	Path     string        `json:"path"`
-	Segments []PathSegment `json:"segments"`
-	Exists   bool          `json:"exists"`
+	Path      string        `json:"path"`
+	Segments  []PathSegment `json:"segments"`
+	Exists    bool          `json:"exists"`
+	CanCreate bool          `json:"canCreate"`
 }

--- a/internal/core/tree/tree_service.go
+++ b/internal/core/tree/tree_service.go
@@ -854,13 +854,15 @@ func (t *TreeService) lookupPagePathLocked(p string) (*PathLookup, error) {
 		return nil, ErrTreeNotLoaded
 	}
 
+	slugService := NewSlugService()
 	path := strings.TrimSpace(p)
 	path = strings.Trim(path, "/")
 	if path == "" {
 		return &PathLookup{
-			Path:     path,
-			Segments: []PathSegment{},
-			Exists:   false,
+			Path:      path,
+			Segments:  []PathSegment{},
+			Exists:    false,
+			CanCreate: false,
 		}, nil
 	}
 
@@ -871,16 +873,18 @@ func (t *TreeService) lookupPagePathLocked(p string) (*PathLookup, error) {
 	pathParts := strings.Split(path, "/")
 	if len(pathParts) == 0 {
 		return &PathLookup{
-			Path:     path,
-			Segments: []PathSegment{},
-			Exists:   false,
+			Path:      path,
+			Segments:  []PathSegment{},
+			Exists:    false,
+			CanCreate: false,
 		}, nil
 	}
 
 	lookup := &PathLookup{
-		Path:     path,
-		Segments: make([]PathSegment, len(pathParts)),
-		Exists:   true,
+		Path:      path,
+		Segments:  make([]PathSegment, len(pathParts)),
+		Exists:    true,
+		CanCreate: true,
 	}
 
 	parent := t.tree
@@ -915,9 +919,16 @@ func (t *TreeService) lookupPagePathLocked(p string) (*PathLookup, error) {
 
 		// If the segment does not exist, set the pathExists flag to false
 		if !lookup.Segments[i].Exists {
+			if lookup.CanCreate && slugService.IsValidSlug(part) != nil {
+				lookup.CanCreate = false
+			}
+
 			// No need to check further segments
 			// Set all remaining segments to non-existing
 			for j := i + 1; j < len(pathParts); j++ {
+				if lookup.CanCreate && slugService.IsValidSlug(pathParts[j]) != nil {
+					lookup.CanCreate = false
+				}
 				lookup.Segments[j] = PathSegment{
 					Slug:   pathParts[j],
 					Exists: false,

--- a/internal/core/tree/tree_service_test.go
+++ b/internal/core/tree/tree_service_test.go
@@ -1483,6 +1483,32 @@ func TestTreeService_LookupPagePath_ReflectsSlugRename(t *testing.T) {
 	}
 }
 
+func TestTreeService_LookupPagePath_CanCreateForMissingValidPath(t *testing.T) {
+	svc, _ := newLoadedService(t)
+
+	lookup, err := svc.LookupPagePath("docs/guide")
+	if err != nil {
+		t.Fatalf("LookupPagePath failed: %v", err)
+	}
+
+	if !lookup.CanCreate {
+		t.Fatal("expected missing valid path to be creatable")
+	}
+}
+
+func TestTreeService_LookupPagePath_CannotCreateReservedMissingPath(t *testing.T) {
+	svc, _ := newLoadedService(t)
+
+	lookup, err := svc.LookupPagePath("history/guide")
+	if err != nil {
+		t.Fatalf("LookupPagePath failed: %v", err)
+	}
+
+	if lookup.CanCreate {
+		t.Fatal("expected reserved slug path to be non-creatable")
+	}
+}
+
 func TestTreeService_ResolvePermalinkTarget_ReflectsRenameAndMove(t *testing.T) {
 	svc, _ := newLoadedService(t)
 

--- a/ui/leafwiki-ui/src/components/Page404.tsx
+++ b/ui/leafwiki-ui/src/components/Page404.tsx
@@ -1,46 +1,101 @@
 import { Button } from '@/components/ui/button'
+import { lookupPath } from '@/lib/api/pages'
 import { DIALOG_CREATE_PAGE_BY_PATH } from '@/lib/registries'
-import { useAppMode } from '@/lib/useAppMode'
 import { useIsReadOnly } from '@/lib/useIsReadOnly'
 import { useConfigStore } from '@/stores/config'
 import { useDialogsStore } from '@/stores/dialogs'
 import { useSessionStore } from '@/stores/session'
-import { useLocation } from 'react-router-dom'
+import { useEffect, useState } from 'react'
 
-export default function Page404() {
+type Page404Props = {
+  targetPath?: string
+  allowCreate?: boolean
+}
+
+export default function Page404({
+  targetPath,
+  allowCreate = false,
+}: Page404Props) {
   const user = useSessionStore((s) => s.user)
   const authDisabled = useConfigStore((s) => s.authDisabled)
   const readOnlyMode = useIsReadOnly()
-  const appMode = useAppMode()
-  const { pathname } = useLocation()
   const openDialog = useDialogsStore((s) => s.openDialog)
+  const [lookupState, setLookupState] = useState<{
+    path: string | null
+    canCreate: boolean
+  }>({
+    path: null,
+    canCreate: false,
+  })
+
+  useEffect(() => {
+    if (!allowCreate || !targetPath) return
+
+    let active = true
+
+    const loadLookup = async () => {
+      try {
+        const lookup = await lookupPath(targetPath)
+        if (active) {
+          setLookupState({
+            path: targetPath,
+            canCreate: lookup.canCreate && !lookup.exists,
+          })
+        }
+      } catch {
+        if (active) {
+          setLookupState({
+            path: targetPath,
+            canCreate: false,
+          })
+        }
+      }
+    }
+
+    void loadLookup()
+
+    return () => {
+      active = false
+    }
+  }, [allowCreate, targetPath])
+
+  const showCreate =
+    Boolean(targetPath) &&
+    allowCreate &&
+    lookupState.path === targetPath &&
+    lookupState.canCreate &&
+    (user || authDisabled) &&
+    !readOnlyMode
 
   return (
-    <div className="page404">
-      <h1 className="page404__title">Page Not Found</h1>
-      <p className="page404__text">
-        The page you are looking for does not exist.
-      </p>
-      {(user || authDisabled) && !readOnlyMode && appMode === 'view' && (
-        <>
-          <p className="page404__text">
-            Create the page by clicking the button below.
-          </p>
-          <Button
-            className="mt-4"
-            onClick={() =>
-              openDialog(DIALOG_CREATE_PAGE_BY_PATH, {
-                initialPath: pathname,
-                readOnlyPath: true,
-                forwardToEditMode: true,
-              })
-            }
-            variant={'outline'}
-          >
-            Create Page
-          </Button>
-        </>
-      )}
+    <div className="page404-shell">
+      <div className="page404" data-testid="page404">
+        <h1 className="page404__title">Page Not Found</h1>
+        <p className="page404__text">
+          The page you are looking for does not exist.
+        </p>
+        {showCreate && (
+          <>
+            <p className="page404__text">
+              Create the page by clicking the button below.
+            </p>
+            <Button
+              className="mt-4"
+              data-testid="page404-create-page-button"
+              onClick={() =>
+                openDialog(DIALOG_CREATE_PAGE_BY_PATH, {
+                  initialPath: targetPath,
+                  readOnlyPath: true,
+                  forwardToEditMode: true,
+                })
+              }
+              variant={'outline'}
+            >
+              Create Page
+            </Button>
+          </>
+        )}
+      </div>
     </div>
   )
 }

--- a/ui/leafwiki-ui/src/features/editor/PageEditor.tsx
+++ b/ui/leafwiki-ui/src/features/editor/PageEditor.tsx
@@ -1,9 +1,10 @@
 import Page404 from '@/components/Page404'
 import { mapApiError, asApiLocalizedError } from '@/lib/api/errors'
 import { buildBrowserEditUrl } from '@/lib/routePath'
+import { getWikiTargetRoutePath } from '@/lib/wikiPath'
 import { useTreeStore } from '@/stores/tree'
 import { useCallback, useEffect, useRef } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { toast } from 'sonner'
 import { useProgressbarStore } from '../progressbar/progressbar'
 import MarkdownEditor, { MarkdownEditorRef } from './MarkdownEditor'
@@ -14,6 +15,7 @@ import { useToolbarActions } from './useToolbarActions'
 export default function PageEditor() {
   const { '*': path } = useParams()
 
+  const { pathname } = useLocation()
   const navigate = useNavigate()
   const editorRef = useRef<MarkdownEditorRef>(null)
   const reloadTree = useTreeStore((s) => s.reloadTree)
@@ -22,6 +24,7 @@ export default function PageEditor() {
   const setContent = usePageEditorStore((s) => s.setContent)
   const loadPageData = usePageEditorStore((s) => s.loadPageData)
   const initialPage = usePageEditorStore((s) => s.initialPage) // contains the initial page data when loaded
+  const notFound = usePageEditorStore((s) => s.notFound)
   const loading = useProgressbarStore((s) => s.loading)
   const error = usePageEditorStore((s) => s.error)
   const page = usePageEditorStore((s) => s.page)
@@ -138,14 +141,13 @@ export default function PageEditor() {
     [setContent],
   )
 
+  if (notFound) {
+    return <Page404 targetPath={getWikiTargetRoutePath(pathname)} />
+  }
+
   if (error) return <p className="page-editor__error">Error: {error}</p>
 
-  if (!initialPage && !loading)
-    return (
-      <div className="page-editor__not-found">
-        <Page404 />
-      </div>
-    )
+  if (!initialPage && !loading) return null
 
   return (
     <>

--- a/ui/leafwiki-ui/src/features/editor/pageEditor.ts
+++ b/ui/leafwiki-ui/src/features/editor/pageEditor.ts
@@ -8,7 +8,7 @@ import {
   previewPageRefactor,
   updatePage,
 } from '@/lib/api/pages'
-import { mapApiError } from '@/lib/api/errors'
+import { isPageNotFoundError, mapApiError } from '@/lib/api/errors'
 import { useConfigStore } from '@/stores/config'
 import { useTreeStore } from '@/stores/tree'
 import { create } from 'zustand'
@@ -21,6 +21,7 @@ interface PageEditorState {
   slug: string // current slug in the editor
   content: string // current markdown content in the editor
   error: string | null // error message, if any
+  notFound: boolean
   page: Page | null // current page being edited
   initialPage: Page | null // initial page data when loaded
   setTitle: (title: string) => void // set the current title
@@ -41,6 +42,7 @@ const isDirtyState = (s: PageEditorState) => {
 
 export const usePageEditorStore = create<PageEditorState>((set, get) => ({
   error: null,
+  notFound: false,
   page: null,
   title: '',
   path: '',
@@ -148,21 +150,31 @@ export const usePageEditorStore = create<PageEditorState>((set, get) => ({
     return get().savePage()
   },
   loadPageData: async (path: string) => {
-    set({ error: null, page: null, initialPage: null })
+    set({ error: null, notFound: false, page: null, initialPage: null })
     useProgressbarStore.getState().setLoading(true)
     try {
       const page = await getPageByPath(path)
       set({
         page,
         initialPage: { ...page },
+        notFound: false,
         title: page.title,
         slug: page.slug,
         content: page.content,
       })
     } catch (err) {
+      if (isPageNotFoundError(err)) {
+        set({
+          error: null,
+          notFound: true,
+        })
+        return
+      }
+
       const mapped = mapApiError(err, 'An unknown error occurred')
       set({
         error: mapped.message,
+        notFound: false,
       })
     } finally {
       useProgressbarStore.getState().setLoading(false)

--- a/ui/leafwiki-ui/src/features/page/PageHistoryPage.tsx
+++ b/ui/leafwiki-ui/src/features/page/PageHistoryPage.tsx
@@ -6,7 +6,7 @@ import { useTreeStore } from '@/stores/tree'
 import { useCallback, useEffect } from 'react'
 import { ArrowLeft } from 'lucide-react'
 import { useToolbarStore } from '../toolbar/toolbar'
-import { toWikiLookupPath } from '@/lib/wikiPath'
+import { getWikiTargetRoutePath, toWikiLookupPath } from '@/lib/wikiPath'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useProgressbarStore } from '../progressbar/progressbar'
 import { useSetPageTitle } from '../viewer/useSetPageTitle'
@@ -23,6 +23,7 @@ export default function PageHistoryPage() {
   const unregisterHotkey = useHotKeysStore((state) => state.unregisterHotkey)
   const loading = useProgressbarStore((s) => s.loading)
   const error = useViewerStore((s) => s.error)
+  const notFound = useViewerStore((s) => s.notFound)
   const page = useViewerStore((s) => s.page)
   const loadPageData = useViewerStore((s) => s.loadPageData)
 
@@ -73,8 +74,8 @@ export default function PageHistoryPage() {
   }, [closeHistory, registerHotkey, setToolbarButtons, unregisterHotkey])
 
   const renderError = () => {
-    if (!loading && !page) {
-      return <Page404 />
+    if (!loading && notFound) {
+      return <Page404 targetPath={getWikiTargetRoutePath(pathname)} />
     }
     if (!loading && error) {
       return <p className="page-viewer__error">Error: {error}</p>

--- a/ui/leafwiki-ui/src/features/page/PermalinkRedirect.tsx
+++ b/ui/leafwiki-ui/src/features/page/PermalinkRedirect.tsx
@@ -1,7 +1,7 @@
 import Page404 from '@/components/Page404'
 import { getPermalinkTarget } from '@/lib/api/pages'
 import { ApiError } from '@/lib/api/auth'
-import { ApiLocalizedError } from '@/lib/api/errors'
+import { isPageNotFoundError } from '@/lib/api/errors'
 import { useProgressbarStore } from '@/features/progressbar/progressbar'
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
@@ -36,7 +36,7 @@ export default function PermalinkRedirect() {
 
         if (
           (err instanceof ApiError && err.status === 404) ||
-          (err instanceof ApiLocalizedError && err.code === 'page_not_found')
+          isPageNotFoundError(err)
         ) {
           setNotFound(true)
           return

--- a/ui/leafwiki-ui/src/features/viewer/PageViewer.tsx
+++ b/ui/leafwiki-ui/src/features/viewer/PageViewer.tsx
@@ -7,7 +7,11 @@ import {
   DIALOG_PAGE_PERMALINK,
 } from '@/lib/registries'
 import { useScrollRestoration } from '@/lib/useScrollRestoration'
-import { getParentWikiRoutePath, toWikiLookupPath } from '@/lib/wikiPath'
+import {
+  getParentWikiRoutePath,
+  getWikiTargetRoutePath,
+  toWikiLookupPath,
+} from '@/lib/wikiPath'
 import { useDialogsStore } from '@/stores/dialogs'
 import { useTreeStore } from '@/stores/tree'
 import { useCallback, useEffect } from 'react'
@@ -33,6 +37,7 @@ export default function PageViewer() {
   const openNode = useTreeStore((state) => state.openNode)
   const loading = useProgressbarStore((s) => s.loading)
   const error = useViewerStore((s) => s.error)
+  const notFound = useViewerStore((s) => s.notFound)
   const page = useViewerStore((s) => s.page)
   const loadPageData = useViewerStore((s) => s.loadPageData)
 
@@ -79,8 +84,10 @@ export default function PageViewer() {
   }, [openNode, page?.id])
 
   const renderError = () => {
-    if (!loading && !page) {
-      return <Page404 />
+    if (!loading && notFound) {
+      return (
+        <Page404 allowCreate targetPath={getWikiTargetRoutePath(pathname)} />
+      )
     }
     if (!loading && error) {
       return <p className="page-viewer__error">Error: {error}</p>

--- a/ui/leafwiki-ui/src/features/viewer/viewer.ts
+++ b/ui/leafwiki-ui/src/features/viewer/viewer.ts
@@ -2,11 +2,13 @@
 // f.g. loading, error, page data
 
 import { getPageByPath, Page } from '@/lib/api/pages'
+import { isPageNotFoundError } from '@/lib/api/errors'
 import { create } from 'zustand'
 import { useProgressbarStore } from '../progressbar/progressbar'
 
 interface ViewerState {
   error: string | null
+  notFound: boolean
   page: Page | null
   setError: (error: string | null) => void
   clear: () => void
@@ -15,20 +17,23 @@ interface ViewerState {
 
 export const useViewerStore = create<ViewerState>((set) => ({
   error: null,
+  notFound: false,
   page: null,
   setError: (error) => set({ error }),
-  clear: () => set({ error: null, page: null }),
+  clear: () => set({ error: null, notFound: false, page: null }),
   loadPageData: async (path: string) => {
     useProgressbarStore.getState().setLoading(true)
-    set({ error: null })
+    set({ error: null, notFound: false, page: null })
     try {
       const page = await getPageByPath(path)
-      set({ page })
+      set({ page, notFound: false })
     } catch (err) {
-      if (err instanceof Error) {
-        set({ error: err.message })
+      if (isPageNotFoundError(err)) {
+        set({ error: null, notFound: true, page: null })
+      } else if (err instanceof Error) {
+        set({ error: err.message, notFound: false })
       } else {
-        set({ error: 'An unknown error occurred' })
+        set({ error: 'An unknown error occurred', notFound: false })
       }
     } finally {
       useProgressbarStore.getState().setLoading(false)

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -574,6 +574,14 @@
 
   /** Page 404 **/
 
+  .page404-shell {
+    @apply mx-auto w-full max-w-6xl px-8 pt-8;
+  }
+
+  .page404 {
+    @apply text-page-text max-w-xl;
+  }
+
   .page404__title {
     @apply text-error mb-2 text-xl;
   }
@@ -916,10 +924,6 @@
 
   .page-editor__error {
     @apply text-error p-6 text-sm;
-  }
-
-  .page-editor__not-found {
-    @apply p-6;
   }
 
   .toolbar-button__close-editor {

--- a/ui/leafwiki-ui/src/lib/api/errors.ts
+++ b/ui/leafwiki-ui/src/lib/api/errors.ts
@@ -53,6 +53,23 @@ export function asApiLocalizedError(err: unknown): ApiLocalizedError | null {
   return null
 }
 
+export function isPageNotFoundError(err: unknown): boolean {
+  if (err instanceof ApiLocalizedError) {
+    return err.code === 'page_not_found'
+  }
+
+  if (
+    err &&
+    typeof err === 'object' &&
+    'status' in err &&
+    (err as { status?: unknown }).status === 404
+  ) {
+    return true
+  }
+
+  return false
+}
+
 export function formatLocalizedErrorTemplate(
   template: string,
   args: string[] = [],

--- a/ui/leafwiki-ui/src/lib/api/pages.ts
+++ b/ui/leafwiki-ui/src/lib/api/pages.ts
@@ -253,6 +253,7 @@ export async function convertPage(
 export type PathLookupResult = {
   path: string
   exists: boolean
+  canCreate: boolean
   segments: { slug: string; id?: string; exists: boolean }[]
 }
 
@@ -262,6 +263,7 @@ export async function lookupPath(path: string): Promise<PathLookupResult> {
   )) as {
     path: string
     exists: boolean
+    canCreate: boolean
     segments: { slug: string; id?: string; exists: boolean }[]
   }
 }

--- a/ui/leafwiki-ui/src/lib/wikiPath.ts
+++ b/ui/leafwiki-ui/src/lib/wikiPath.ts
@@ -44,6 +44,18 @@ export function toWikiLookupPath(path: string): string {
 }
 
 /**
+ * Converts any supported route variant to the normalized wiki route/path.
+ *
+ * Examples:
+ * - `/docs` -> `/docs`
+ * - `/e/docs` -> `/docs`
+ * - `/history/docs` -> `/docs`
+ */
+export function getWikiTargetRoutePath(pathname: string): string {
+  return normalizeWikiRoutePath(buildViewUrl(pathname))
+}
+
+/**
  * Resolves a relative Markdown link against the current wiki page path.
  *
  * The result is always an absolute wiki route/path without query or hash.


### PR DESCRIPTION
Centralize not-found handling for viewer, editor, and history routes.

Use backend lookup metadata for create CTA decisions and keep history not-found inside the standard layout container.