### PR TITLE
fix: align password change dialogs

### DIFF
--- a/e2e/pages/ViewPage.ts
+++ b/e2e/pages/ViewPage.ts
@@ -31,6 +31,7 @@ export default class ViewPage {
 
   async logout() {
     const loginField = this.page.locator('input[data-testid="login-identifier"]');
+    const openDialog = this.page.locator('div[role="dialog"]');
 
     // Already logged out?
     try {
@@ -52,6 +53,17 @@ export default class ViewPage {
     } catch {
       // not logged in / wrong page / page already gone
       return;
+    }
+
+    // If a modal is still open from the test flow, close it before trying to
+    // use the user toolbar. Otherwise the dialog overlay can intercept clicks.
+    try {
+      if (await openDialog.isVisible({ timeout: 500 })) {
+        await this.page.keyboard.press('Escape');
+        await openDialog.waitFor({ state: 'hidden', timeout: 2000 });
+      }
+    } catch {
+      // ignore; if no dialog is open or it is already closing, continue
     }
 
     // 3) Open dropdown

--- a/internal/http/router_test.go
+++ b/internal/http/router_test.go
@@ -2371,6 +2371,52 @@ func TestUpdateUserEndpoint(t *testing.T) {
 
 }
 
+func TestChangeOwnPasswordEndpoint(t *testing.T) {
+	w := createWikiTestInstance(t)
+	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
+	router := createRouterTestInstance(w, t)
+
+	create := `{"username": "jane", "email": "jane@example.com", "password": "secretpassword", "role": "editor"}`
+	resp := authenticatedRequest(t, router, http.MethodPost, "/api/users", strings.NewReader(create))
+	var user map[string]interface{}
+	_ = json.Unmarshal(resp.Body.Bytes(), &user)
+
+	changePayload := `{"oldPassword":"secretpassword","newPassword":"newsecretpassword"}`
+	rec := authenticatedRequestAs(t, router, "jane", "secretpassword", http.MethodPut, "/api/users/me/password", strings.NewReader(changePayload))
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("Expected 204 No Content for own password change, got %d - %s", rec.Code, rec.Body.String())
+	}
+
+	loginWithOld := map[string]string{
+		"identifier": "jane",
+		"password":   "secretpassword",
+	}
+	loginWithOldBody, _ := json.Marshal(loginWithOld)
+	oldReq := httptest.NewRequest(http.MethodPost, "/api/auth/login", bytes.NewReader(loginWithOldBody))
+	oldReq.Header.Set("Content-Type", "application/json")
+	oldRec := httptest.NewRecorder()
+	router.ServeHTTP(oldRec, oldReq)
+
+	if oldRec.Code != http.StatusUnauthorized {
+		t.Fatalf("Expected 401 Unauthorized with old password, got %d - %s", oldRec.Code, oldRec.Body.String())
+	}
+
+	loginWithNew := map[string]string{
+		"identifier": "jane",
+		"password":   "newsecretpassword",
+	}
+	loginWithNewBody, _ := json.Marshal(loginWithNew)
+	newReq := httptest.NewRequest(http.MethodPost, "/api/auth/login", bytes.NewReader(loginWithNewBody))
+	newReq.Header.Set("Content-Type", "application/json")
+	newRec := httptest.NewRecorder()
+	router.ServeHTTP(newRec, newReq)
+
+	if newRec.Code != http.StatusOK {
+		t.Fatalf("Expected 200 OK with new password, got %d - %s", newRec.Code, newRec.Body.String())
+	}
+}
+
 func TestDeleteUserEndpoint(t *testing.T) {
 	w := createWikiTestInstance(t)
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)

--- a/ui/leafwiki-ui/src/components/FormInput.tsx
+++ b/ui/leafwiki-ui/src/components/FormInput.tsx
@@ -2,19 +2,23 @@ import { Input } from '@/components/ui/input'
 
 type FormInputProps = {
   label?: string
+  name?: string
   value: string
   onChange: (value: string) => void
   placeholder?: string
   testid?: string
   error?: string
   type?: string
+  autoComplete?: string
   autoFocus?: boolean
   readOnly?: boolean
 }
 
 export function FormInput({
   label,
+  name,
   value,
+  autoComplete,
   autoFocus,
   onChange,
   testid,
@@ -28,10 +32,12 @@ export function FormInput({
       {label && <label className="form-input__label">{label}</label>}
       <Input
         autoFocus={autoFocus || false}
+        name={name}
         type={type}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
+        autoComplete={autoComplete}
         readOnly={readOnly}
         className={error ? 'form-input__input-error' : ''}
         data-testid={testid}

--- a/ui/leafwiki-ui/src/features/users/ChangeOwnPasswordDialog.tsx
+++ b/ui/leafwiki-ui/src/features/users/ChangeOwnPasswordDialog.tsx
@@ -74,7 +74,6 @@ export function ChangeOwnPasswordDialog() {
   return (
     <BaseDialog
       dialogType={DIALOG_CHANGE_OWN_PASSWORD}
-      defaultAction="cancel"
       dialogTitle="Change Own Password"
       dialogDescription="Change your password. Make sure to remember it!"
       testidPrefix="change-own-password-dialog"
@@ -105,29 +104,45 @@ export function ChangeOwnPasswordDialog() {
       }}
     >
       <div className="space-y-3 pt-2">
+        <input
+          aria-hidden="true"
+          autoComplete="username"
+          className="hidden"
+          name="username"
+          readOnly
+          tabIndex={-1}
+          type="text"
+          value={user.username}
+        />
         <FormInput
           autoFocus={true}
           label="Old Password"
+          name="current-password"
           type="password"
           value={oldPassword}
           onChange={handleOldPasswordChange}
           placeholder="Old Password"
+          autoComplete="current-password"
           error={fieldErrors.oldPassword}
         />
         <FormInput
           label="New Password"
+          name="new-password"
           type="password"
           value={newPassword}
           onChange={handleNewPasswordChange}
           placeholder="New Password"
+          autoComplete="new-password"
           error={fieldErrors.newPassword}
         />
         <FormInput
           label="Confirm Password"
+          name="confirm-new-password"
           type="password"
           value={confirm}
           onChange={handleConfirmChange}
           placeholder="Confirm Password"
+          autoComplete="new-password"
           error={fieldErrors.confirm}
         />
       </div>

--- a/ui/leafwiki-ui/src/features/users/ChangePasswordDialog.tsx
+++ b/ui/leafwiki-ui/src/features/users/ChangePasswordDialog.tsx
@@ -4,6 +4,7 @@ import { handleFieldErrors } from '@/lib/handleFieldErrors'
 import { DIALOG_CHANGE_USER_PASSWORD } from '@/lib/registries'
 import { useUserStore } from '@/stores/users'
 import { useCallback, useState } from 'react'
+import { toast } from 'sonner'
 
 type ChangePasswordDialogProps = {
   userId: string
@@ -67,6 +68,7 @@ export function ChangePasswordDialog({
         ...user,
         password,
       })
+      toast.success('Password changed successfully')
       return true // Close the dialog
     } catch (err) {
       console.warn(err)
@@ -104,21 +106,35 @@ export function ChangePasswordDialog({
       ]}
     >
       <div className="space-y-3 pt-2">
+        <input
+          aria-hidden="true"
+          autoComplete="username"
+          className="hidden"
+          name="username"
+          readOnly
+          tabIndex={-1}
+          type="text"
+          value={username}
+        />
         <FormInput
           autoFocus={true}
           label="New Password"
+          name="new-password"
           type="password"
           value={password}
           onChange={handlePasswordChange}
           placeholder="New Password"
+          autoComplete="new-password"
           error={fieldErrors.password}
         />
         <FormInput
           label="Confirm Password"
+          name="confirm-new-password"
           type="password"
           value={confirm}
           onChange={handleConfirmChange}
           placeholder="Confirm Password"
+          autoComplete="new-password"
           error={fieldErrors.confirm}
         />
       </div>

--- a/ui/leafwiki-ui/src/features/users/UserFormDialog.tsx
+++ b/ui/leafwiki-ui/src/features/users/UserFormDialog.tsx
@@ -87,33 +87,39 @@ export function UserFormDialog({ user }: UserFormDialogProps) {
         <FormInput
           autoFocus={true}
           label="username"
+          name="username"
           value={username}
           onChange={(val) => {
             setUsername(val)
             setFieldErrors((prev) => ({ ...prev, username: '' }))
           }}
           placeholder="username"
+          autoComplete="username"
           error={fieldErrors.username}
         />
         <FormInput
           label="email"
+          name="email"
           value={email}
           onChange={(val) => {
             setEmail(val)
             setFieldErrors((prev) => ({ ...prev, email: '' }))
           }}
           placeholder="email"
+          autoComplete="email"
           error={fieldErrors.email}
         />
         {!isEdit && (
           <FormInput
             label="password"
+            name="new-password"
             value={password}
             onChange={(val) => {
               setPassword(val)
               setFieldErrors((prev) => ({ ...prev, password: '' }))
             }}
             placeholder="password"
+            autoComplete="new-password"
             error={fieldErrors.password}
             type="password"
           />

--- a/ui/leafwiki-ui/src/lib/api/users.ts
+++ b/ui/leafwiki-ui/src/lib/api/users.ts
@@ -34,8 +34,8 @@ export async function changeOwnPassword(
   return await fetchWithAuth(`/api/users/me/password`, {
     method: 'PUT',
     body: JSON.stringify({
-      new_password: newPassword,
-      old_password: oldPassword,
+      oldPassword,
+      newPassword,
     }),
   })
 }


### PR DESCRIPTION
Add coverage for the /users/me/password flow and fix the frontend payload shape. Also improve browser autofill behavior across password-related dialogs and add consistent success feedback in user management.