### PR TITLE
fix: Improve error handling during migration

### DIFF
--- a/internal/core/tree/node_store.go
+++ b/internal/core/tree/node_store.go
@@ -38,7 +38,13 @@ func ensureUniqueReconstructedSlug(seenSlugs map[string]string, slug string, pat
 		return fmt.Errorf("reconstruct tree from fs: empty slug at %s", path)
 	}
 	if existingPath, exists := seenSlugs[key]; exists {
-		return fmt.Errorf("duplicate slug %q (case-insensitive) in %s and %s", slug, existingPath, path)
+		parentDir := filepath.Base(filepath.Dir(path))
+		return fmt.Errorf(
+			"duplicate slug %q: a directory and a .md file share the same name in %s/. "+
+				"Rename or remove one of them (e.g. rename %s.md -> %s-page.md) to resolve the conflict. "+
+				"Conflicting paths: %s and %s",
+			slug, parentDir, slug, slug, existingPath, path,
+		)
 	}
 	seenSlugs[key] = path
 	return nil

--- a/internal/core/tree/node_store_reconstruct_test.go
+++ b/internal/core/tree/node_store_reconstruct_test.go
@@ -345,6 +345,31 @@ func TestNodeStore_ReconstructTreeFromFS_ReturnsErrorOnCaseInsensitiveDuplicateS
 	}
 }
 
+func TestNodeStore_ReconstructTreeFromFS_ReturnsActionableErrorOnDirectoryFileSlugConflict(t *testing.T) {
+	tmp := t.TempDir()
+	store := NewNodeStore(tmp)
+
+	mustMkdir(t, filepath.Join(tmp, "root", "notes"))
+	mustWriteFile(t, filepath.Join(tmp, "root", "notes", "index.md"), "# Notes section", 0o644)
+	mustWriteFile(t, filepath.Join(tmp, "root", "notes.md"), "# Notes page", 0o644)
+
+	_, err := store.ReconstructTreeFromFS()
+	if err == nil {
+		t.Fatalf("expected duplicate slug error")
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, `duplicate slug "notes": a directory and a .md file share the same name in root/.`) {
+		t.Fatalf("expected actionable duplicate slug summary, got: %v", err)
+	}
+	if !strings.Contains(errMsg, "Rename or remove one of them") {
+		t.Fatalf("expected actionable remediation hint, got: %v", err)
+	}
+	if !strings.Contains(errMsg, "rename notes.md -> notes-page.md") {
+		t.Fatalf("expected rename example in error, got: %v", err)
+	}
+}
+
 func TestNodeStore_ReconstructTreeFromFS_WritesIDsBackToFiles(t *testing.T) {
 	tmp := t.TempDir()
 	store := NewNodeStore(tmp)

--- a/internal/core/treemigration/runner.go
+++ b/internal/core/treemigration/runner.go
@@ -209,13 +209,17 @@ func backfillChildOrder(deps Dependencies, node Node) error {
 
 	children := node.Children()
 	if len(children) > 0 {
-		if node.ID() == "root" || node.Kind() == NodeKindSection {
-			if err := deps.Store.SaveChildOrder(node); err != nil {
-				return fmt.Errorf("persist child order for node %s: %w", node.ID(), err)
-			}
-		} else {
-			deps.Log.Warn("skipping child order backfill for non-section node with children — likely caused by a folder and .md file sharing the same name in a previous version",
+		if node.ID() != "root" && node.Kind() != NodeKindSection {
+			// Legacy snapshots could have a page node with children when a folder and an
+			// .md file shared the same name. Coerce to section so SaveChildOrder can write
+			// the .order.json and preserve the legacy child ordering. ReconstructTreeFromFS
+			// will derive the correct kind from the filesystem after migration completes.
+			deps.Log.Warn("coercing non-section node with children to section for child order backfill — likely caused by a folder and .md file sharing the same name in a previous version",
 				"nodeID", node.ID(), "slug", node.Slug(), "kind", node.Kind())
+			node.SetKind(NodeKindSection)
+		}
+		if err := deps.Store.SaveChildOrder(node); err != nil {
+			return fmt.Errorf("persist child order for node %s: %w", node.ID(), err)
 		}
 	}
 

--- a/internal/core/treemigration/runner.go
+++ b/internal/core/treemigration/runner.go
@@ -209,8 +209,13 @@ func backfillChildOrder(deps Dependencies, node Node) error {
 
 	children := node.Children()
 	if len(children) > 0 {
-		if err := deps.Store.SaveChildOrder(node); err != nil {
-			return fmt.Errorf("persist child order for node %s: %w", node.ID(), err)
+		if node.ID() == "root" || node.Kind() == NodeKindSection {
+			if err := deps.Store.SaveChildOrder(node); err != nil {
+				return fmt.Errorf("persist child order for node %s: %w", node.ID(), err)
+			}
+		} else {
+			deps.Log.Warn("skipping child order backfill for non-section node with children — likely caused by a folder and .md file sharing the same name in a previous version",
+				"nodeID", node.ID(), "slug", node.Slug(), "kind", node.Kind())
 		}
 	}
 

--- a/internal/core/treemigration/runner_test.go
+++ b/internal/core/treemigration/runner_test.go
@@ -377,6 +377,58 @@ func TestTreeMigration_LoadTree_MigratesToV4_MaterializesMissingSectionIndex(t *
 	}
 }
 
+func TestTreeMigration_LoadTree_MigratesToV5_PageNodeWithChildrenDoesNotBreakMigration(t *testing.T) {
+	// Regression test for: https://github.com/perber/wiki/issues/932
+	// Legacy trees could contain page nodes that have children (e.g. when a directory and
+	// an .md file share the same name). The V5 migration must not try to write a .order.json
+	// for such page nodes — only root and section nodes carry child-order files.
+	if tree.CurrentSchemaVersion < 5 {
+		t.Skip("requires schema v5+")
+	}
+
+	tmpDir := t.TempDir()
+	writeSchema(t, tmpDir, tree.CurrentSchemaVersion)
+
+	svc := tree.NewTreeService(tmpDir)
+	if err := svc.LoadTree(); err != nil {
+		t.Fatalf("LoadTree failed: %v", err)
+	}
+
+	// Build: root → notes (section) → guide (page)
+	notesID, err := svc.CreateNode("system", nil, "Notes", "notes", ptrKind(tree.NodeKindSection))
+	if err != nil {
+		t.Fatalf("CreateNode notes failed: %v", err)
+	}
+	_, err = svc.CreateNode("system", notesID, "Guide", "guide", ptrKind(tree.NodeKindPage))
+	if err != nil {
+		t.Fatalf("CreateNode guide failed: %v", err)
+	}
+
+	// Corrupt the tree snapshot: flip "notes" kind from section → page to simulate
+	// the legacy data shape reported in issue #932 (folder and .md file with same name).
+	root := svc.GetTree()
+	for _, child := range root.Children {
+		if child.ID == *notesID {
+			child.Kind = tree.NodeKindPage
+		}
+	}
+
+	if err := os.Remove(filepath.Join(tmpDir, "root", ".order.json")); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("remove root order file: %v", err)
+	}
+	if err := os.Remove(filepath.Join(tmpDir, "root", "notes", ".order.json")); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("remove notes order file: %v", err)
+	}
+
+	persistLegacyTreeSnapshot(t, tmpDir, root)
+	writeSchema(t, tmpDir, 4)
+
+	loaded := tree.NewTreeService(tmpDir)
+	if err := loaded.LoadTree(); err != nil {
+		t.Fatalf("migration failed for page node with children (issue #932): %v", err)
+	}
+}
+
 func TestTreeMigration_LoadTree_MigratesToV5_ReturnsErrorWhenOrderFileCannotBeWritten(t *testing.T) {
 	if tree.CurrentSchemaVersion < 5 {
 		t.Skip("requires schema v5+")

--- a/internal/core/treemigration/runner_test.go
+++ b/internal/core/treemigration/runner_test.go
@@ -377,11 +377,11 @@ func TestTreeMigration_LoadTree_MigratesToV4_MaterializesMissingSectionIndex(t *
 	}
 }
 
-func TestTreeMigration_LoadTree_MigratesToV5_PageNodeWithChildrenDoesNotBreakMigration(t *testing.T) {
+func TestTreeMigration_LoadTree_MigratesToV5_PageNodeWithChildrenPreservesChildOrder(t *testing.T) {
 	// Regression test for: https://github.com/perber/wiki/issues/932
-	// Legacy trees could contain page nodes that have children (e.g. when a directory and
-	// an .md file share the same name). The V5 migration must not try to write a .order.json
-	// for such page nodes — only root and section nodes carry child-order files.
+	// Legacy trees could contain page nodes that have children when a folder and an .md file
+	// shared the same name. The V5 migration must coerce such nodes to section so that
+	// SaveChildOrder can write the .order.json and the legacy child ordering is preserved.
 	if tree.CurrentSchemaVersion < 5 {
 		t.Skip("requires schema v5+")
 	}
@@ -394,14 +394,19 @@ func TestTreeMigration_LoadTree_MigratesToV5_PageNodeWithChildrenDoesNotBreakMig
 		t.Fatalf("LoadTree failed: %v", err)
 	}
 
-	// Build: root → notes (section) → guide (page)
+	// Build: root → notes (section) → zebra, alpha (pages in non-alphabetical order)
+	// so we can verify the legacy ordering is preserved, not reset to alphabetical.
 	notesID, err := svc.CreateNode("system", nil, "Notes", "notes", ptrKind(tree.NodeKindSection))
 	if err != nil {
 		t.Fatalf("CreateNode notes failed: %v", err)
 	}
-	_, err = svc.CreateNode("system", notesID, "Guide", "guide", ptrKind(tree.NodeKindPage))
+	zebraID, err := svc.CreateNode("system", notesID, "Zebra", "zebra", ptrKind(tree.NodeKindPage))
 	if err != nil {
-		t.Fatalf("CreateNode guide failed: %v", err)
+		t.Fatalf("CreateNode zebra failed: %v", err)
+	}
+	alphaID, err := svc.CreateNode("system", notesID, "Alpha", "alpha", ptrKind(tree.NodeKindPage))
+	if err != nil {
+		t.Fatalf("CreateNode alpha failed: %v", err)
 	}
 
 	// Corrupt the tree snapshot: flip "notes" kind from section → page to simulate
@@ -426,6 +431,23 @@ func TestTreeMigration_LoadTree_MigratesToV5_PageNodeWithChildrenDoesNotBreakMig
 	loaded := tree.NewTreeService(tmpDir)
 	if err := loaded.LoadTree(); err != nil {
 		t.Fatalf("migration failed for page node with children (issue #932): %v", err)
+	}
+
+	// .order.json for notes must exist and reflect the legacy order (zebra before alpha),
+	// not the alphabetical fallback order that ReconstructTreeFromFS would produce without it.
+	var notesOrder struct {
+		OrderedIDs []string `json:"ordered_ids"`
+	}
+	rawOrder, err := os.ReadFile(filepath.Join(tmpDir, "root", "notes", ".order.json"))
+	if err != nil {
+		t.Fatalf("read notes order file: %v", err)
+	}
+	if err := json.Unmarshal(rawOrder, &notesOrder); err != nil {
+		t.Fatalf("unmarshal notes order file: %v", err)
+	}
+	want := []string{*zebraID, *alphaID}
+	if strings.Join(notesOrder.OrderedIDs, ",") != strings.Join(want, ",") {
+		t.Fatalf("unexpected notes child order after migration: got %v want %v", notesOrder.OrderedIDs, want)
 	}
 }
 


### PR DESCRIPTION
Legacy tree.json data could contain page nodes that carried children when a folder and an .md file shared the same name. The V5 migration called SaveChildOrder on every node with children, which rejected non-section nodes and caused a fatal startup error on affected installations.

Only root and section nodes receive .order.json files; page nodes are now skipped with a warning log entry. Content and structure are unaffected because ReconstructTreeFromFS heals the node kind from the filesystem after the migration completes.

Closes #932