### PR TITLE
fix(revision): disable storage with flag

### DIFF
--- a/cmd/leafwiki/main.go
+++ b/cmd/leafwiki/main.go
@@ -234,6 +234,7 @@ func main() {
 		AccessTokenTimeout:  accessTokenTimeout,
 		RefreshTokenTimeout: refreshTokenTimeout,
 		AuthDisabled:        disableAuth,
+		EnableRevision:      enableRevision,
 		MaxRevisionHistory:  maxRevisionHistory,
 	})
 	if err != nil {

--- a/internal/http/router_test.go
+++ b/internal/http/router_test.go
@@ -29,12 +29,17 @@ func pageNodeKind() *tree.NodeKind {
 }
 
 func createWikiTestInstance(t *testing.T) *wiki.Wiki {
+	return createWikiTestInstanceWithRevisionFlag(t, true)
+}
+
+func createWikiTestInstanceWithRevisionFlag(t *testing.T, enableRevision bool) *wiki.Wiki {
 	w, err := wiki.NewWiki(&wiki.WikiOptions{
 		StorageDir:          t.TempDir(),
 		AdminPassword:       "admin",
 		JWTSecret:           "secretkey",
 		AccessTokenTimeout:  15 * time.Minute,
 		RefreshTokenTimeout: 7 * 24 * time.Hour,
+		EnableRevision:      enableRevision,
 	})
 	if err != nil {
 		t.Fatalf("Failed to create wiki instance: %v", err)
@@ -842,6 +847,62 @@ func TestRefactorPreviewEndpoint_IsDisabledWhenFlagIsOff(t *testing.T) {
 	previewRec := authenticatedRequest(t, router, http.MethodPost, "/api/pages/"+target.ID+"/refactor/preview", previewBody)
 	if previewRec.Code != http.StatusNotFound {
 		t.Fatalf("Expected 404 when link refactor is disabled, got %d - %s", previewRec.Code, previewRec.Body.String())
+	}
+}
+
+func TestRefactorApply_DoesNotPersistRevisionsWhenRevisionDisabled(t *testing.T) {
+	w := createWikiTestInstanceWithRevisionFlag(t, false)
+	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
+
+	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
+		PublicAccess:            false,
+		InjectCodeInHeader:      "",
+		AllowInsecure:           true,
+		AccessTokenTimeout:      15 * time.Minute,
+		RefreshTokenTimeout:     7 * 24 * time.Hour,
+		HideLinkMetadataSection: false,
+		MaxAssetUploadSizeBytes: assets.DefaultMaxUploadSizeBytes,
+		EnableRevision:          false,
+		EnableLinkRefactor:      true,
+	})
+
+	target := createPageViaAPI(t, router, "Target", "target", nil, pageNodeKind())
+	ref := createPageViaAPI(t, router, "Ref", "ref", nil, pageNodeKind())
+
+	updateBody := strings.NewReader(`{"version":"` + ref.Version + `","title":"Ref","slug":"ref","content":"[Target](/target)"}`)
+	updateRec := authenticatedRequest(t, router, http.MethodPut, "/api/pages/"+ref.ID, updateBody)
+	if updateRec.Code != http.StatusOK {
+		t.Fatalf("Expected 200 OK on page update, got %d - %s", updateRec.Code, updateRec.Body.String())
+	}
+
+	applyBody := strings.NewReader(`{"kind":"rename","version":"` + target.Version + `","title":"Target","slug":"target-renamed","rewriteLinks":true}`)
+	applyRec := authenticatedRequest(t, router, http.MethodPost, "/api/pages/"+target.ID+"/refactor/apply", applyBody)
+	if applyRec.Code != http.StatusOK {
+		t.Fatalf("Expected 200 OK on refactor apply, got %d - %s", applyRec.Code, applyRec.Body.String())
+	}
+
+	refPageRec := authenticatedRequest(t, router, http.MethodGet, "/api/pages/"+ref.ID, strings.NewReader(""))
+	if refPageRec.Code != http.StatusOK {
+		t.Fatalf("Expected 200 OK on ref page fetch, got %d - %s", refPageRec.Code, refPageRec.Body.String())
+	}
+
+	var refPage map[string]any
+	if err := json.Unmarshal(refPageRec.Body.Bytes(), &refPage); err != nil {
+		t.Fatalf("Invalid ref page JSON: %v", err)
+	}
+
+	if got, _ := refPage["content"].(string); got != "[Target](/target-renamed)" {
+		t.Fatalf("Expected rewritten ref content, got %q", got)
+	}
+
+	revisionsRec := authenticatedRequest(t, router, http.MethodGet, "/api/pages/"+target.ID+"/revisions", strings.NewReader(""))
+	if revisionsRec.Code != http.StatusNotFound {
+		t.Fatalf("Expected 404 on revisions endpoint when revision is disabled, got %d - %s", revisionsRec.Code, revisionsRec.Body.String())
+	}
+
+	revisionsDir := filepath.Join(w.GetStorageDir(), ".leafwiki", "revisions")
+	if _, err := os.Stat(revisionsDir); !os.IsNotExist(err) {
+		t.Fatalf("Expected no revision storage directory, got err=%v", err)
 	}
 }
 

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -70,6 +70,7 @@ type WikiOptions struct {
 	AccessTokenTimeout      time.Duration // Access token timeout duration
 	RefreshTokenTimeout     time.Duration // Refresh token timeout duration
 	AuthDisabled            bool          // Whether authentication is disabled
+	EnableRevision          bool          // Whether revisions should be recorded and exposed
 	MaxRevisionHistory      int           // Max revisions kept per page; 0 = unlimited
 	MaxAssetUploadSizeBytes int64         // Maximum allowed size in bytes for asset/import uploads; 0 = default
 }
@@ -98,8 +99,10 @@ func NewWiki(options *WikiOptions) (*Wiki, error) {
 	if err := w.EnsureWelcomePage(); err != nil {
 		return nil, err
 	}
-	w.revision = revision.NewService(w.storageDir, w.tree, w.log,
-		revision.ServiceOptions{MaxRevisions: options.MaxRevisionHistory})
+	if options.EnableRevision {
+		w.revision = revision.NewService(w.storageDir, w.tree, w.log,
+			revision.ServiceOptions{MaxRevisions: options.MaxRevisionHistory})
+	}
 	w.buildRoutes(options)
 	return w, nil
 }

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -70,7 +70,7 @@ type WikiOptions struct {
 	AccessTokenTimeout      time.Duration // Access token timeout duration
 	RefreshTokenTimeout     time.Duration // Refresh token timeout duration
 	AuthDisabled            bool          // Whether authentication is disabled
-	EnableRevision          bool          // Whether revisions should be recorded and exposed
+	EnableRevision          bool          // Whether revision recording/storage is enabled
 	MaxRevisionHistory      int           // Max revisions kept per page; 0 = unlimited
 	MaxAssetUploadSizeBytes int64         // Maximum allowed size in bytes for asset/import uploads; 0 = default
 }

--- a/internal/wiki/wiki_test.go
+++ b/internal/wiki/wiki_test.go
@@ -17,6 +17,7 @@ func createWikiTestInstance(t *testing.T) *Wiki {
 		JWTSecret:           "secretkey",
 		AccessTokenTimeout:  15 * time.Minute,
 		RefreshTokenTimeout: 7 * 24 * time.Hour,
+		EnableRevision:      true,
 	})
 	if err != nil {
 		t.Fatalf("Failed to create wiki instance: %v", err)


### PR DESCRIPTION
Only initialize the revision service when the revision feature flag is enabled so hidden history does not continue to persist in the background.

Keep link refactoring functional without revisions and cover the flag combination with router tests.