### PR TITLE
fix(history): remove duplicate current label

### DIFF
--- a/ui/leafwiki-ui/src/features/history/PageHistoryContent.tsx
+++ b/ui/leafwiki-ui/src/features/history/PageHistoryContent.tsx
@@ -1160,11 +1160,7 @@ export function PageHistoryContent({
                 onClick={() => void handleRestore()}
                 data-testid={`${testidPrefix}-restore`}
               >
-                {restoreLoading
-                  ? 'Restoring...'
-                  : isSelectedRevisionLatest
-                    ? 'Current version'
-                    : 'Restore'}
+                {restoreLoading ? 'Restoring...' : 'Restore'}
               </Button>
             </div>
           </div>


### PR DESCRIPTION
Keep the latest revision as a normal history entry and avoid repeating its current-state label in the restore action. This reduces the impression that the active version and last revision are separate items.