### PR TITLE
feat(install): Add new argument from V9 in installer.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,14 @@ LEAFWIKI_JWT_SECRET=
 
 # Admin password (required)
 LEAFWIKI_ADMIN_PASSWORD=
+
+# Enable revision history / page history (true/false)
+LEAFWIKI_ENABLE_REVISION=
+
+# Maximum revisions kept per page; 0 means unlimited
+LEAFWIKI_MAX_REVISION_HISTORY=
+
+# Enable link refactoring dialog and rewrite flow (true/false)
+LEAFWIKI_ENABLE_LINK_REFACTOR=
+
+

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,10 @@ JWT_SECRET=""
 ADMIN_PASSWORD=""
 ENV_FILE=".env"
 ENV_FILE_PATH="/etc/leafwiki/.env"
+ENABLE_LINK_REFACTORING="false"
+ENABLE_REVISION="false"
+MAX_REVISION_HISTORY="100"
+
 
 # Usage function
 usage() {
@@ -162,6 +166,9 @@ if [[ "$INTERACTIVE" == 0 ]]; then
     ADMIN_PASSWORD="${LEAFWIKI_ADMIN_PASSWORD:-$ADMIN_PASSWORD}"
     ALLOW_INSECURE=${LEAFWIKI_ALLOW_INSECURE:-false}
     DISABLE_AUTH=${LEAFWIKI_DISABLE_AUTH:-false}
+    ENABLE_REVISION=${LEAFWIKI_ENABLE_REVISION:-false}
+    MAX_REVISION_HISTORY=${LEAFWIKI_MAX_REVISION_HISTORY:-"100"}
+    ENABLE_LINK_REFACTORING=${LEAFWIKI_ENABLE_LINK_REFACTOR:-false}
 
     validate_architecture
     validate_requirements_non_interactive "$ARCH" "LEAFWIKI_ARCH"
@@ -207,6 +214,30 @@ else
         DATA_DIR="$RESPONSE_DATA_DIR"
     fi
 
+    read -rp "Do you want to enable versioning? (default: n) y/N: " RESPONSE_REVISION
+    if [[ $RESPONSE_REVISION == "y" || $RESPONSE_REVISION == "Y" ]]; then
+
+        ENABLE_REVISION="true"
+
+        while true; do
+            read -p "Would you specify a max revison number ? (default: $MAX_REVISION_HISTORY) : " RESPONSE_MAX_REVISION
+            if [[ -z "$RESPONSE_MAX_REVISION" ]]; then
+                break
+            elif [[ "$RESPONSE_MAX_REVISION" =~ ^[0-9]+$ ]]; then
+                MAX_REVISION_HISTORY="$RESPONSE_MAX_REVISION"
+                break
+            else
+                echo "Invalid max revision number. Please
+                enter an integer greater than or equal to 0, or press Enter to
+                keep the default."
+            fi
+        done
+        
+    else
+        ENABLE_REVISION="false"
+    fi
+    
+
     validate_port
     validate_architecture
 
@@ -219,6 +250,8 @@ else
     echo "LEAFWIKI_HOST=\"$HOST\"" >> "$ENV_FILE_PATH"
     echo "LEAFWIKI_JWT_SECRET=\"$JWT_SECRET\"" >> "$ENV_FILE_PATH"
     echo "LEAFWIKI_ADMIN_PASSWORD=\"$ADMIN_PASSWORD\"" >> "$ENV_FILE_PATH"
+    echo "LEAFWIKI_ENABLE_REVISION=\"$ENABLE_VERSIONING\"" >> "$ENV_FILE_PATH"
+    echo "LEAFWIKI_MAX_REVISION_HISTORY=\"$MAX_REVISION_HISTORY\"" >> "$ENV_FILE_PATH"
 
 fi
 

--- a/readme.md
+++ b/readme.md
@@ -191,7 +191,7 @@ sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/perber/leafwik
 
 This installs LeafWiki as a system service on the target machine.
 The service is started automatically after installation.
-> The installation script has been tested on Ubuntu.
+> The installation script has been tested on Ubuntu, Debian, and Raspbian.
 > Feedback for other distributions is welcome via GitHub issues.
 
 #### Deployment examples


### PR DESCRIPTION
Hey @perber,

After the v9 release, I thought we could improve the installer to support the latest flags that were added.

It now supports flags for:
- Versioning
- Maximum number of versions per page
- Permalinks

I decided not to include permalinks in the interactive installation flow to avoid overloading it. Does that choice make sense to you?