### PR TITLE
refactor(pages): batch refactor follow-ups

### DIFF
--- a/internal/core/revision/service.go
+++ b/internal/core/revision/service.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/perber/wiki/internal/core/shared"
@@ -77,43 +78,53 @@ func (s *Service) CapturePageState(pageID string) (*RevisionState, error) {
 //
 // Assumption: asset changes go through Upload/Rename/Delete hooks and call RecordAssetChange.
 func (s *Service) RecordContentUpdate(pageID, authorID, summary string) (*Revision, bool, error) {
-	prev, err := s.store.GetLatestRevision(pageID)
+	page, err := s.pages.GetPage(pageID)
 	if err != nil {
 		return nil, false, err
 	}
+	return s.recordContentUpdateForPage(page, authorID, summary)
+}
 
-	state, err := s.capturePageState(pageID, false)
-	if err != nil {
-		return nil, false, err
-	}
-
-	if prev != nil && prev.ContentHash == state.ContentHash {
-		return prev, false, nil
-	}
-
-	assetManifestHash, err := s.resolveAssetManifestHash(pageID, prev)
-	if err != nil {
-		return nil, false, err
+func (s *Service) RecordContentUpdates(pages []*tree.Page, authorID, summary string) []error {
+	errs := make([]error, len(pages))
+	if len(pages) == 0 {
+		return errs
 	}
 
-	contentHash, err := s.store.SaveContentBlob([]byte(state.Content))
-	if err != nil {
-		return nil, false, err
-	}
-	if contentHash != state.ContentHash {
-		return nil, false, fmt.Errorf("content hash mismatch: computed=%s saved=%s", state.ContentHash, contentHash)
+	type batchItem struct {
+		index int
+		page  *tree.Page
 	}
 
-	rev, err := s.newRevision(RevisionTypeContentUpdate, state, authorID, summary, assetManifestHash)
-	if err != nil {
-		return nil, false, err
+	grouped := make(map[string][]batchItem)
+	nilItems := make([]int, 0)
+	for i, page := range pages {
+		if page == nil {
+			nilItems = append(nilItems, i)
+			continue
+		}
+		grouped[page.ID] = append(grouped[page.ID], batchItem{index: i, page: page})
 	}
-	if err := s.store.SaveRevision(rev); err != nil {
-		return nil, false, err
-	}
-	s.pruneAfterSave(rev.PageID)
 
-	return rev, true, nil
+	for _, i := range nilItems {
+		errs[i] = fmt.Errorf("page is required")
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(grouped))
+	for _, items := range grouped {
+		go func(items []batchItem) {
+			defer wg.Done()
+			for _, item := range items {
+				if _, _, err := s.recordContentUpdateForPage(item.page, authorID, summary); err != nil {
+					errs[item.index] = err
+				}
+			}
+		}(items)
+	}
+	wg.Wait()
+
+	return errs
 }
 
 // RecordAssetChange records a full snapshot when live assets changed.
@@ -617,26 +628,7 @@ func (s *Service) capturePageState(pageID string, withAssets bool) (*RevisionSta
 		return nil, err
 	}
 
-	parentID := ""
-	if page.Parent != nil && page.Parent.ID != "root" {
-		parentID = page.Parent.ID
-	}
-
-	state := &RevisionState{
-		PageID:        page.ID,
-		ParentID:      parentID,
-		Title:         page.Title,
-		Slug:          page.Slug,
-		Kind:          string(page.Kind),
-		Path:          page.CalculatePath(),
-		Content:       page.Content,
-		ContentHash:   sha256HexBytes([]byte(page.Content)),
-		PageCreatedAt: page.Metadata.CreatedAt.UTC(),
-		PageUpdatedAt: page.Metadata.UpdatedAt.UTC(),
-		CreatorID:     strings.TrimSpace(page.Metadata.CreatorID),
-		LastAuthorID:  strings.TrimSpace(page.Metadata.LastAuthorID),
-		CapturedAt:    time.Now().UTC(),
-	}
+	state := s.revisionStateFromPage(page)
 
 	if !withAssets {
 		return state, nil
@@ -655,6 +647,66 @@ func (s *Service) capturePageState(pageID string, withAssets bool) (*RevisionSta
 	state.AssetManifestHash = hash
 
 	return state, nil
+}
+
+func (s *Service) revisionStateFromPage(page *tree.Page) *RevisionState {
+	parentID := ""
+	if page.Parent != nil && page.Parent.ID != "root" {
+		parentID = page.Parent.ID
+	}
+
+	return &RevisionState{
+		PageID:        page.ID,
+		ParentID:      parentID,
+		Title:         page.Title,
+		Slug:          page.Slug,
+		Kind:          string(page.Kind),
+		Path:          page.CalculatePath(),
+		Content:       page.Content,
+		ContentHash:   sha256HexBytes([]byte(page.Content)),
+		PageCreatedAt: page.Metadata.CreatedAt.UTC(),
+		PageUpdatedAt: page.Metadata.UpdatedAt.UTC(),
+		CreatorID:     strings.TrimSpace(page.Metadata.CreatorID),
+		LastAuthorID:  strings.TrimSpace(page.Metadata.LastAuthorID),
+		CapturedAt:    time.Now().UTC(),
+	}
+}
+
+func (s *Service) recordContentUpdateForPage(page *tree.Page, authorID, summary string) (*Revision, bool, error) {
+	prev, err := s.store.GetLatestRevision(page.ID)
+	if err != nil {
+		return nil, false, err
+	}
+
+	state := s.revisionStateFromPage(page)
+
+	if prev != nil && prev.ContentHash == state.ContentHash {
+		return prev, false, nil
+	}
+
+	assetManifestHash, err := s.resolveAssetManifestHash(page.ID, prev)
+	if err != nil {
+		return nil, false, err
+	}
+
+	contentHash, err := s.store.SaveContentBlob([]byte(state.Content))
+	if err != nil {
+		return nil, false, err
+	}
+	if contentHash != state.ContentHash {
+		return nil, false, fmt.Errorf("content hash mismatch: computed=%s saved=%s", state.ContentHash, contentHash)
+	}
+
+	rev, err := s.newRevision(RevisionTypeContentUpdate, state, authorID, summary, assetManifestHash)
+	if err != nil {
+		return nil, false, err
+	}
+	if err := s.store.SaveRevision(rev); err != nil {
+		return nil, false, err
+	}
+	s.pruneAfterSave(rev.PageID)
+
+	return rev, true, nil
 }
 
 func (s *Service) newRevision(t RevisionType, state *RevisionState, authorID, summary, assetManifestHash string) (*Revision, error) {

--- a/internal/core/revision/service.go
+++ b/internal/core/revision/service.go
@@ -11,6 +11,7 @@ import (
 	"mime"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -110,11 +111,20 @@ func (s *Service) RecordContentUpdates(pages []*tree.Page, authorID, summary str
 		errs[i] = fmt.Errorf("page is required")
 	}
 
+	parallelism := runtime.GOMAXPROCS(0)
+	if parallelism < 1 {
+		parallelism = 1
+	}
+	sem := make(chan struct{}, parallelism)
+
 	var wg sync.WaitGroup
 	wg.Add(len(grouped))
 	for _, items := range grouped {
 		go func(items []batchItem) {
 			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
 			for _, item := range items {
 				if _, _, err := s.recordContentUpdateForPage(item.page, authorID, summary); err != nil {
 					errs[item.index] = err

--- a/internal/core/revision/service_test.go
+++ b/internal/core/revision/service_test.go
@@ -81,6 +81,150 @@ func TestRecordContentUpdateHappyPathAndNoop(t *testing.T) {
 	}
 }
 
+func TestRecordContentUpdatesHappyPathAndNoop(t *testing.T) {
+	service, treeService, storageDir := newRevisionTestService(t)
+	pageID1 := createRevisionTestPage(t, treeService, "Page 1", "page-1", "hello")
+	pageID2 := createRevisionTestPage(t, treeService, "Page 2", "page-2", "world")
+	writeLiveAsset(t, storageDir, pageID1, "a.txt", "asset-a")
+	writeLiveAsset(t, storageDir, pageID2, "b.txt", "asset-b")
+
+	page1, err := treeService.GetPage(pageID1)
+	if err != nil {
+		t.Fatalf("GetPage(page1) failed: %v", err)
+	}
+	page2, err := treeService.GetPage(pageID2)
+	if err != nil {
+		t.Fatalf("GetPage(page2) failed: %v", err)
+	}
+
+	errs := service.RecordContentUpdates([]*tree.Page{page1, page2}, "tester", "batch")
+	if len(errs) != 2 {
+		t.Fatalf("expected 2 result errors, got %d", len(errs))
+	}
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("RecordContentUpdates error[%d] = %v", i, err)
+		}
+	}
+
+	revisions1, err := service.ListRevisions(pageID1)
+	if err != nil {
+		t.Fatalf("ListRevisions(page1) failed: %v", err)
+	}
+	if len(revisions1) != 1 || revisions1[0].Type != RevisionTypeContentUpdate {
+		t.Fatalf("unexpected revisions for page1: %#v", revisions1)
+	}
+
+	revisions2, err := service.ListRevisions(pageID2)
+	if err != nil {
+		t.Fatalf("ListRevisions(page2) failed: %v", err)
+	}
+	if len(revisions2) != 1 || revisions2[0].Type != RevisionTypeContentUpdate {
+		t.Fatalf("unexpected revisions for page2: %#v", revisions2)
+	}
+
+	errs = service.RecordContentUpdates([]*tree.Page{page1, page2}, "tester", "batch")
+	if len(errs) != 2 {
+		t.Fatalf("expected 2 noop result errors, got %d", len(errs))
+	}
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("RecordContentUpdates noop error[%d] = %v", i, err)
+		}
+	}
+
+	revisions1After, err := service.ListRevisions(pageID1)
+	if err != nil {
+		t.Fatalf("ListRevisions(page1 after noop) failed: %v", err)
+	}
+	if len(revisions1After) != 1 {
+		t.Fatalf("expected page1 noop to keep 1 revision, got %d", len(revisions1After))
+	}
+
+	revisions2After, err := service.ListRevisions(pageID2)
+	if err != nil {
+		t.Fatalf("ListRevisions(page2 after noop) failed: %v", err)
+	}
+	if len(revisions2After) != 1 {
+		t.Fatalf("expected page2 noop to keep 1 revision, got %d", len(revisions2After))
+	}
+}
+
+func TestRecordContentUpdates_PreservesPerInputErrors(t *testing.T) {
+	service, treeService, storageDir := newRevisionTestService(t)
+	pageID1 := createRevisionTestPage(t, treeService, "Page 1", "page-1", "hello")
+	pageID2 := createRevisionTestPage(t, treeService, "Page 2", "page-2", "world")
+	writeLiveAsset(t, storageDir, pageID1, "a.txt", "asset-a")
+	writeLiveAsset(t, storageDir, pageID2, "b.txt", "asset-b")
+
+	page1, err := treeService.GetPage(pageID1)
+	if err != nil {
+		t.Fatalf("GetPage(page1) failed: %v", err)
+	}
+	page2, err := treeService.GetPage(pageID2)
+	if err != nil {
+		t.Fatalf("GetPage(page2) failed: %v", err)
+	}
+
+	errs := service.RecordContentUpdates([]*tree.Page{page1, nil, page2}, "tester", "batch")
+	if len(errs) != 3 {
+		t.Fatalf("expected 3 result errors, got %d", len(errs))
+	}
+	if errs[0] != nil {
+		t.Fatalf("unexpected error for page1: %v", errs[0])
+	}
+	if errs[1] == nil || errs[1].Error() != "page is required" {
+		t.Fatalf("expected nil-page error in slot 1, got %v", errs[1])
+	}
+	if errs[2] != nil {
+		t.Fatalf("unexpected error for page2: %v", errs[2])
+	}
+
+	revisions1, err := service.ListRevisions(pageID1)
+	if err != nil {
+		t.Fatalf("ListRevisions(page1) failed: %v", err)
+	}
+	if len(revisions1) != 1 {
+		t.Fatalf("expected 1 revision for page1, got %d", len(revisions1))
+	}
+
+	revisions2, err := service.ListRevisions(pageID2)
+	if err != nil {
+		t.Fatalf("ListRevisions(page2) failed: %v", err)
+	}
+	if len(revisions2) != 1 {
+		t.Fatalf("expected 1 revision for page2, got %d", len(revisions2))
+	}
+}
+
+func TestRecordContentUpdates_DuplicatePageIDsStayDeterministic(t *testing.T) {
+	service, treeService, storageDir := newRevisionTestService(t)
+	pageID := createRevisionTestPage(t, treeService, "Page", "page", "hello")
+	writeLiveAsset(t, storageDir, pageID, "a.txt", "asset-a")
+
+	page, err := treeService.GetPage(pageID)
+	if err != nil {
+		t.Fatalf("GetPage(page) failed: %v", err)
+	}
+
+	errs := service.RecordContentUpdates([]*tree.Page{page, page}, "tester", "batch")
+	if len(errs) != 2 {
+		t.Fatalf("expected 2 result errors, got %d", len(errs))
+	}
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("unexpected error in slot %d: %v", i, err)
+		}
+	}
+
+	revisions, err := service.ListRevisions(pageID)
+	if err != nil {
+		t.Fatalf("ListRevisions(page) failed: %v", err)
+	}
+	if len(revisions) != 1 {
+		t.Fatalf("expected duplicate batch entry to yield 1 revision, got %d", len(revisions))
+	}
+}
 
 func TestLocalizedErrorHelpers(t *testing.T) {
 	cause := errors.New("boom")
@@ -150,7 +294,6 @@ func TestServiceWrappersAndHelpers(t *testing.T) {
 		t.Fatalf("scanLiveAssets(missing) failed: %v", err)
 	}
 }
-
 
 func TestRecordAssetAndStructureBranches(t *testing.T) {
 	service, treeService, storageDir := newRevisionTestService(t)
@@ -358,7 +501,6 @@ func TestCapturePageStateAndNewRevisionHelpers(t *testing.T) {
 	}
 }
 
-
 func TestRecordContentAndAssetUpdatesWithoutAssets(t *testing.T) {
 	service, treeService, _ := newRevisionTestService(t)
 	pageID := createRevisionTestPage(t, treeService, "Page", "page", "hello")
@@ -402,7 +544,6 @@ func TestRecordContentAndAssetUpdatesWithoutAssets(t *testing.T) {
 		t.Fatalf("unexpected content revision: %#v created=%v", contentRev, created)
 	}
 }
-
 
 func TestRestoreRevisionRehydratesLivePageState(t *testing.T) {
 	service, treeService, storageDir := newRevisionTestService(t)
@@ -487,7 +628,6 @@ func TestRestoreRevisionRehydratesLivePageState(t *testing.T) {
 		t.Fatalf("latest revision = %#v", latest)
 	}
 }
-
 
 func TestRecordContentAndStructureRebuildMissingPreviousManifest(t *testing.T) {
 	service, treeService, storageDir := newRevisionTestService(t)

--- a/internal/links/link_service.go
+++ b/internal/links/link_service.go
@@ -130,6 +130,30 @@ func (b *LinkService) UpdateLinksForPage(page *tree.Page, content string) error 
 	return nil
 }
 
+func (b *LinkService) UpdateLinksAndHealForPages(pages []*tree.Page) error {
+	updates := make([]PageLinkUpdate, 0, len(pages))
+	for _, page := range pages {
+		if page == nil {
+			continue
+		}
+		pagePath := normalizeWikiPath(page.CalculatePath())
+		links := extractLinksFromMarkdown(page.Content)
+		targets := resolveTargetLinks(b.treeService, pagePath, links)
+		updates = append(updates, PageLinkUpdate{
+			FromPageID: page.ID,
+			FromTitle:  page.Title,
+			ToPath:     pagePath,
+			Targets:    targets,
+		})
+	}
+
+	if len(updates) == 0 {
+		return nil
+	}
+
+	return b.store.ReplaceLinksAndHeal(updates)
+}
+
 // DeleteOutgoingLinksForPage removes all outgoing link records for a page.
 func (b *LinkService) DeleteOutgoingLinksForPage(pageID string) error {
 	return b.store.DeleteOutgoingLinks(pageID)

--- a/internal/links/link_service_test.go
+++ b/internal/links/link_service_test.go
@@ -106,6 +106,7 @@ Internal: [Page](/docs/page1)
 		}
 	}
 }
+
 // helper to create a small tree structure:
 // root
 //
@@ -1078,5 +1079,161 @@ func TestLinksStore_GetBrokenIncomingForPath_OnlyReturnsBrokenNotResolved(t *tes
 	}
 	if backlinks[0].FromPageID != pageAID {
 		t.Errorf("backlink FromPageID = %q, want %q", backlinks[0].FromPageID, pageAID)
+	}
+}
+
+func TestLinkService_UpdateLinksAndHealForPages_UpdatesAndHealsMultiplePages(t *testing.T) {
+	svc, ts, _ := setupLinkService(t)
+
+	aIDPtr, err := ts.CreateNode("system", nil, "Page A", "a", pageNodeKind())
+	if err != nil {
+		t.Fatalf("CreateNode A failed: %v", err)
+	}
+	pageAID := *aIDPtr
+
+	cIDPtr, err := ts.CreateNode("system", nil, "Page C", "c", pageNodeKind())
+	if err != nil {
+		t.Fatalf("CreateNode C failed: %v", err)
+	}
+	pageCID := *cIDPtr
+
+	pageA, err := ts.GetPage(pageAID)
+	if err != nil {
+		t.Fatalf("GetPage A failed: %v", err)
+	}
+	contentA := "Link: [B](/b)"
+	if err := ts.UpdateNode("system", pageA.ID, pageA.Title, pageA.Slug, &contentA); err != nil {
+		t.Fatalf("UpdateNode A failed: %v", err)
+	}
+
+	pageC, err := ts.GetPage(pageCID)
+	if err != nil {
+		t.Fatalf("GetPage C failed: %v", err)
+	}
+	contentC := "Link: [D](/d)"
+	if err := ts.UpdateNode("system", pageC.ID, pageC.Title, pageC.Slug, &contentC); err != nil {
+		t.Fatalf("UpdateNode C failed: %v", err)
+	}
+
+	if err := svc.IndexAllPages(); err != nil {
+		t.Fatalf("IndexAllPages failed: %v", err)
+	}
+
+	bIDPtr, err := ts.CreateNode("system", nil, "Page B", "b", pageNodeKind())
+	if err != nil {
+		t.Fatalf("CreateNode B failed: %v", err)
+	}
+	pageB, err := ts.GetPage(*bIDPtr)
+	if err != nil {
+		t.Fatalf("GetPage B failed: %v", err)
+	}
+
+	dIDPtr, err := ts.CreateNode("system", nil, "Page D", "d", pageNodeKind())
+	if err != nil {
+		t.Fatalf("CreateNode D failed: %v", err)
+	}
+	pageD, err := ts.GetPage(*dIDPtr)
+	if err != nil {
+		t.Fatalf("GetPage D failed: %v", err)
+	}
+
+	if err := svc.UpdateLinksAndHealForPages([]*tree.Page{pageB, pageD}); err != nil {
+		t.Fatalf("UpdateLinksAndHealForPages failed: %v", err)
+	}
+
+	outA, err := svc.GetOutgoingLinksForPage(pageAID)
+	if err != nil {
+		t.Fatalf("GetOutgoingLinksForPage(A) failed: %v", err)
+	}
+	if outA.Count != 1 {
+		t.Fatalf("expected 1 outgoing for A, got %d: %#v", outA.Count, outA.Outgoings)
+	}
+	if outA.Outgoings[0].Broken {
+		t.Fatalf("expected A link to be healed, got %#v", outA.Outgoings[0])
+	}
+	if outA.Outgoings[0].ToPageID != pageB.ID {
+		t.Fatalf("A ToPageID = %q, want %q", outA.Outgoings[0].ToPageID, pageB.ID)
+	}
+
+	outC, err := svc.GetOutgoingLinksForPage(pageCID)
+	if err != nil {
+		t.Fatalf("GetOutgoingLinksForPage(C) failed: %v", err)
+	}
+	if outC.Count != 1 {
+		t.Fatalf("expected 1 outgoing for C, got %d: %#v", outC.Count, outC.Outgoings)
+	}
+	if outC.Outgoings[0].Broken {
+		t.Fatalf("expected C link to be healed, got %#v", outC.Outgoings[0])
+	}
+	if outC.Outgoings[0].ToPageID != pageD.ID {
+		t.Fatalf("C ToPageID = %q, want %q", outC.Outgoings[0].ToPageID, pageD.ID)
+	}
+}
+
+func TestLinkService_UpdateLinksAndHealForPages_ReindexesOutgoingForSourcePages(t *testing.T) {
+	svc, ts, _ := setupLinkService(t)
+
+	sourceIDPtr, err := ts.CreateNode("system", nil, "Source", "source", pageNodeKind())
+	if err != nil {
+		t.Fatalf("CreateNode source failed: %v", err)
+	}
+	sourceID := *sourceIDPtr
+
+	oldTargetIDPtr, err := ts.CreateNode("system", nil, "Old Target", "old-target", pageNodeKind())
+	if err != nil {
+		t.Fatalf("CreateNode old target failed: %v", err)
+	}
+	oldTargetID := *oldTargetIDPtr
+
+	source, err := ts.GetPage(sourceID)
+	if err != nil {
+		t.Fatalf("GetPage source failed: %v", err)
+	}
+	oldContent := "Link: [Old](/old-target)"
+	if err := ts.UpdateNode("system", source.ID, source.Title, source.Slug, &oldContent); err != nil {
+		t.Fatalf("UpdateNode source failed: %v", err)
+	}
+
+	if err := svc.IndexAllPages(); err != nil {
+		t.Fatalf("IndexAllPages failed: %v", err)
+	}
+
+	newTargetIDPtr, err := ts.CreateNode("system", nil, "New Target", "new-target", pageNodeKind())
+	if err != nil {
+		t.Fatalf("CreateNode new target failed: %v", err)
+	}
+	newTargetID := *newTargetIDPtr
+
+	updatedContent := "Link: [New](/new-target)"
+	if err := ts.UpdateNode("system", source.ID, source.Title, source.Slug, &updatedContent); err != nil {
+		t.Fatalf("UpdateNode source (rewrite) failed: %v", err)
+	}
+
+	updatedSource, err := ts.GetPage(sourceID)
+	if err != nil {
+		t.Fatalf("GetPage source (updated) failed: %v", err)
+	}
+
+	if err := svc.UpdateLinksAndHealForPages([]*tree.Page{updatedSource}); err != nil {
+		t.Fatalf("UpdateLinksAndHealForPages failed: %v", err)
+	}
+
+	oldBacklinks, err := svc.GetBacklinksForPage(oldTargetID)
+	if err != nil {
+		t.Fatalf("GetBacklinksForPage(old target) failed: %v", err)
+	}
+	if oldBacklinks.Count != 0 {
+		t.Fatalf("expected 0 backlinks for old target, got %d: %#v", oldBacklinks.Count, oldBacklinks.Backlinks)
+	}
+
+	newBacklinks, err := svc.GetBacklinksForPage(newTargetID)
+	if err != nil {
+		t.Fatalf("GetBacklinksForPage(new target) failed: %v", err)
+	}
+	if newBacklinks.Count != 1 {
+		t.Fatalf("expected 1 backlink for new target, got %d: %#v", newBacklinks.Count, newBacklinks.Backlinks)
+	}
+	if newBacklinks.Backlinks[0].FromPageID != sourceID {
+		t.Fatalf("new backlink FromPageID = %q, want %q", newBacklinks.Backlinks[0].FromPageID, sourceID)
 	}
 }

--- a/internal/links/links_store.go
+++ b/internal/links/links_store.go
@@ -19,6 +19,13 @@ type LinksStore struct {
 	db         *sql.DB
 }
 
+type PageLinkUpdate struct {
+	FromPageID string
+	FromTitle  string
+	ToPath     string
+	Targets    []TargetLink
+}
+
 func linksDatabasePath(storageDir string, filename string) string {
 	normalizedStorageDir := filepath.FromSlash(strings.ReplaceAll(storageDir, `\`, `/`))
 	return filepath.Join(normalizedStorageDir, filename)
@@ -199,6 +206,86 @@ func (s *LinksStore) AddLinks(fromPageID string, fromTitle string, toLinks []Tar
 	}
 
 	return tx.Commit()
+}
+
+func (s *LinksStore) ReplaceLinksAndHeal(updates []PageLinkUpdate) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+
+	if err := s.replaceLinksAndHealTx(tx, updates); err != nil {
+		rbErr := tx.Rollback()
+		if rbErr != nil {
+			return errors.Join(err, rbErr)
+		}
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func (s *LinksStore) replaceLinksAndHealTx(tx *sql.Tx, updates []PageLinkUpdate) error {
+	deleteStmt, err := tx.Prepare(`DELETE FROM links WHERE from_page_id = ?`)
+	if err != nil {
+		return fmt.Errorf("failed to prepare delete statement for batched link update: %w", err)
+	}
+	defer func() {
+		if err := deleteStmt.Close(); err != nil {
+			slog.Default().Error("could not close statement", "error", err)
+		}
+	}()
+
+	insertStmt, err := tx.Prepare(`INSERT OR REPLACE INTO links(from_page_id, to_page_id, to_path, from_title, broken) VALUES (?, ?, ?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("failed to prepare insert statement for batched link update: %w", err)
+	}
+	defer func() {
+		if err := insertStmt.Close(); err != nil {
+			slog.Default().Error("could not close statement", "error", err)
+		}
+	}()
+
+	healStmt, err := tx.Prepare(`
+		UPDATE links
+		SET to_page_id = ?, broken = 0
+		WHERE to_path = ? AND broken = 1
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to prepare heal statement for batched link update: %w", err)
+	}
+	defer func() {
+		if err := healStmt.Close(); err != nil {
+			slog.Default().Error("could not close statement", "error", err)
+		}
+	}()
+
+	for _, update := range updates {
+		if _, err := deleteStmt.Exec(update.FromPageID); err != nil {
+			return fmt.Errorf("failed to clear existing links for page %s: %w", update.FromPageID, err)
+		}
+
+		for _, link := range update.Targets {
+			brokenInt := 0
+			if link.Broken {
+				brokenInt = 1
+			}
+			if _, err := insertStmt.Exec(update.FromPageID, link.TargetPageID, link.TargetPagePath, update.FromTitle, brokenInt); err != nil {
+				return fmt.Errorf("failed to insert link from %s to %s: %w", update.FromPageID, link.TargetPageID, err)
+			}
+		}
+	}
+
+	for _, update := range updates {
+		if _, err := healStmt.Exec(update.FromPageID, update.ToPath); err != nil {
+			return fmt.Errorf("failed to heal links for path %s: %w", update.ToPath, err)
+		}
+	}
+
+	return nil
 }
 
 func (s *LinksStore) GetBacklinksForPage(pageID string) ([]Backlink, error) {

--- a/internal/wiki/pages/refactor.go
+++ b/internal/wiki/pages/refactor.go
@@ -407,9 +407,12 @@ func (uc *ApplyPageRefactorUseCase) rewriteAffectedPages(userID string, affected
 
 	if uc.links != nil && len(updatedPages) > 0 {
 		if err := uc.links.UpdateLinksAndHealForPages(updatedPages); err != nil {
-			for _, page := range updatedPages {
-				uc.log.Warn("failed to update link index after rewrite", "pageID", page.ID, "error", err)
-			}
+			uc.log.Warn(
+				"failed to update link index after rewrite",
+				"pageCount", len(updatedPages),
+				"pageIDSample", samplePageIDs(updatedPages, 5),
+				"error", err,
+			)
 		}
 	}
 	return nil
@@ -469,9 +472,12 @@ func (uc *ApplyPageRefactorUseCase) rewritePathChangedSubtree(userID string, sna
 
 	if uc.links != nil && len(updatedPages) > 0 {
 		if err := uc.links.UpdateLinksAndHealForPages(updatedPages); err != nil {
-			for _, page := range updatedPages {
-				uc.log.Warn("failed to update link index after subtree rewrite", "pageID", page.ID, "error", err)
-			}
+			uc.log.Warn(
+				"failed to update link index after subtree rewrite",
+				"pageCount", len(updatedPages),
+				"pageIDSample", samplePageIDs(updatedPages, 5),
+				"error", err,
+			)
 		}
 	}
 	return nil
@@ -501,6 +507,24 @@ func ensureStrings(values []string) []string {
 		return []string{}
 	}
 	return values
+}
+
+func samplePageIDs(pages []*tree.Page, limit int) []string {
+	if limit <= 0 || len(pages) == 0 {
+		return []string{}
+	}
+	if len(pages) < limit {
+		limit = len(pages)
+	}
+
+	ids := make([]string, 0, limit)
+	for i := 0; i < limit; i++ {
+		if pages[i] == nil {
+			continue
+		}
+		ids = append(ids, pages[i].ID)
+	}
+	return ids
 }
 
 func collectPreviewWarnings(pages []RefactorAffectedPage) []string {

--- a/internal/wiki/pages/refactor.go
+++ b/internal/wiki/pages/refactor.go
@@ -383,25 +383,32 @@ func (uc *ApplyPageRefactorUseCase) rewriteAffectedPages(userID string, affected
 	}
 
 	errs := uc.tree.BulkUpdateContent(userID, bulk)
+	updatedPages := make([]*tree.Page, 0, len(items))
 
 	for i, item := range items {
 		if errs[i] != nil {
 			uc.log.Warn("failed to rewrite links in page", "pageID", item.page.ID, "error", errs[i])
 			continue
 		}
-		if uc.revision != nil {
-			if _, _, err := uc.revision.RecordContentUpdate(item.page.ID, userID, ""); err != nil {
-				uc.log.Warn("failed to record content revision", "pageID", item.page.ID, "error", err)
+		updatedPages = append(updatedPages, &tree.Page{
+			PageNode: item.page.PageNode,
+			Content:  item.content,
+		})
+	}
+
+	if uc.revision != nil {
+		revErrs := uc.revision.RecordContentUpdates(updatedPages, userID, "")
+		for i, err := range revErrs {
+			if err != nil {
+				uc.log.Warn("failed to record content revision", "pageID", updatedPages[i].ID, "error", err)
 			}
 		}
-		if uc.links != nil {
-			updated, err := uc.tree.GetPage(item.page.ID)
-			if err != nil {
-				uc.log.Warn("failed to re-fetch page after link rewrite", "pageID", item.page.ID, "error", err)
-				continue
-			}
-			if err := uc.links.UpdateLinksForPage(updated, item.content); err != nil {
-				uc.log.Warn("failed to update link index after rewrite", "pageID", item.page.ID, "error", err)
+	}
+
+	if uc.links != nil && len(updatedPages) > 0 {
+		if err := uc.links.UpdateLinksAndHealForPages(updatedPages); err != nil {
+			for _, page := range updatedPages {
+				uc.log.Warn("failed to update link index after rewrite", "pageID", page.ID, "error", err)
 			}
 		}
 	}
@@ -438,28 +445,32 @@ func (uc *ApplyPageRefactorUseCase) rewritePathChangedSubtree(userID string, sna
 	}
 
 	errs := uc.tree.BulkUpdateContent(userID, bulk)
+	updatedPages := make([]*tree.Page, 0, len(items))
 
 	for i, item := range items {
 		if errs[i] != nil {
 			uc.log.Warn("failed to rewrite relative links in subtree page", "pageID", item.page.ID, "error", errs[i])
 			continue
 		}
-		if uc.revision != nil {
-			if _, _, err := uc.revision.RecordContentUpdate(item.page.ID, userID, ""); err != nil {
-				uc.log.Warn("failed to record content revision", "pageID", item.page.ID, "error", err)
+		updatedPages = append(updatedPages, &tree.Page{
+			PageNode: item.page.PageNode,
+			Content:  item.content,
+		})
+	}
+
+	if uc.revision != nil {
+		revErrs := uc.revision.RecordContentUpdates(updatedPages, userID, "")
+		for i, err := range revErrs {
+			if err != nil {
+				uc.log.Warn("failed to record content revision", "pageID", updatedPages[i].ID, "error", err)
 			}
 		}
-		if uc.links != nil {
-			updated, err := uc.tree.GetPage(item.page.ID)
-			if err != nil {
-				uc.log.Warn("failed to re-fetch subtree page after link rewrite", "pageID", item.page.ID, "error", err)
-				continue
-			}
-			if err := uc.links.UpdateLinksForPage(updated, item.content); err != nil {
-				uc.log.Warn("failed to update link index after subtree rewrite", "pageID", item.page.ID, "error", err)
-			}
-			if err := uc.links.HealLinksForExactPath(updated); err != nil {
-				uc.log.Warn("failed to heal links after subtree rewrite", "pageID", item.page.ID, "error", err)
+	}
+
+	if uc.links != nil && len(updatedPages) > 0 {
+		if err := uc.links.UpdateLinksAndHealForPages(updatedPages); err != nil {
+			for _, page := range updatedPages {
+				uc.log.Warn("failed to update link index after subtree rewrite", "pageID", page.ID, "error", err)
 			}
 		}
 	}


### PR DESCRIPTION
Reduce per-page follow-up work after bulk content rewrites.

Batch link refresh and healing, avoid extra tree rereads, and process content revisions in batches with safe parallelism across pages.