### PR TITLE
fix: Remove hosted version link from README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,8 +67,6 @@ Try: `Ctrl+E` to edit, `Ctrl+S` to save, `Ctrl+Shift+F` to open the search.
 Login credentials are displayed on the demo site.  
 The demo instance resets automatically every hour, so all changes are temporary.
 
-Prefer a hosted version instead of running LeafWiki yourself? [Read more here.](https://leafwiki.com/hosted/)
-
 ---
 
 **Mobile View:**


### PR DESCRIPTION
Removed link to hosted version of LeafWiki.