### PR TITLE
fix(wiki): preserve import frontmatter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ clean:
 test:
 	go test ./...
 
+bench:
+	go test -bench=. -benchmem -benchtime=3s ./internal/links/... ./internal/core/revision/...
+
 # Build all platform targets
 release: $(PLATFORMS)
 	@echo "✅ All builds complete."
@@ -98,6 +101,7 @@ help:
 	@echo "  make release              – Cross-compile binaries for all platforms (via Docker)"
 	@echo "  make clean                – Clean all generated files"
 	@echo "  make test                 – Run all Go tests"
+	@echo "  make bench                – Run Go benchmarks for links and revision"
 	@echo "  make run-e2e              – Run end-to-end tests (using Docker)"
 	@echo "  make run-e2e-local        – Run end-to-end tests via local fast path"
 	@echo "  make run-e2e-local-fast   – Run E2E tests locally, skip UI build (use when dist/ is current)"
@@ -106,4 +110,4 @@ help:
 	@echo "  make docker-build-publish – Build and push multi-arch Docker image"
 	@echo "  make changelog            – Generate changelog"
 
-.PHONY: all build run clean test fmt lint help docker-build-publish changelog run-e2e run-e2e-local run-e2e-local-fast
+.PHONY: all build run clean test bench fmt lint help docker-build-publish changelog run-e2e run-e2e-local run-e2e-local-fast

--- a/internal/core/revision/service.go
+++ b/internal/core/revision/service.go
@@ -589,7 +589,7 @@ func (s *Service) RestoreRevision(pageID, revisionID, authorID string) error {
 	}
 
 	restoredContent := string(content)
-	if err := s.pages.UpdateNode(authorID, pageID, rev.Title, beforeState.Slug, &restoredContent, tree.VersionUnchecked); err != nil {
+	if err := s.pages.UpdateNode(authorID, pageID, rev.Title, beforeState.Slug, &restoredContent, tree.VersionUnchecked, false); err != nil {
 		return sharederrors.NewLocalizedError(
 			"revision_restore_failed",
 			"Failed to restore page",
@@ -601,7 +601,7 @@ func (s *Service) RestoreRevision(pageID, revisionID, authorID string) error {
 
 	if err := s.restoreAssets(pageID, assets); err != nil {
 		restoreRollbackContent := beforeState.Content
-		if rollbackErr := s.pages.UpdateNode(authorID, pageID, beforeState.Title, beforeState.Slug, &restoreRollbackContent, tree.VersionUnchecked); rollbackErr != nil {
+		if rollbackErr := s.pages.UpdateNode(authorID, pageID, beforeState.Title, beforeState.Slug, &restoreRollbackContent, tree.VersionUnchecked, false); rollbackErr != nil {
 			s.log.Warn("failed to rollback restored content", "pageID", pageID, "error", rollbackErr)
 		}
 		if rollbackErr := s.restoreAssets(pageID, beforeState.Assets); rollbackErr != nil {
@@ -618,7 +618,7 @@ func (s *Service) RestoreRevision(pageID, revisionID, authorID string) error {
 
 	if err := s.recordRestoreRevision(pageID, authorID); err != nil {
 		restoreRollbackContent := beforeState.Content
-		if rollbackErr := s.pages.UpdateNode(authorID, pageID, beforeState.Title, beforeState.Slug, &restoreRollbackContent, tree.VersionUnchecked); rollbackErr != nil {
+		if rollbackErr := s.pages.UpdateNode(authorID, pageID, beforeState.Title, beforeState.Slug, &restoreRollbackContent, tree.VersionUnchecked, false); rollbackErr != nil {
 			s.log.Warn("failed to rollback restored content", "pageID", pageID, "error", rollbackErr)
 		}
 		if rollbackErr := s.restoreAssets(pageID, beforeState.Assets); rollbackErr != nil {

--- a/internal/core/revision/service_test.go
+++ b/internal/core/revision/service_test.go
@@ -30,7 +30,7 @@ func createRevisionTestPage(t *testing.T, treeService *tree.TreeService, title, 
 	if err != nil {
 		t.Fatalf("CreateNode failed: %v", err)
 	}
-	if err := treeService.UpdateNode("tester", *id, title, slug, &content, tree.VersionUnchecked); err != nil {
+	if err := treeService.UpdateNode("tester", *id, title, slug, &content, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode failed: %v", err)
 	}
 	return *id
@@ -521,7 +521,7 @@ func TestRecordContentAndAssetUpdatesWithoutAssets(t *testing.T) {
 	}
 
 	content := "hello-2"
-	if err := treeService.UpdateNode("tester", pageID, "Page", "page", &content, tree.VersionUnchecked); err != nil {
+	if err := treeService.UpdateNode("tester", pageID, "Page", "page", &content, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode content failed: %v", err)
 	}
 	assetRev3, created, err := service.RecordAssetChange(pageID, "tester", "asset after content")
@@ -533,7 +533,7 @@ func TestRecordContentAndAssetUpdatesWithoutAssets(t *testing.T) {
 	}
 
 	content = "hello-3"
-	if err := treeService.UpdateNode("tester", pageID, "Page", "page", &content, tree.VersionUnchecked); err != nil {
+	if err := treeService.UpdateNode("tester", pageID, "Page", "page", &content, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode second content failed: %v", err)
 	}
 	contentRev, created, err := service.RecordContentUpdate(pageID, "tester", "content")
@@ -566,7 +566,7 @@ func TestRestoreRevisionRehydratesLivePageState(t *testing.T) {
 	pageID := *pageIDPtr
 
 	originalContent := "first version"
-	if err := treeService.UpdateNode("tester", pageID, "Original", "original", &originalContent, tree.VersionUnchecked); err != nil {
+	if err := treeService.UpdateNode("tester", pageID, "Original", "original", &originalContent, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode(original) failed: %v", err)
 	}
 	writeLiveAsset(t, storageDir, pageID, "old.txt", "old-asset")
@@ -579,7 +579,7 @@ func TestRestoreRevisionRehydratesLivePageState(t *testing.T) {
 	}
 
 	changedContent := "second version"
-	if err := treeService.UpdateNode("tester", pageID, "Changed", "changed", &changedContent, tree.VersionUnchecked); err != nil {
+	if err := treeService.UpdateNode("tester", pageID, "Changed", "changed", &changedContent, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode(changed) failed: %v", err)
 	}
 	if err := treeService.MoveNode("tester", pageID, *archiveID, tree.VersionUnchecked); err != nil {
@@ -647,7 +647,7 @@ func TestRecordContentAndStructureRebuildMissingPreviousManifest(t *testing.T) {
 	}
 
 	content := "hello-updated"
-	if err := treeService.UpdateNode("tester", pageID, "Page", "page", &content, tree.VersionUnchecked); err != nil {
+	if err := treeService.UpdateNode("tester", pageID, "Page", "page", &content, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode failed: %v", err)
 	}
 	contentRev, created, err := service.RecordContentUpdate(pageID, "tester", "content")
@@ -752,7 +752,7 @@ func TestCompareRevisionSnapshots(t *testing.T) {
 	}
 
 	content := "two"
-	if err := treeService.UpdateNode("tester", pageID, "Page", "page", &content, tree.VersionUnchecked); err != nil {
+	if err := treeService.UpdateNode("tester", pageID, "Page", "page", &content, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode failed: %v", err)
 	}
 	writeLiveAsset(t, storageDir, pageID, "b.txt", "asset-b")

--- a/internal/core/tree/node_store.go
+++ b/internal/core/tree/node_store.go
@@ -636,11 +636,44 @@ func (f *NodeStore) CreateSection(parentEntry *PageNode, newEntry *PageNode) err
 	return nil
 }
 
-// UpsertContent updates the content of a page file on disk
-// It creates the file if it does not exist also for sections (index.md)
+// UpsertContent updates the content of a page file on disk, treating the
+// incoming content as plain body text. Any frontmatter-like blocks the caller
+// passes are stored verbatim in the body and are never extracted into the
+// system-managed frontmatter. Use this for all UI-originated writes.
+// It creates the file if it does not exist also for sections (index.md).
 func (f *NodeStore) UpsertContent(entry *PageNode, content string) error {
 	if entry == nil {
 		return &InvalidOpError{Op: "UpsertContent", Reason: "an entry is required"}
+	}
+
+	filePath, err := f.contentPathForNodeWrite(entry)
+	if err != nil {
+		return err
+	}
+
+	mdFile := markdown.NewMarkdownFile(filePath, "", markdown.Frontmatter{})
+	if fileExists(filePath) {
+		mdFile, err = markdown.LoadMarkdownFile(filePath)
+		if err != nil {
+			return fmt.Errorf("could not load markdown file: %w", err)
+		}
+	}
+
+	mdFile.SetContent(content)
+	f.syncManagedFrontmatter(mdFile, entry)
+	if err := mdFile.WriteToFile(); err != nil {
+		return fmt.Errorf("could not write markdown file: %w", err)
+	}
+
+	return nil
+}
+
+// UpsertContentPreservingFrontmatter is the importer variant of UpsertContent.
+// It parses any frontmatter block at the top of content and merges the extra
+// fields into the system-managed frontmatter block written to disk.
+func (f *NodeStore) UpsertContentPreservingFrontmatter(entry *PageNode, content string) error {
+	if entry == nil {
+		return &InvalidOpError{Op: "UpsertContentPreservingFrontmatter", Reason: "an entry is required"}
 	}
 
 	filePath, err := f.contentPathForNodeWrite(entry)

--- a/internal/core/tree/node_store_test.go
+++ b/internal/core/tree/node_store_test.go
@@ -400,7 +400,9 @@ leafwiki_title: Old Title
 	}
 }
 
-func TestNodeStore_UpsertContent_RawFrontmatter_MergesExtrasIntoWrittenFrontmatter(t *testing.T) {
+// UpsertContent must treat incoming content that looks like frontmatter as plain
+// body text — matching the UI behaviour where the editor sends raw markdown.
+func TestNodeStore_UpsertContent_RawFrontmatter_TreatedAsPlainBody(t *testing.T) {
 	tmp := t.TempDir()
 	store := NewNodeStore(tmp)
 
@@ -423,6 +425,101 @@ func TestNodeStore_UpsertContent_RawFrontmatter_MergesExtrasIntoWrittenFrontmatt
 		t.Fatalf("ParseFrontmatter: %v", err)
 	}
 	if !has {
+		t.Fatalf("expected system frontmatter in written file")
+	}
+	// The full raw input must appear verbatim in the body.
+	if !strings.Contains(body, "custom_key: keep-me") {
+		t.Fatalf("expected raw content in body, got: %q", body)
+	}
+	if !strings.Contains(body, "# Imported Title") {
+		t.Fatalf("expected heading in body, got: %q", body)
+	}
+	// No user keys must leak into system ExtraFields.
+	if fm.ExtraFields["custom_key"] != nil {
+		t.Fatalf("expected custom_key to stay as body, got ExtraField %#v", fm.ExtraFields["custom_key"])
+	}
+	// Managed fields must come from the page node, not from user content.
+	if fm.LeafWikiID != "p1" {
+		t.Fatalf("expected managed leafwiki_id p1, got %q", fm.LeafWikiID)
+	}
+	if fm.LeafWikiTitle != "My Page" {
+		t.Fatalf("expected managed leafwiki_title 'My Page', got %q", fm.LeafWikiTitle)
+	}
+}
+
+// Regression test for #942: content typed in the UI that looks like frontmatter
+// must be stored as plain body text, not extracted and merged into system frontmatter.
+func TestNodeStore_UpsertContent_TreatsLeadingFrontmatterAsPlainBody(t *testing.T) {
+	tmp := t.TempDir()
+	store := NewNodeStore(tmp)
+
+	root := &PageNode{ID: "root", Slug: "root", Title: "root", Kind: NodeKindSection}
+	page := &PageNode{ID: "p1", Slug: "p", Title: "My Page", Kind: NodeKindPage, Parent: root}
+
+	if err := store.CreatePage(root, page); err != nil {
+		t.Fatalf("CreatePage: %v", err)
+	}
+
+	userContent := "---\ncustom: bar\ntitle: user-title\n---\n\n# Heading"
+	if err := store.UpsertContent(page, userContent); err != nil {
+		t.Fatalf("UpsertContent: %v", err)
+	}
+
+	path := filepath.Join(tmp, "root", "p.md")
+	raw := string(mustRead(t, path))
+	fm, body, has, err := markdown.ParseFrontmatter(raw)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	if !has {
+		t.Fatalf("expected system frontmatter in written file")
+	}
+	// System frontmatter must use the page's managed identity, not the user-supplied value.
+	if fm.LeafWikiID != "p1" {
+		t.Fatalf("expected managed leafwiki_id, got %q", fm.LeafWikiID)
+	}
+	// User-supplied keys must NOT be extracted into ExtraFields.
+	if fm.ExtraFields["custom"] != nil {
+		t.Fatalf("expected custom to stay as body text, got ExtraField %#v", fm.ExtraFields["custom"])
+	}
+	if fm.ExtraFields["title"] != nil {
+		t.Fatalf("expected title to stay as body text, got ExtraField %#v", fm.ExtraFields["title"])
+	}
+	// The full user content (including the frontmatter-like block) must be in the body.
+	if !strings.Contains(body, "custom: bar") {
+		t.Fatalf("expected user frontmatter block preserved in body, got: %q", body)
+	}
+	if !strings.Contains(body, "# Heading") {
+		t.Fatalf("expected heading in body, got: %q", body)
+	}
+}
+
+// UpsertContentPreservingFrontmatter is used by the importer: it parses
+// frontmatter from the incoming content and merges extra fields into the
+// system-managed frontmatter block.
+func TestNodeStore_UpsertContentPreservingFrontmatter_MergesExtrasIntoWrittenFrontmatter(t *testing.T) {
+	tmp := t.TempDir()
+	store := NewNodeStore(tmp)
+
+	root := &PageNode{ID: "root", Slug: "root", Title: "root", Kind: NodeKindSection}
+	page := &PageNode{ID: "p1", Slug: "p", Title: "My Page", Kind: NodeKindPage, Parent: root}
+
+	if err := store.CreatePage(root, page); err != nil {
+		t.Fatalf("CreatePage: %v", err)
+	}
+
+	rawContent := "---\naliases:\n  - alpha\ncustom_key: keep-me\nleafwiki_id: source-id\nleafwiki_title: Source Title\ntitle: Imported Title\n---\n\n# Imported Title\nBody"
+	if err := store.UpsertContentPreservingFrontmatter(page, rawContent); err != nil {
+		t.Fatalf("UpsertContentPreservingFrontmatter: %v", err)
+	}
+
+	path := filepath.Join(tmp, "root", "p.md")
+	raw := string(mustRead(t, path))
+	fm, body, has, err := markdown.ParseFrontmatter(raw)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	if !has {
 		t.Fatalf("expected frontmatter in written file")
 	}
 	if body != "\n# Imported Title\nBody" {
@@ -432,7 +529,7 @@ func TestNodeStore_UpsertContent_RawFrontmatter_MergesExtrasIntoWrittenFrontmatt
 		t.Fatalf("expected custom_key to be preserved, got %#v", got)
 	}
 	if got := fm.ExtraFields["title"]; got != "Imported Title" {
-		t.Fatalf("expected title to be preserved, got %#v", got)
+		t.Fatalf("expected title extra field to be preserved, got %#v", got)
 	}
 	aliases, ok := fm.ExtraFields["aliases"].([]interface{})
 	if !ok || len(aliases) != 1 || aliases[0] != "alpha" {
@@ -441,14 +538,8 @@ func TestNodeStore_UpsertContent_RawFrontmatter_MergesExtrasIntoWrittenFrontmatt
 	if strings.Contains(raw, "leafwiki_id: source-id") {
 		t.Fatalf("expected source leafwiki_id to be dropped, got: %q", raw)
 	}
-	if strings.Contains(raw, "leafwiki_title: Source Title") {
-		t.Fatalf("expected source leafwiki_title to be dropped, got: %q", raw)
-	}
 	if fm.LeafWikiID != "p1" {
 		t.Fatalf("expected managed leafwiki_id, got %q", fm.LeafWikiID)
-	}
-	if fm.LeafWikiTitle != "My Page" {
-		t.Fatalf("expected managed leafwiki_title, got %q", fm.LeafWikiTitle)
 	}
 }
 

--- a/internal/core/tree/tree_service.go
+++ b/internal/core/tree/tree_service.go
@@ -591,7 +591,7 @@ func (t *TreeService) DeleteNode(userID string, id string, recursive bool, expec
 }
 
 // UpdateNode updates a node (page/section) in the tree and syncs disk state via NodeStore.
-func (t *TreeService) UpdateNode(userID string, id string, title string, slug string, content *string, expectedVersion string) error {
+func (t *TreeService) UpdateNode(userID string, id string, title string, slug string, content *string, expectedVersion string, fromImport bool) error {
 	return t.withLockedTree(func() error {
 		if t.tree == nil {
 			return ErrTreeNotLoaded
@@ -618,8 +618,14 @@ func (t *TreeService) UpdateNode(userID string, id string, title string, slug st
 		// Content update?
 		if content != nil {
 			t.log.Info("updating node content", "nodeID", node.ID)
-			if err := t.store.UpsertContent(node, *content); err != nil {
-				return fmt.Errorf("could not upsert content: %w", err)
+			var upsertErr error
+			if fromImport {
+				upsertErr = t.store.UpsertContentPreservingFrontmatter(node, *content)
+			} else {
+				upsertErr = t.store.UpsertContent(node, *content)
+			}
+			if upsertErr != nil {
+				return fmt.Errorf("could not upsert content: %w", upsertErr)
 			}
 		}
 

--- a/internal/core/tree/tree_service_test.go
+++ b/internal/core/tree/tree_service_test.go
@@ -3035,7 +3035,7 @@ func TestTreeService_GetPages_PreservesOrderAndAlignsErrors(t *testing.T) {
 	}
 }
 
-func TestTreeService_BulkUpdateContent_PartialFailure_RollsBackFailedMetadata(t *testing.T) {
+func TestTreeService_BulkUpdateContent_TreatsFrontmatterLikeInputAsBody(t *testing.T) {
 	svc, _ := newLoadedService(t)
 
 	firstID, err := svc.CreateNode("system", nil, "First", "first", ptrKind(NodeKindPage))

--- a/internal/core/tree/tree_service_test.go
+++ b/internal/core/tree/tree_service_test.go
@@ -253,7 +253,7 @@ func TestTreeService_TreeHash_ChangesWhenTreeChanges(t *testing.T) {
 		t.Fatalf("expected hash to change after create")
 	}
 
-	if err := svc.UpdateNode("system", *pageID, "Welcome 2", "welcome", nil, VersionUnchecked); err != nil {
+	if err := svc.UpdateNode("system", *pageID, "Welcome 2", "welcome", nil, VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode failed: %v", err)
 	}
 	afterUpdate := svc.TreeHash()
@@ -568,7 +568,7 @@ func TestTreeService_UpdateNode_TitleOnly_SyncsFrontmatterIfFileExists(t *testin
 	mustStat(t, p)
 
 	// Update title only: content=nil, slug unchanged
-	if err := svc.UpdateNode("system", *id, "Documentation", "docs", nil, VersionUnchecked); err != nil {
+	if err := svc.UpdateNode("system", *id, "Documentation", "docs", nil, VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode failed: %v", err)
 	}
 
@@ -600,7 +600,7 @@ func TestTreeService_UpdateNode_SlugRename_RenamesOnDisk(t *testing.T) {
 	mustStat(t, oldPath)
 
 	newSlug := "documentation"
-	if err := svc.UpdateNode("system", *id, "Docs", newSlug, nil, VersionUnchecked); err != nil {
+	if err := svc.UpdateNode("system", *id, "Docs", newSlug, nil, VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode failed: %v", err)
 	}
 
@@ -621,7 +621,7 @@ func TestTreeService_UpdateNode_RejectsCaseInsensitiveSlugConflict(t *testing.T)
 		t.Fatalf("CreateNode second failed: %v", err)
 	}
 
-	err = svc.UpdateNode("system", *secondID, "Beta", "alpha", nil, VersionUnchecked)
+	err = svc.UpdateNode("system", *secondID, "Beta", "alpha", nil, VersionUnchecked, false)
 	if !errors.Is(err, ErrPageAlreadyExists) {
 		t.Fatalf("expected ErrPageAlreadyExists, got %v", err)
 	}
@@ -651,7 +651,7 @@ func TestTreeService_UpdateNode_SectionToPage_DisallowedWithChildren(t *testing.
 	}
 
 	// Now parent is section with children, attempt to convert back to page
-	err = svc.UpdateNode("system", *parentID, "Docs", "docs", nil, VersionUnchecked)
+	err = svc.UpdateNode("system", *parentID, "Docs", "docs", nil, VersionUnchecked, false)
 	if err == nil {
 		t.Fatalf("expected error converting section->page with children")
 	}
@@ -1338,7 +1338,7 @@ func TestTreeService_FindPageByRoutePath_ReturnsContent(t *testing.T) {
 	// Update specs content
 	specsNode := svc.GetTree().Children[0].Children[0].Children[0]
 	body := "# Specs\nHello"
-	if err := svc.UpdateNode("system", specsNode.ID, "Specs", "specs", &body, VersionUnchecked); err != nil {
+	if err := svc.UpdateNode("system", specsNode.ID, "Specs", "specs", &body, VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode content failed: %v", err)
 	}
 
@@ -1454,7 +1454,7 @@ func TestTreeService_LookupPagePath_ReflectsSlugRename(t *testing.T) {
 		t.Fatalf("CreateNode guide failed: %v", err)
 	}
 
-	if err := svc.UpdateNode("system", *id, "Documentation", "documentation", nil, VersionUnchecked); err != nil {
+	if err := svc.UpdateNode("system", *id, "Documentation", "documentation", nil, VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode failed: %v", err)
 	}
 
@@ -1525,7 +1525,7 @@ func TestTreeService_ResolvePermalinkTarget_ReflectsRenameAndMove(t *testing.T) 
 		t.Fatalf("CreateNode archive failed: %v", err)
 	}
 
-	if err := svc.UpdateNode("system", *guideID, "User Guide", "user-guide", nil, VersionUnchecked); err != nil {
+	if err := svc.UpdateNode("system", *guideID, "User Guide", "user-guide", nil, VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode guide failed: %v", err)
 	}
 	if err := svc.MoveNode("system", *guideID, *archiveID, VersionUnchecked); err != nil {
@@ -3051,14 +3051,9 @@ func TestTreeService_BulkUpdateContent_PartialFailure_RollsBackFailedMetadata(t 
 	if err != nil {
 		t.Fatalf("GetPage(first before) failed: %v", err)
 	}
-	beforeSecond, err := svc.GetPage(*secondID)
-	if err != nil {
-		t.Fatalf("GetPage(second before) failed: %v", err)
-	}
-	beforeSecondVersion := beforeSecond.Version()
-	beforeSecondUpdatedAt := beforeSecond.Metadata.UpdatedAt
-	beforeSecondAuthor := beforeSecond.Metadata.LastAuthorID
 
+	// Content that looks like invalid YAML frontmatter is now stored as plain
+	// body text — UpsertContent no longer parses frontmatter from UI content.
 	errs := svc.BulkUpdateContent("bulk-user", []BulkContentUpdate{
 		{ID: *firstID, Content: "updated first"},
 		{ID: *secondID, Content: "---\ninvalid: [\n---\nbody"},
@@ -3071,11 +3066,9 @@ func TestTreeService_BulkUpdateContent_PartialFailure_RollsBackFailedMetadata(t 
 	if errs[0] != nil {
 		t.Fatalf("expected index 0 success, got %v", errs[0])
 	}
-	if errs[1] == nil {
-		t.Fatal("expected index 1 parse failure, got nil")
-	}
-	if !strings.Contains(errs[1].Error(), "could not parse markdown content") {
-		t.Fatalf("expected parse failure at index 1, got %v", errs[1])
+	// Index 1 now succeeds: frontmatter-like content is treated as plain body.
+	if errs[1] != nil {
+		t.Fatalf("expected index 1 success (plain body), got %v", errs[1])
 	}
 	if !errors.Is(errs[2], ErrPageNotFound) {
 		t.Fatalf("expected ErrPageNotFound at index 2, got %v", errs[2])
@@ -3099,17 +3092,9 @@ func TestTreeService_BulkUpdateContent_PartialFailure_RollsBackFailedMetadata(t 
 	if err != nil {
 		t.Fatalf("GetPage(second after) failed: %v", err)
 	}
-	if afterSecond.Content != beforeSecond.Content {
-		t.Fatalf("expected second content unchanged, before=%q after=%q", beforeSecond.Content, afterSecond.Content)
-	}
-	if afterSecond.Version() != beforeSecondVersion {
-		t.Fatalf("expected second version unchanged, before=%q after=%q", beforeSecondVersion, afterSecond.Version())
-	}
-	if !afterSecond.Metadata.UpdatedAt.Equal(beforeSecondUpdatedAt) {
-		t.Fatalf("expected second UpdatedAt restored, before=%s after=%s", beforeSecondUpdatedAt, afterSecond.Metadata.UpdatedAt)
-	}
-	if afterSecond.Metadata.LastAuthorID != beforeSecondAuthor {
-		t.Fatalf("expected second LastAuthorID restored, before=%q after=%q", beforeSecondAuthor, afterSecond.Metadata.LastAuthorID)
+	// The "invalid YAML" block is now stored verbatim as body content.
+	if !strings.Contains(afterSecond.Content, "invalid: [") {
+		t.Fatalf("expected second content to contain plain body text, got %q", afterSecond.Content)
 	}
 }
 
@@ -3125,12 +3110,12 @@ func TestTreeService_UpdateNode_StaleVersion_ReturnsErrVersionConflict(t *testin
 	currentVersion := node.Version()
 
 	// First update succeeds — advances the version.
-	if err := svc.UpdateNode("system", *id, "Page v2", "page", nil, currentVersion); err != nil {
+	if err := svc.UpdateNode("system", *id, "Page v2", "page", nil, currentVersion, false); err != nil {
 		t.Fatalf("first UpdateNode failed: %v", err)
 	}
 
 	// Second update with the same (now stale) version must fail.
-	err := svc.UpdateNode("system", *id, "Page v3", "page", nil, currentVersion)
+	err := svc.UpdateNode("system", *id, "Page v3", "page", nil, currentVersion, false)
 	if !errors.Is(err, ErrVersionConflict) {
 		t.Fatalf("expected ErrVersionConflict, got %v", err)
 	}
@@ -3140,7 +3125,7 @@ func TestTreeService_UpdateNode_MissingVersion_ReturnsErrVersionRequired(t *test
 	svc, _ := newLoadedService(t)
 	id, _ := svc.CreateNode("system", nil, "Page", "page", ptrKind(NodeKindPage))
 
-	err := svc.UpdateNode("system", *id, "Page v2", "page", nil, "")
+	err := svc.UpdateNode("system", *id, "Page v2", "page", nil, "", false)
 	if !errors.Is(err, ErrVersionRequired) {
 		t.Fatalf("expected ErrVersionRequired, got %v", err)
 	}
@@ -3154,7 +3139,7 @@ func TestTreeService_DeleteNode_StaleVersion_ReturnsErrVersionConflict(t *testin
 	staleVersion := node.Version()
 
 	// Advance the version via an update.
-	if err := svc.UpdateNode("system", *id, "Page v2", "page", nil, staleVersion); err != nil {
+	if err := svc.UpdateNode("system", *id, "Page v2", "page", nil, staleVersion, false); err != nil {
 		t.Fatalf("UpdateNode failed: %v", err)
 	}
 
@@ -3183,7 +3168,7 @@ func TestTreeService_MoveNode_StaleVersion_ReturnsErrVersionConflict(t *testing.
 	staleVersion := node.Version()
 
 	// Advance the version.
-	if err := svc.UpdateNode("system", *moveID, "Move v2", "move", nil, staleVersion); err != nil {
+	if err := svc.UpdateNode("system", *moveID, "Move v2", "move", nil, staleVersion, false); err != nil {
 		t.Fatalf("UpdateNode failed: %v", err)
 	}
 
@@ -3212,7 +3197,7 @@ func TestTreeService_ConvertNode_StaleVersion_ReturnsErrVersionConflict(t *testi
 	staleVersion := node.Version()
 
 	// Advance the version.
-	if err := svc.UpdateNode("system", *id, "Page v2", "page", nil, staleVersion); err != nil {
+	if err := svc.UpdateNode("system", *id, "Page v2", "page", nil, staleVersion, false); err != nil {
 		t.Fatalf("UpdateNode failed: %v", err)
 	}
 
@@ -3237,10 +3222,10 @@ func TestTreeService_VersionUnchecked_BypassesVersionCheck(t *testing.T) {
 	id, _ := svc.CreateNode("system", nil, "Page", "page", ptrKind(NodeKindPage))
 
 	// VersionUnchecked must always succeed regardless of actual node version.
-	if err := svc.UpdateNode("system", *id, "Page v2", "page", nil, VersionUnchecked); err != nil {
+	if err := svc.UpdateNode("system", *id, "Page v2", "page", nil, VersionUnchecked, false); err != nil {
 		t.Fatalf("expected VersionUnchecked to bypass check, got: %v", err)
 	}
-	if err := svc.UpdateNode("system", *id, "Page v3", "page", nil, VersionUnchecked); err != nil {
+	if err := svc.UpdateNode("system", *id, "Page v3", "page", nil, VersionUnchecked, false); err != nil {
 		t.Fatalf("expected VersionUnchecked to bypass check on second call, got: %v", err)
 	}
 }

--- a/internal/links/link_service.go
+++ b/internal/links/link_service.go
@@ -68,6 +68,38 @@ func (b *LinkService) GetRefactorMatchesForPrefix(oldPrefix string) ([]RefactorL
 	return b.store.GetRefactorMatchesForPrefix(oldPrefix)
 }
 
+func (b *LinkService) GetRefactorSourcePageIDsForPrefix(oldPrefix string) ([]string, error) {
+	return b.store.GetRefactorSourcePageIDsForPrefix(oldPrefix)
+}
+
+func (b *LinkService) UpdateRewrittenLinksAndHealForPages(pages []*tree.Page, rules []RewriteRule) error {
+	outgoingByPageID, err := b.store.GetOutgoingLinksForPages(pageIDsForPages(pages))
+	if err != nil {
+		return err
+	}
+
+	updates := make([]PageLinkUpdate, 0, len(pages))
+	for _, page := range pages {
+		if page == nil {
+			continue
+		}
+		pagePath := normalizeWikiPath(page.CalculatePath())
+		targets := rewriteResolvedTargets(pagePath, outgoingByPageID[page.ID], rules, b.treeService)
+		updates = append(updates, PageLinkUpdate{
+			FromPageID: page.ID,
+			FromTitle:  page.Title,
+			ToPath:     pagePath,
+			Targets:    targets,
+		})
+	}
+
+	if len(updates) == 0 {
+		return nil
+	}
+
+	return b.store.ReplaceLinksAndHeal(updates)
+}
+
 func (b *LinkService) GetLinkStatusForPage(pageID string, pagePath string) (*LinkStatusResult, error) {
 	pagePath = normalizeWikiPath(pagePath)
 
@@ -186,4 +218,32 @@ func (b *LinkService) Close() error {
 		return nil
 	}
 	return b.store.Close()
+}
+
+func pageIDsForPages(pages []*tree.Page) []string {
+	ids := make([]string, 0, len(pages))
+	for _, page := range pages {
+		if page == nil {
+			continue
+		}
+		ids = append(ids, page.ID)
+	}
+	return ids
+}
+
+func rewriteResolvedTargets(currentPath string, outgoings []Outgoing, rules []RewriteRule, treeService *tree.TreeService) []TargetLink {
+	if len(outgoings) == 0 {
+		return nil
+	}
+
+	paths := make([]string, 0, len(outgoings))
+	for _, outgoing := range outgoings {
+		targetPath := normalizeWikiPath(outgoing.ToPath)
+		if rewritten, ok := applyRewriteRules(targetPath, rules); ok {
+			targetPath = rewritten
+		}
+		paths = append(paths, targetPath)
+	}
+
+	return resolveTargetLinks(treeService, currentPath, paths)
 }

--- a/internal/links/link_service_test.go
+++ b/internal/links/link_service_test.go
@@ -269,7 +269,7 @@ func createSimpleLinkedPages(t *testing.T, ts *tree.TreeService) (pageAID, pageB
 		t.Fatalf("GetPage a failed: %v", err)
 	}
 	contentA := "Link to B: [Go to B](/b)"
-	if err := ts.UpdateNode("system", aPage.ID, aPage.Title, aPage.Slug, &contentA, tree.VersionUnchecked); err != nil {
+	if err := ts.UpdateNode("system", aPage.ID, aPage.Title, aPage.Slug, &contentA, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdatePage a failed: %v", err)
 	}
 
@@ -278,7 +278,7 @@ func createSimpleLinkedPages(t *testing.T, ts *tree.TreeService) (pageAID, pageB
 		t.Fatalf("GetPage b failed: %v", err)
 	}
 	contentB := "# Page B\nNo outgoing links."
-	if err := ts.UpdateNode("system", bPage.ID, bPage.Title, bPage.Slug, &contentB, tree.VersionUnchecked); err != nil {
+	if err := ts.UpdateNode("system", bPage.ID, bPage.Title, bPage.Slug, &contentB, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdatePage b failed: %v", err)
 	}
 
@@ -327,7 +327,7 @@ func TestLinkService_IndexAllPages_ReplacesExistingLinks(t *testing.T) {
 		t.Fatalf("GetPage a failed: %v", err)
 	}
 	var noLinks = "No more links."
-	if err := ts.UpdateNode("system", aPage.ID, aPage.Title, aPage.Slug, &noLinks, tree.VersionUnchecked); err != nil {
+	if err := ts.UpdateNode("system", aPage.ID, aPage.Title, aPage.Slug, &noLinks, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdatePage a failed: %v", err)
 	}
 
@@ -452,7 +452,7 @@ func TestLinkService_GetOutgoingLinksForPage_NoOutgoings(t *testing.T) {
 	}
 
 	var noLinks = "Just some text, no links."
-	if err := ts.UpdateNode("system", page.ID, page.Title, page.Slug, &noLinks, tree.VersionUnchecked); err != nil {
+	if err := ts.UpdateNode("system", page.ID, page.Title, page.Slug, &noLinks, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode lonely failed: %v", err)
 	}
 
@@ -494,7 +494,7 @@ func TestLinkService_IndexAllPages_IgnoresAssetLinksInOutgoingAndBrokenSets(t *t
 		t.Fatalf("GetPage a failed: %v", err)
 	}
 	contentA := "Asset: [Manual](/assets/abc/manual.pdf)\nPage: [Go](/b)"
-	if err := ts.UpdateNode("system", pageA.ID, pageA.Title, pageA.Slug, &contentA, tree.VersionUnchecked); err != nil {
+	if err := ts.UpdateNode("system", pageA.ID, pageA.Title, pageA.Slug, &contentA, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode a failed: %v", err)
 	}
 
@@ -587,7 +587,7 @@ func TestLinkService_LateCreatedTarget_BecomesResolvedAfterReindex(t *testing.T)
 		t.Fatalf("GetPage a failed: %v", err)
 	}
 	var linkToB = "Link to B: [Go](/b)"
-	if err := ts.UpdateNode("system", aPage.ID, aPage.Title, aPage.Slug, &linkToB, tree.VersionUnchecked); err != nil {
+	if err := ts.UpdateNode("system", aPage.ID, aPage.Title, aPage.Slug, &linkToB, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode a failed: %v", err)
 	}
 
@@ -623,7 +623,7 @@ func TestLinkService_LateCreatedTarget_BecomesResolvedAfterReindex(t *testing.T)
 		t.Fatalf("GetPage b failed: %v", err)
 	}
 	var pageBContent = "# Page B"
-	if err := ts.UpdateNode("system", bPage.ID, bPage.Title, bPage.Slug, &pageBContent, tree.VersionUnchecked); err != nil {
+	if err := ts.UpdateNode("system", bPage.ID, bPage.Title, bPage.Slug, &pageBContent, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode b failed: %v", err)
 	}
 
@@ -674,7 +674,7 @@ func TestLinkService_HealOnPageCreate_ResolvesBrokenLinksWithoutReindex(t *testi
 		t.Fatalf("GetPage A failed: %v", err)
 	}
 	var linkToB = "Link to B: [Go](/b)"
-	if err := ts.UpdateNode("system", pageA.ID, pageA.Title, pageA.Slug, &linkToB, tree.VersionUnchecked); err != nil {
+	if err := ts.UpdateNode("system", pageA.ID, pageA.Title, pageA.Slug, &linkToB, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode A failed: %v", err)
 	}
 
@@ -773,7 +773,7 @@ func TestLinksStore_GetBrokenIncomingForPath_ReturnsBrokenLinks(t *testing.T) {
 		t.Fatalf("GetPage A failed: %v", err)
 	}
 	var linkToMissing = "Link: [Missing](/nonexistent)"
-	if err := ts.UpdateNode("system", pageA.ID, pageA.Title, pageA.Slug, &linkToMissing, tree.VersionUnchecked); err != nil {
+	if err := ts.UpdateNode("system", pageA.ID, pageA.Title, pageA.Slug, &linkToMissing, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode A failed: %v", err)
 	}
 
@@ -781,7 +781,7 @@ func TestLinksStore_GetBrokenIncomingForPath_ReturnsBrokenLinks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetPage B failed: %v", err)
 	}
-	if err := ts.UpdateNode("system", pageB.ID, pageB.Title, pageB.Slug, &linkToMissing, tree.VersionUnchecked); err != nil {
+	if err := ts.UpdateNode("system", pageB.ID, pageB.Title, pageB.Slug, &linkToMissing, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode B failed: %v", err)
 	}
 
@@ -791,7 +791,7 @@ func TestLinksStore_GetBrokenIncomingForPath_ReturnsBrokenLinks(t *testing.T) {
 		t.Fatalf("GetPage C failed: %v", err)
 	}
 	var linkToOther = "Link: [Other](/other-missing)"
-	if err := ts.UpdateNode("system", pageC.ID, pageC.Title, pageC.Slug, &linkToOther, tree.VersionUnchecked); err != nil {
+	if err := ts.UpdateNode("system", pageC.ID, pageC.Title, pageC.Slug, &linkToOther, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode C failed: %v", err)
 	}
 
@@ -857,7 +857,7 @@ func TestLinksStore_GetBrokenIncomingForPath_FiltersByPath(t *testing.T) {
 		t.Fatalf("GetPage A failed: %v", err)
 	}
 	var linkToMissing1 = "Link: [Missing1](/missing1)"
-	if err := ts.UpdateNode("system", pageA.ID, pageA.Title, pageA.Slug, &linkToMissing1, tree.VersionUnchecked); err != nil {
+	if err := ts.UpdateNode("system", pageA.ID, pageA.Title, pageA.Slug, &linkToMissing1, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode A failed: %v", err)
 	}
 
@@ -867,7 +867,7 @@ func TestLinksStore_GetBrokenIncomingForPath_FiltersByPath(t *testing.T) {
 		t.Fatalf("GetPage B failed: %v", err)
 	}
 	var linkToMissing2 = "Link: [Missing2](/missing2)"
-	if err := ts.UpdateNode("system", pageB.ID, pageB.Title, pageB.Slug, &linkToMissing2, tree.VersionUnchecked); err != nil {
+	if err := ts.UpdateNode("system", pageB.ID, pageB.Title, pageB.Slug, &linkToMissing2, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode B failed: %v", err)
 	}
 
@@ -922,7 +922,7 @@ func TestLinksStore_GetBrokenIncomingForPath_EmptyWhenNoBrokenLinks(t *testing.T
 		t.Fatalf("GetPage A failed: %v", err)
 	}
 	var linkToB = "Link: [To B](/b)"
-	if err := ts.UpdateNode("system", pageA.ID, pageA.Title, pageA.Slug, &linkToB, tree.VersionUnchecked); err != nil {
+	if err := ts.UpdateNode("system", pageA.ID, pageA.Title, pageA.Slug, &linkToB, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode A failed: %v", err)
 	}
 
@@ -978,7 +978,7 @@ func TestLinksStore_GetBrokenIncomingForPath_OrdersByFromTitle(t *testing.T) {
 			t.Fatalf("GetPage(%s) failed: %v", id, err)
 		}
 		var linkToMissing = "Link: [Missing](/missing)"
-		if err := ts.UpdateNode("system", page.ID, page.Title, page.Slug, &linkToMissing, tree.VersionUnchecked); err != nil {
+		if err := ts.UpdateNode("system", page.ID, page.Title, page.Slug, &linkToMissing, tree.VersionUnchecked, false); err != nil {
 			t.Fatalf("UpdateNode(%s) failed: %v", id, err)
 		}
 	}
@@ -1021,7 +1021,7 @@ func TestLinksStore_GetBrokenIncomingForPath_OnlyReturnsBrokenNotResolved(t *tes
 		t.Fatalf("GetPage A failed: %v", err)
 	}
 	var linkToB = "Link: [To B](/b)"
-	if err := ts.UpdateNode("system", pageA.ID, pageA.Title, pageA.Slug, &linkToB, tree.VersionUnchecked); err != nil {
+	if err := ts.UpdateNode("system", pageA.ID, pageA.Title, pageA.Slug, &linkToB, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode A failed: %v", err)
 	}
 
@@ -1051,7 +1051,7 @@ func TestLinksStore_GetBrokenIncomingForPath_OnlyReturnsBrokenNotResolved(t *tes
 		t.Fatalf("GetPage B failed: %v", err)
 	}
 	var contentB = "# Page B"
-	if err := ts.UpdateNode("system", pageB.ID, pageB.Title, pageB.Slug, &contentB, tree.VersionUnchecked); err != nil {
+	if err := ts.UpdateNode("system", pageB.ID, pageB.Title, pageB.Slug, &contentB, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode B failed: %v", err)
 	}
 
@@ -1102,7 +1102,7 @@ func TestLinkService_UpdateLinksAndHealForPages_UpdatesAndHealsMultiplePages(t *
 		t.Fatalf("GetPage A failed: %v", err)
 	}
 	contentA := "Link: [B](/b)"
-	if err := ts.UpdateNode("system", pageA.ID, pageA.Title, pageA.Slug, &contentA, tree.VersionUnchecked); err != nil {
+	if err := ts.UpdateNode("system", pageA.ID, pageA.Title, pageA.Slug, &contentA, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode A failed: %v", err)
 	}
 
@@ -1111,7 +1111,7 @@ func TestLinkService_UpdateLinksAndHealForPages_UpdatesAndHealsMultiplePages(t *
 		t.Fatalf("GetPage C failed: %v", err)
 	}
 	contentC := "Link: [D](/d)"
-	if err := ts.UpdateNode("system", pageC.ID, pageC.Title, pageC.Slug, &contentC, tree.VersionUnchecked); err != nil {
+	if err := ts.UpdateNode("system", pageC.ID, pageC.Title, pageC.Slug, &contentC, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode C failed: %v", err)
 	}
 
@@ -1190,7 +1190,7 @@ func TestLinkService_UpdateLinksAndHealForPages_ReindexesOutgoingForSourcePages(
 		t.Fatalf("GetPage source failed: %v", err)
 	}
 	oldContent := "Link: [Old](/old-target)"
-	if err := ts.UpdateNode("system", source.ID, source.Title, source.Slug, &oldContent, tree.VersionUnchecked); err != nil {
+	if err := ts.UpdateNode("system", source.ID, source.Title, source.Slug, &oldContent, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode source failed: %v", err)
 	}
 
@@ -1205,7 +1205,7 @@ func TestLinkService_UpdateLinksAndHealForPages_ReindexesOutgoingForSourcePages(
 	newTargetID := *newTargetIDPtr
 
 	updatedContent := "Link: [New](/new-target)"
-	if err := ts.UpdateNode("system", source.ID, source.Title, source.Slug, &updatedContent, tree.VersionUnchecked); err != nil {
+	if err := ts.UpdateNode("system", source.ID, source.Title, source.Slug, &updatedContent, tree.VersionUnchecked, false); err != nil {
 		t.Fatalf("UpdateNode source (rewrite) failed: %v", err)
 	}
 

--- a/internal/links/links_store.go
+++ b/internal/links/links_store.go
@@ -19,6 +19,8 @@ type LinksStore struct {
 	db         *sql.DB
 }
 
+const maxOutgoingLinksQueryArgs = 900
+
 type PageLinkUpdate struct {
 	FromPageID string
 	FromTitle  string
@@ -375,6 +377,22 @@ func (s *LinksStore) GetOutgoingLinksForPages(pageIDs []string) (map[string][]Ou
 		return map[string][]Outgoing{}, nil
 	}
 
+	outgoingByPageID := make(map[string][]Outgoing, len(pageIDs))
+	for start := 0; start < len(pageIDs); start += maxOutgoingLinksQueryArgs {
+		end := start + maxOutgoingLinksQueryArgs
+		if end > len(pageIDs) {
+			end = len(pageIDs)
+		}
+
+		if err := s.appendOutgoingLinksForPageBatch(outgoingByPageID, pageIDs[start:end]); err != nil {
+			return nil, err
+		}
+	}
+
+	return outgoingByPageID, nil
+}
+
+func (s *LinksStore) appendOutgoingLinksForPageBatch(outgoingByPageID map[string][]Outgoing, pageIDs []string) error {
 	placeholders := strings.TrimRight(strings.Repeat("?,", len(pageIDs)), ",")
 	args := make([]any, 0, len(pageIDs))
 	for _, pageID := range pageIDs {
@@ -388,7 +406,7 @@ func (s *LinksStore) GetOutgoingLinksForPages(pageIDs []string) (map[string][]Ou
         ORDER BY from_page_id
     `, args...)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer func() {
 		if err := rows.Close(); err != nil {
@@ -396,14 +414,13 @@ func (s *LinksStore) GetOutgoingLinksForPages(pageIDs []string) (map[string][]Ou
 		}
 	}()
 
-	outgoingByPageID := make(map[string][]Outgoing, len(pageIDs))
 	for rows.Next() {
 		var outgoing Outgoing
 		var toPageID sql.NullString
 		var brokenInt int
 
 		if err := rows.Scan(&outgoing.FromPageID, &toPageID, &outgoing.ToPath, &outgoing.FromTitle, &brokenInt); err != nil {
-			return nil, err
+			return err
 		}
 
 		if toPageID.Valid {
@@ -412,11 +429,8 @@ func (s *LinksStore) GetOutgoingLinksForPages(pageIDs []string) (map[string][]Ou
 		outgoing.Broken = brokenInt != 0
 		outgoingByPageID[outgoing.FromPageID] = append(outgoingByPageID[outgoing.FromPageID], outgoing)
 	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
 
-	return outgoingByPageID, nil
+	return rows.Err()
 }
 
 func (s *LinksStore) GetRefactorMatchesForPrefix(oldPrefix string) ([]RefactorLinkMatch, error) {

--- a/internal/links/links_store.go
+++ b/internal/links/links_store.go
@@ -82,6 +82,7 @@ func (s *LinksStore) ensureSchema() error {
 
 		CREATE INDEX IF NOT EXISTS idx_links_to_page_id ON links(to_page_id);
 		CREATE INDEX IF NOT EXISTS idx_links_to_path    ON links(to_path);
+		CREATE INDEX IF NOT EXISTS idx_links_to_path_from_page_id ON links(to_path, from_page_id);
 		CREATE INDEX IF NOT EXISTS idx_links_broken     ON links(broken);
 	`)
 	return err
@@ -366,6 +367,58 @@ func (s *LinksStore) GetOutgoingLinksForPage(pageID string) ([]Outgoing, error) 
 	return outgoings, nil
 }
 
+func (s *LinksStore) GetOutgoingLinksForPages(pageIDs []string) (map[string][]Outgoing, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(pageIDs) == 0 {
+		return map[string][]Outgoing{}, nil
+	}
+
+	placeholders := strings.TrimRight(strings.Repeat("?,", len(pageIDs)), ",")
+	args := make([]any, 0, len(pageIDs))
+	for _, pageID := range pageIDs {
+		args = append(args, pageID)
+	}
+
+	rows, err := s.db.Query(`
+        SELECT from_page_id, to_page_id, to_path, from_title, broken
+        FROM links
+        WHERE from_page_id IN (`+placeholders+`)
+        ORDER BY from_page_id
+    `, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Default().Error("could not close rows", "error", err)
+		}
+	}()
+
+	outgoingByPageID := make(map[string][]Outgoing, len(pageIDs))
+	for rows.Next() {
+		var outgoing Outgoing
+		var toPageID sql.NullString
+		var brokenInt int
+
+		if err := rows.Scan(&outgoing.FromPageID, &toPageID, &outgoing.ToPath, &outgoing.FromTitle, &brokenInt); err != nil {
+			return nil, err
+		}
+
+		if toPageID.Valid {
+			outgoing.ToPageID = toPageID.String
+		}
+		outgoing.Broken = brokenInt != 0
+		outgoingByPageID[outgoing.FromPageID] = append(outgoingByPageID[outgoing.FromPageID], outgoing)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return outgoingByPageID, nil
+}
+
 func (s *LinksStore) GetRefactorMatchesForPrefix(oldPrefix string) ([]RefactorLinkMatch, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -374,7 +427,6 @@ func (s *LinksStore) GetRefactorMatchesForPrefix(oldPrefix string) ([]RefactorLi
 		SELECT from_page_id, from_title, to_path, broken
 		FROM links
 		WHERE to_path = ? OR to_path LIKE ?
-		ORDER BY from_title, to_path
 	`, oldPrefix, oldPrefix+"/%")
 	if err != nil {
 		return nil, err
@@ -400,6 +452,39 @@ func (s *LinksStore) GetRefactorMatchesForPrefix(oldPrefix string) ([]RefactorLi
 	}
 
 	return matches, nil
+}
+
+func (s *LinksStore) GetRefactorSourcePageIDsForPrefix(oldPrefix string) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	rows, err := s.db.Query(`
+		SELECT DISTINCT from_page_id
+		FROM links
+		WHERE to_path = ? OR to_path LIKE ?
+	`, oldPrefix, oldPrefix+"/%")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Default().Error("could not close rows", "error", err)
+		}
+	}()
+
+	var pageIDs []string
+	for rows.Next() {
+		var pageID string
+		if err := rows.Scan(&pageID); err != nil {
+			return nil, err
+		}
+		pageIDs = append(pageIDs, pageID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return pageIDs, nil
 }
 
 func (s *LinksStore) GetBrokenIncomingForPath(toPath string) ([]Backlink, error) {

--- a/internal/links/links_store_test.go
+++ b/internal/links/links_store_test.go
@@ -1,6 +1,7 @@
 package links
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,5 +28,47 @@ func TestLinksDatabasePath_WindowsPath(t *testing.T) {
 	want := `C:/wiki/data/links.db`
 	if got != want {
 		t.Fatalf("path = %q, want %q", got, want)
+	}
+}
+
+func TestLinksStore_GetOutgoingLinksForPages_BatchesLargeInputs(t *testing.T) {
+	tmp := t.TempDir()
+	store, err := NewLinksStore(tmp)
+	if err != nil {
+		t.Fatalf("NewLinksStore err: %v", err)
+	}
+	defer test_utils.WrapCloseWithErrorCheck(store.Close, t)
+
+	pageIDs := make([]string, 0, maxOutgoingLinksQueryArgs+5)
+	for i := 0; i < maxOutgoingLinksQueryArgs+5; i++ {
+		pageID := fmt.Sprintf("page-%d", i)
+		pageIDs = append(pageIDs, pageID)
+		if err := store.AddLinks(pageID, "Title "+pageID, []TargetLink{{
+			TargetPageID:   "target-" + pageID,
+			TargetPagePath: "target/" + pageID,
+		}}); err != nil {
+			t.Fatalf("AddLinks(%s) failed: %v", pageID, err)
+		}
+	}
+
+	outgoingByPageID, err := store.GetOutgoingLinksForPages(pageIDs)
+	if err != nil {
+		t.Fatalf("GetOutgoingLinksForPages failed: %v", err)
+	}
+	if len(outgoingByPageID) != len(pageIDs) {
+		t.Fatalf("expected %d page entries, got %d", len(pageIDs), len(outgoingByPageID))
+	}
+
+	for _, pageID := range pageIDs {
+		outgoings := outgoingByPageID[pageID]
+		if len(outgoings) != 1 {
+			t.Fatalf("expected 1 outgoing for %s, got %d", pageID, len(outgoings))
+		}
+		if outgoings[0].FromPageID != pageID {
+			t.Fatalf("expected outgoing from %s, got %s", pageID, outgoings[0].FromPageID)
+		}
+		if outgoings[0].ToPath != "target/"+pageID {
+			t.Fatalf("expected target path %q, got %q", "target/"+pageID, outgoings[0].ToPath)
+		}
 	}
 }

--- a/internal/wiki/import_adapter.go
+++ b/internal/wiki/import_adapter.go
@@ -83,7 +83,7 @@ func (a *WikiImportAdapter) UpdatePage(userID, id, title, slug string, content *
 	}
 	out, err := wikipages.NewUpdatePageUseCase(a.tree, a.slug, a.orchestrator(), a.log).Execute(
 		context.Background(),
-		wikipages.UpdatePageInput{UserID: userID, ID: id, Version: current.Version(), Title: title, Slug: slug, Content: content, Kind: kind},
+		wikipages.UpdatePageInput{UserID: userID, ID: id, Version: current.Version(), Title: title, Slug: slug, Content: content, Kind: kind, FromImport: true},
 	)
 	if err != nil {
 		return nil, err

--- a/internal/wiki/pages/copy_page.go
+++ b/internal/wiki/pages/copy_page.go
@@ -82,7 +82,7 @@ func (uc *CopyPageUseCase) Execute(_ context.Context, in CopyPageInput) (*CopyPa
 	}
 
 	updatedContent := strings.ReplaceAll(page.Content, "/assets/"+page.ID+"/", "/assets/"+copyPage.ID+"/")
-	if err := uc.tree.UpdateNode(in.UserID, copyPage.ID, copyPage.Title, copyPage.Slug, &updatedContent, tree.VersionUnchecked); err != nil {
+	if err := uc.tree.UpdateNode(in.UserID, copyPage.ID, copyPage.Title, copyPage.Slug, &updatedContent, tree.VersionUnchecked, false); err != nil {
 		cleanup()
 		_ = uc.assets.DeleteAllAssetsForPage(copyPage.PageNode)
 		return nil, err

--- a/internal/wiki/pages/refactor.go
+++ b/internal/wiki/pages/refactor.go
@@ -260,19 +260,19 @@ func NewApplyPageRefactorUseCase(
 
 // Execute applies the refactor operation to the page tree.
 func (uc *ApplyPageRefactorUseCase) Execute(ctx context.Context, in RefactorApplyInput) (*tree.Page, error) {
-	prev, err := uc.preview.Execute(ctx, in.RefactorPreviewInput)
+	plan, err := uc.buildApplyPlan(in)
 	if err != nil {
 		return nil, err
 	}
 
-	snapshots, err := uc.captureSnapshots(in)
+	snapshots, err := uc.captureSnapshots(plan.page, in)
 	if err != nil {
 		return nil, err
 	}
 
 	if in.RewriteLinks {
-		rules := []links.RewriteRule{{OldPath: prev.OldPath, NewPath: prev.NewPath}}
-		if err := uc.rewriteAffectedPages(in.UserID, prev.AffectedPages, rules); err != nil {
+		rules := []links.RewriteRule{{OldPath: plan.oldPath, NewPath: plan.newPath}}
+		if err := uc.rewriteAffectedPages(in.UserID, plan.affectedPageIDs, rules); err != nil {
 			return nil, err
 		}
 	}
@@ -297,7 +297,7 @@ func (uc *ApplyPageRefactorUseCase) Execute(ctx context.Context, in RefactorAppl
 		if err != nil {
 			return nil, err
 		}
-		if err := uc.rewritePathChangedSubtree(in.UserID, snapshots, prev.OldPath, prev.NewPath); err != nil {
+		if err := uc.rewritePathChangedSubtree(in.UserID, snapshots, plan.oldPath, plan.newPath); err != nil {
 			return nil, err
 		}
 		return uc.tree.GetPage(updated.Page.ID)
@@ -311,7 +311,7 @@ func (uc *ApplyPageRefactorUseCase) Execute(ctx context.Context, in RefactorAppl
 		if err := moveUC.Execute(ctx, MovePageInput{UserID: in.UserID, ID: in.PageID, Version: in.Version, ParentID: parentID}); err != nil {
 			return nil, err
 		}
-		if err := uc.rewritePathChangedSubtree(in.UserID, snapshots, prev.OldPath, prev.NewPath); err != nil {
+		if err := uc.rewritePathChangedSubtree(in.UserID, snapshots, plan.oldPath, plan.newPath); err != nil {
 			return nil, err
 		}
 		return uc.tree.GetPage(in.PageID)
@@ -321,6 +321,52 @@ func (uc *ApplyPageRefactorUseCase) Execute(ctx context.Context, in RefactorAppl
 	}
 }
 
+type applyRefactorPlan struct {
+	page            *tree.Page
+	oldPath         string
+	newPath         string
+	affectedPageIDs []string
+}
+
+func (uc *ApplyPageRefactorUseCase) buildApplyPlan(in RefactorApplyInput) (*applyRefactorPlan, error) {
+	page, err := uc.tree.GetPage(in.PageID)
+	if err != nil {
+		return nil, err
+	}
+
+	oldPath := page.CalculatePath()
+	newPath, err := uc.preview.computeTargetPath(page, in.RefactorPreviewInput)
+	if err != nil {
+		return nil, err
+	}
+
+	plan := &applyRefactorPlan{
+		page:    page,
+		oldPath: oldPath,
+		newPath: newPath,
+	}
+
+	if !in.RewriteLinks || uc.links == nil {
+		return plan, nil
+	}
+
+	pageIDs, err := uc.links.GetRefactorSourcePageIDsForPrefix(oldPath)
+	if err != nil {
+		return nil, err
+	}
+
+	excludeIDs := subtreeIDSet(page.PageNode)
+	plan.affectedPageIDs = make([]string, 0, len(pageIDs))
+	for _, pageID := range pageIDs {
+		if _, excluded := excludeIDs[pageID]; excluded {
+			continue
+		}
+		plan.affectedPageIDs = append(plan.affectedPageIDs, pageID)
+	}
+
+	return plan, nil
+}
+
 type pathChangeSnapshot struct {
 	PageID   string
 	OldPath  string
@@ -328,11 +374,7 @@ type pathChangeSnapshot struct {
 	RootPage bool
 }
 
-func (uc *ApplyPageRefactorUseCase) captureSnapshots(in RefactorApplyInput) ([]pathChangeSnapshot, error) {
-	page, err := uc.tree.GetPage(in.PageID)
-	if err != nil {
-		return nil, err
-	}
+func (uc *ApplyPageRefactorUseCase) captureSnapshots(page *tree.Page, in RefactorApplyInput) ([]pathChangeSnapshot, error) {
 	ids := collectSubtreeIDs(page.PageNode)
 	if len(ids) == 0 {
 		ids = []string{in.PageID}
@@ -354,7 +396,7 @@ func (uc *ApplyPageRefactorUseCase) captureSnapshots(in RefactorApplyInput) ([]p
 	return snapshots, nil
 }
 
-func (uc *ApplyPageRefactorUseCase) rewriteAffectedPages(userID string, affected []RefactorAffectedPage, rules []links.RewriteRule) error {
+func (uc *ApplyPageRefactorUseCase) rewriteAffectedPages(userID string, affectedPageIDs []string, rules []links.RewriteRule) error {
 	engine := links.NewMarkdownRefactorEngine()
 
 	type pending struct {
@@ -364,10 +406,11 @@ func (uc *ApplyPageRefactorUseCase) rewriteAffectedPages(userID string, affected
 	var items []pending
 	var bulk []tree.BulkContentUpdate
 
-	for _, ap := range affected {
-		page, err := uc.tree.GetPage(ap.FromPageID)
-		if err != nil {
-			uc.log.Warn("failed to get page for link rewrite, skipping", "pageID", ap.FromPageID, "error", err)
+	pagesByID := uc.loadPagesByID(affectedPageIDs, "failed to get page for link rewrite, skipping")
+
+	for _, pageID := range affectedPageIDs {
+		page, ok := pagesByID[pageID]
+		if !ok {
 			continue
 		}
 		result := engine.Rewrite(page.Content, page.CalculatePath(), rules)
@@ -406,7 +449,7 @@ func (uc *ApplyPageRefactorUseCase) rewriteAffectedPages(userID string, affected
 	}
 
 	if uc.links != nil && len(updatedPages) > 0 {
-		if err := uc.links.UpdateLinksAndHealForPages(updatedPages); err != nil {
+		if err := uc.links.UpdateRewrittenLinksAndHealForPages(updatedPages, rules); err != nil {
 			uc.log.Warn(
 				"failed to update link index after rewrite",
 				"pageCount", len(updatedPages),
@@ -429,10 +472,15 @@ func (uc *ApplyPageRefactorUseCase) rewritePathChangedSubtree(userID string, sna
 	var items []pending
 	var bulk []tree.BulkContentUpdate
 
+	pageIDs := make([]string, 0, len(snapshots))
 	for _, snap := range snapshots {
-		current, err := uc.tree.GetPage(snap.PageID)
-		if err != nil {
-			uc.log.Warn("failed to get subtree page for link rewrite, skipping", "pageID", snap.PageID, "error", err)
+		pageIDs = append(pageIDs, snap.PageID)
+	}
+	pagesByID := uc.loadPagesByID(pageIDs, "failed to get subtree page for link rewrite, skipping")
+
+	for _, snap := range snapshots {
+		current, ok := pagesByID[snap.PageID]
+		if !ok {
 			continue
 		}
 		result := engine.RewriteRelativeLinksForPathChange(snap.Content, snap.OldPath, current.CalculatePath(), rules)
@@ -525,6 +573,27 @@ func samplePageIDs(pages []*tree.Page, limit int) []string {
 		ids = append(ids, pages[i].ID)
 	}
 	return ids
+}
+
+func (uc *ApplyPageRefactorUseCase) loadPagesByID(ids []string, warningMessage string) map[string]*tree.Page {
+	if len(ids) == 0 {
+		return map[string]*tree.Page{}
+	}
+
+	pages, errs := uc.tree.GetPages(ids)
+	loaded := make(map[string]*tree.Page, len(ids))
+	for i, id := range ids {
+		if errs[i] != nil {
+			uc.log.Warn(warningMessage, "pageID", id, "error", errs[i])
+			continue
+		}
+		if pages[i] == nil {
+			continue
+		}
+		loaded[id] = pages[i]
+	}
+
+	return loaded
 }
 
 func collectPreviewWarnings(pages []RefactorAffectedPage) []string {

--- a/internal/wiki/pages/update_page.go
+++ b/internal/wiki/pages/update_page.go
@@ -11,13 +11,14 @@ import (
 
 // UpdatePageInput is the input for UpdatePageUseCase.
 type UpdatePageInput struct {
-	UserID  string
-	ID      string
-	Version string
-	Title   string
-	Slug    string
-	Content *string
-	Kind    *tree.NodeKind
+	UserID     string
+	ID         string
+	Version    string
+	Title      string
+	Slug       string
+	Content    *string
+	Kind       *tree.NodeKind
+	FromImport bool
 }
 
 // UpdatePageOutput is the output of UpdatePageUseCase.
@@ -77,7 +78,7 @@ func (uc *UpdatePageUseCase) Execute(_ context.Context, in UpdatePageInput) (*Up
 		}
 	}
 
-	if err = uc.tree.UpdateNode(in.UserID, in.ID, in.Title, in.Slug, in.Content, in.Version); err != nil {
+	if err = uc.tree.UpdateNode(in.UserID, in.ID, in.Title, in.Slug, in.Content, in.Version, in.FromImport); err != nil {
 		return nil, err
 	}
 

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -102,9 +102,37 @@ func NewWiki(options *WikiOptions) (*Wiki, error) {
 	if options.EnableRevision {
 		w.revision = revision.NewService(w.storageDir, w.tree, w.log,
 			revision.ServiceOptions{MaxRevisions: options.MaxRevisionHistory})
+		w.ensureBaselineRevisions()
 	}
 	w.buildRoutes(options)
 	return w, nil
+}
+
+func (w *Wiki) ensureBaselineRevisions() {
+	var ids []string
+	_ = w.tree.WalkNodes(func(id string) error {
+		ids = append(ids, id)
+		return nil
+	})
+	if len(ids) == 0 {
+		return
+	}
+	pages, _ := w.tree.GetPages(ids)
+	var valid []*tree.Page
+	for _, p := range pages {
+		if p != nil {
+			valid = append(valid, p)
+		}
+	}
+	if len(valid) == 0 {
+		return
+	}
+	errs := w.revision.RecordContentUpdates(valid, "", "")
+	for i, err := range errs {
+		if err != nil {
+			w.log.Warn("baseline revision failed", "pageID", valid[i].ID, "error", err)
+		}
+	}
 }
 
 // ─── Subsystem initializers ───────────────────────────────────────────────────

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -110,16 +110,23 @@ func NewWiki(options *WikiOptions) (*Wiki, error) {
 
 func (w *Wiki) ensureBaselineRevisions() {
 	var ids []string
-	_ = w.tree.WalkNodes(func(id string) error {
+	if err := w.tree.WalkNodes(func(id string) error {
 		ids = append(ids, id)
 		return nil
-	})
+	}); err != nil {
+		w.log.Warn("failed to enumerate pages for baseline revisions", "error", err)
+		return
+	}
 	if len(ids) == 0 {
 		return
 	}
-	pages, _ := w.tree.GetPages(ids)
+	pages, pageErrs := w.tree.GetPages(ids)
 	var valid []*tree.Page
-	for _, p := range pages {
+	for i, p := range pages {
+		if pageErrs[i] != nil {
+			w.log.Warn("failed to load page for baseline revision", "pageID", ids[i], "error", pageErrs[i])
+			continue
+		}
 		if p != nil {
 			valid = append(valid, p)
 		}

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -127,7 +127,7 @@ func (w *Wiki) ensureBaselineRevisions() {
 	if len(valid) == 0 {
 		return
 	}
-	errs := w.revision.RecordContentUpdates(valid, "", "")
+	errs := w.revision.RecordContentUpdates(valid, SYSTEM_USER_ID, "baseline")
 	for i, err := range errs {
 		if err != nil {
 			w.log.Warn("baseline revision failed", "pageID", valid[i].ID, "error", err)

--- a/internal/wiki/wiki_test.go
+++ b/internal/wiki/wiki_test.go
@@ -2,6 +2,8 @@ package wiki
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -276,4 +278,42 @@ func TestWiki_AuthDisabled_CoreFunctionalityWorks(t *testing.T) {
 
 	// Test deleting a page
 	deletePageForTest(t, wikiInstance, "system", page.ID, false)
+}
+
+func TestWiki_EnsureBaselineRevisions_SkipsUnreadablePages(t *testing.T) {
+	w := createWikiTestInstance(t)
+	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
+
+	okPage := createPageForTest(t, w, "system", nil, "Healthy", "healthy", pageNodeKind())
+	brokenPage := createPageForTest(t, w, "system", nil, "Broken", "broken", pageNodeKind())
+
+	if err := w.revision.DeletePageData(okPage.ID); err != nil {
+		t.Fatalf("DeletePageData(okPage) failed: %v", err)
+	}
+	if err := w.revision.DeletePageData(brokenPage.ID); err != nil {
+		t.Fatalf("DeletePageData(brokenPage) failed: %v", err)
+	}
+
+	brokenPath := filepath.Join(w.storageDir, "root", "broken.md")
+	if err := os.Remove(brokenPath); err != nil {
+		t.Fatalf("Remove(%s) failed: %v", brokenPath, err)
+	}
+
+	w.ensureBaselineRevisions()
+
+	okRevisions, err := w.revision.ListRevisions(okPage.ID)
+	if err != nil {
+		t.Fatalf("ListRevisions(okPage) failed: %v", err)
+	}
+	if len(okRevisions) == 0 {
+		t.Fatalf("expected baseline revision for readable page")
+	}
+
+	brokenRevisions, err := w.revision.ListRevisions(brokenPage.ID)
+	if err != nil {
+		t.Fatalf("ListRevisions(brokenPage) failed: %v", err)
+	}
+	if len(brokenRevisions) != 0 {
+		t.Fatalf("expected no baseline revision for unreadable page, got %d", len(brokenRevisions))
+	}
 }

--- a/ui/leafwiki-ui/src/features/editor/PageEditor.tsx
+++ b/ui/leafwiki-ui/src/features/editor/PageEditor.tsx
@@ -3,7 +3,7 @@ import { mapApiError, asApiLocalizedError } from '@/lib/api/errors'
 import { buildBrowserEditUrl } from '@/lib/routePath'
 import { getWikiTargetRoutePath } from '@/lib/wikiPath'
 import { useTreeStore } from '@/stores/tree'
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { toast } from 'sonner'
 import { useProgressbarStore } from '../progressbar/progressbar'
@@ -18,6 +18,7 @@ export default function PageEditor() {
   const { pathname } = useLocation()
   const navigate = useNavigate()
   const editorRef = useRef<MarkdownEditorRef>(null)
+  const [skipNavigationGuard, setSkipNavigationGuard] = useState(false)
   const reloadTree = useTreeStore((s) => s.reloadTree)
   const savePage = usePageEditorStore((s) => s.savePage)
   const forceOverwrite = usePageEditorStore((s) => s.forceOverwrite)
@@ -27,7 +28,6 @@ export default function PageEditor() {
   const notFound = usePageEditorStore((s) => s.notFound)
   const loading = useProgressbarStore((s) => s.loading)
   const error = usePageEditorStore((s) => s.error)
-  const page = usePageEditorStore((s) => s.page)
   const openNode = useTreeStore((s) => s.openNode)
   const dirty = usePageEditorStore((s) => {
     const { page, title, slug, content } = s
@@ -39,11 +39,19 @@ export default function PageEditor() {
 
   // Shows Unsaved Changes Dialog when navigating away with dirty state
   useNavigationGuard({
-    when: dirty,
+    when: dirty && !skipNavigationGuard,
     onNavigate: async () => {
       await reloadTree()
     },
   })
+
+  useEffect(() => {
+    if (!skipNavigationGuard) {
+      return
+    }
+
+    setSkipNavigationGuard(false)
+  }, [pathname, skipNavigationGuard])
 
   // Load page data when path changes
   useEffect(() => {
@@ -121,12 +129,32 @@ export default function PageEditor() {
   }, [savePage, forceOverwrite])
 
   const handleClose = useCallback(() => {
-    if (page?.path) {
-      navigate(`/${page.path}`)
+    const {
+      page: currentPage,
+      title: currentTitle,
+      slug: currentSlug,
+      content: currentContent,
+    } = usePageEditorStore.getState()
+
+    const hasUnsavedChanges = currentPage
+      ? currentPage.title !== currentTitle ||
+        currentPage.slug !== currentSlug ||
+        currentPage.content !== currentContent
+      : false
+
+    if (!hasUnsavedChanges) {
+      // Saving updates the editor store before React finishes re-rendering.
+      // Skip the blocker for this close action when the latest store snapshot
+      // is already clean.
+      setSkipNavigationGuard(true)
+    }
+
+    if (currentPage?.path) {
+      navigate(`/${currentPage.path}`)
     } else {
       navigate('/')
     }
-  }, [page, navigate])
+  }, [navigate])
 
   // register toolbar actions
   useToolbarActions({

--- a/ui/leafwiki-ui/src/features/editor/PageEditor.tsx
+++ b/ui/leafwiki-ui/src/features/editor/PageEditor.tsx
@@ -3,7 +3,7 @@ import { mapApiError, asApiLocalizedError } from '@/lib/api/errors'
 import { buildBrowserEditUrl } from '@/lib/routePath'
 import { getWikiTargetRoutePath } from '@/lib/wikiPath'
 import { useTreeStore } from '@/stores/tree'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { toast } from 'sonner'
 import { useProgressbarStore } from '../progressbar/progressbar'
@@ -18,7 +18,7 @@ export default function PageEditor() {
   const { pathname } = useLocation()
   const navigate = useNavigate()
   const editorRef = useRef<MarkdownEditorRef>(null)
-  const [skipNavigationGuard, setSkipNavigationGuard] = useState(false)
+  const skipNavigationGuardRef = useRef(false)
   const reloadTree = useTreeStore((s) => s.reloadTree)
   const savePage = usePageEditorStore((s) => s.savePage)
   const forceOverwrite = usePageEditorStore((s) => s.forceOverwrite)
@@ -39,19 +39,11 @@ export default function PageEditor() {
 
   // Shows Unsaved Changes Dialog when navigating away with dirty state
   useNavigationGuard({
-    when: dirty && !skipNavigationGuard,
+    when: () => dirty && !skipNavigationGuardRef.current,
     onNavigate: async () => {
       await reloadTree()
     },
   })
-
-  useEffect(() => {
-    if (!skipNavigationGuard) {
-      return
-    }
-
-    setSkipNavigationGuard(false)
-  }, [pathname, skipNavigationGuard])
 
   // Load page data when path changes
   useEffect(() => {
@@ -146,7 +138,7 @@ export default function PageEditor() {
       // Saving updates the editor store before React finishes re-rendering.
       // Skip the blocker for this close action when the latest store snapshot
       // is already clean.
-      setSkipNavigationGuard(true)
+      skipNavigationGuardRef.current = true
     }
 
     if (currentPage?.path) {

--- a/ui/leafwiki-ui/src/features/editor/useNavigationGuard.tsx
+++ b/ui/leafwiki-ui/src/features/editor/useNavigationGuard.tsx
@@ -10,7 +10,7 @@ import { useBlocker } from 'react-router-dom'
 import { useExternalUnloadBlocker } from './useExternalUnloadBlocker'
 
 type UseNavigationGuardProps = {
-  when: boolean
+  when: boolean | (() => boolean)
   onNavigate: () => void
 }
 
@@ -18,11 +18,14 @@ export default function useNavigationGuard({
   when,
   onNavigate,
 }: UseNavigationGuardProps) {
-  const blocker = useBlocker(() => when)
+  const shouldBlock = useCallback(() => {
+    return typeof when === 'function' ? when() : when
+  }, [when])
+  const blocker = useBlocker(shouldBlock)
   const openDialog = useDialogsStore((state) => state.openDialog)
   const closeDialog = useDialogsStore((state) => state.closeDialog)
 
-  useExternalUnloadBlocker(when)
+  useExternalUnloadBlocker(typeof when === 'function' ? when() : when)
 
   // onCancel resets the navigation blocker
   // so the user stays on the current page


### PR DESCRIPTION
Treat UI content that looks like frontmatter as plain body text while keeping importer updates on the frontmatter-preserving path.

Also initialize baseline revisions for existing pages when revisions are enabled so revision history starts from the current state.