### PR TITLE
refactor: remove tree dependency from TagsService and PropertiesService

### DIFF
--- a/internal/properties/properties_service.go
+++ b/internal/properties/properties_service.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/perber/wiki/internal/core/markdown"
-	"github.com/perber/wiki/internal/core/tree"
 )
 
 // reservedKeys are frontmatter keys that must never be stored in the properties index.
@@ -16,44 +15,19 @@ var reservedKeys = map[string]struct{}{
 
 type PropertiesService struct {
 	store *PropertiesStore
-	tree  *tree.TreeService
 }
 
-func NewPropertiesService(treeService *tree.TreeService, store *PropertiesStore) *PropertiesService {
-	return &PropertiesService{store: store, tree: treeService}
+func NewPropertiesService(store *PropertiesStore) *PropertiesService {
+	return &PropertiesService{store: store}
 }
 
-// IndexAllPages rebuilds the entire properties index from the current tree state.
-func (s *PropertiesService) IndexAllPages() error {
-	if !s.tree.IsLoaded() {
-		return nil
-	}
+func (s *PropertiesService) ClearIndex() error {
+	return s.store.Clear()
+}
 
-	if err := s.store.Clear(); err != nil {
-		return err
-	}
-
-	var ids []string
-	if err := s.tree.WalkNodes(func(id string) error {
-		ids = append(ids, id)
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	for _, id := range ids {
-		raw, err := s.tree.ReadPageRaw(id)
-		if err != nil {
-			return err
-		}
-
-		props := ExtractPropertiesFromContent(raw)
-		if err := s.store.SetPropertiesForPage(id, props); err != nil {
-			return err
-		}
-	}
-
-	return nil
+func (s *PropertiesService) IndexPageContent(pageID, rawContent string) error {
+	props := ExtractPropertiesFromContent(rawContent)
+	return s.store.SetPropertiesForPage(pageID, props)
 }
 
 func (s *PropertiesService) SetPropertiesForPage(pageID string, props map[string]PropertyEntry) error {

--- a/internal/properties/properties_service_test.go
+++ b/internal/properties/properties_service_test.go
@@ -214,7 +214,27 @@ func setupPropertiesService(t *testing.T) (*PropertiesService, *tree.TreeService
 	}
 	t.Cleanup(func() { test_utils.WrapCloseWithErrorCheck(store.Close, t) })
 
-	return NewPropertiesService(ts, store), ts
+	return NewPropertiesService(store), ts
+}
+
+func indexAllPages(t *testing.T, svc *PropertiesService, ts *tree.TreeService) {
+	t.Helper()
+	var ids []string
+	if err := ts.WalkNodes(func(id string) error {
+		ids = append(ids, id)
+		return nil
+	}); err != nil {
+		t.Fatalf("WalkNodes: %v", err)
+	}
+	pages, errs := ts.GetPages(ids)
+	for i, page := range pages {
+		if errs[i] != nil {
+			t.Fatalf("GetPages[%d]: %v", i, errs[i])
+		}
+		if err := svc.IndexPageContent(page.ID, page.RawContent); err != nil {
+			t.Fatalf("IndexPageContent %s: %v", page.ID, err)
+		}
+	}
 }
 
 func pageKind() *tree.NodeKind {
@@ -240,9 +260,7 @@ func TestPropertiesService_IndexAllPages_BuildsIndex(t *testing.T) {
 	id1 := createPageWithContent(t, ts, "Page A", "page-a", "---\nstatus: draft\n---\n# A")
 	id2 := createPageWithContent(t, ts, "Page B", "page-b", "---\nstatus: published\n---\n# B")
 
-	if err := svc.IndexAllPages(); err != nil {
-		t.Fatalf("IndexAllPages: %v", err)
-	}
+	indexAllPages(t, svc, ts)
 
 	ids, err := svc.GetPageIDsByProperty("status", "draft")
 	if err != nil {
@@ -266,9 +284,10 @@ func TestPropertiesService_IndexAllPages_IsIdempotent(t *testing.T) {
 	createPageWithContent(t, ts, "Page A", "page-a", "---\nstatus: draft\n---\n# A")
 
 	for i := 0; i < 3; i++ {
-		if err := svc.IndexAllPages(); err != nil {
-			t.Fatalf("IndexAllPages (run %d): %v", i, err)
+		if err := svc.ClearIndex(); err != nil {
+			t.Fatalf("ClearIndex (run %d): %v", i, err)
 		}
+		indexAllPages(t, svc, ts)
 	}
 
 	keys, err := svc.GetAllPropertyKeys("", 50)
@@ -285,9 +304,7 @@ func TestPropertiesService_IndexAllPages_SkipsReservedKeys(t *testing.T) {
 	createPageWithContent(t, ts, "Page A", "page-a",
 		"---\ntags:\n  - go\ntitle: Custom\nleafwiki_id: abc\nstatus: draft\n---\n# A")
 
-	if err := svc.IndexAllPages(); err != nil {
-		t.Fatalf("IndexAllPages: %v", err)
-	}
+	indexAllPages(t, svc, ts)
 
 	keys, err := svc.GetAllPropertyKeys("", 50)
 	if err != nil {
@@ -314,9 +331,7 @@ func TestPropertiesService_IndexAllPages_SkipsListValues(t *testing.T) {
 	createPageWithContent(t, ts, "Page A", "page-a",
 		"---\nkeywords: [go, testing]\nstatus: draft\n---\n# A")
 
-	if err := svc.IndexAllPages(); err != nil {
-		t.Fatalf("IndexAllPages: %v", err)
-	}
+	indexAllPages(t, svc, ts)
 
 	keys, err := svc.GetAllPropertyKeys("", 50)
 	if err != nil {
@@ -333,9 +348,7 @@ func TestPropertiesService_IndexAllPages_PagesWithoutPropertiesAreSkipped(t *tes
 	svc, ts := setupPropertiesService(t)
 	createPageWithContent(t, ts, "No Props", "no-props", "# Just content")
 
-	if err := svc.IndexAllPages(); err != nil {
-		t.Fatalf("IndexAllPages: %v", err)
-	}
+	indexAllPages(t, svc, ts)
 
 	keys, err := svc.GetAllPropertyKeys("", 50)
 	if err != nil {
@@ -358,9 +371,7 @@ func TestPropertiesService_IndexAllPages_ReadsPropertiesFromRawFrontmatter(t *te
 		t.Fatalf("expected parsed page content to exclude frontmatter properties, got %v", got)
 	}
 
-	if err := svc.IndexAllPages(); err != nil {
-		t.Fatalf("IndexAllPages: %v", err)
-	}
+	indexAllPages(t, svc, ts)
 
 	ids, err := svc.GetPageIDsByProperty("status", "draft")
 	if err != nil {
@@ -368,6 +379,76 @@ func TestPropertiesService_IndexAllPages_ReadsPropertiesFromRawFrontmatter(t *te
 	}
 	if len(ids) != 1 || ids[0] != pageID {
 		t.Fatalf("expected [%s], got %v", pageID, ids)
+	}
+}
+
+// ─── IndexPageContent ─────────────────────────────────────────────────────────
+
+func TestPropertiesService_IndexPageContent_StoresProperties(t *testing.T) {
+	svc, _ := setupPropertiesService(t)
+
+	raw := "---\nstatus: draft\nauthor: alice\n---\n\n# Page"
+	if err := svc.IndexPageContent("page-1", raw); err != nil {
+		t.Fatalf("IndexPageContent: %v", err)
+	}
+
+	keys, err := svc.GetAllPropertyKeys("", 50)
+	if err != nil {
+		t.Fatalf("GetAllPropertyKeys: %v", err)
+	}
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 keys, got %v", keys)
+	}
+
+	ids, err := svc.GetPageIDsByProperty("status", "draft")
+	if err != nil {
+		t.Fatalf("GetPageIDsByProperty: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "page-1" {
+		t.Errorf("expected [page-1], got %v", ids)
+	}
+}
+
+func TestPropertiesService_IndexPageContent_NoFrontmatterStoresNothing(t *testing.T) {
+	svc, _ := setupPropertiesService(t)
+
+	if err := svc.IndexPageContent("page-1", "# Just content"); err != nil {
+		t.Fatalf("IndexPageContent: %v", err)
+	}
+
+	keys, err := svc.GetAllPropertyKeys("", 50)
+	if err != nil {
+		t.Fatalf("GetAllPropertyKeys: %v", err)
+	}
+	if len(keys) != 0 {
+		t.Errorf("expected no keys, got %v", keys)
+	}
+}
+
+func TestPropertiesService_IndexPageContent_UpdatesExistingEntry(t *testing.T) {
+	svc, _ := setupPropertiesService(t)
+
+	if err := svc.IndexPageContent("page-1", "---\nstatus: draft\n---\n"); err != nil {
+		t.Fatalf("IndexPageContent (first): %v", err)
+	}
+	if err := svc.IndexPageContent("page-1", "---\nstatus: published\n---\n"); err != nil {
+		t.Fatalf("IndexPageContent (second): %v", err)
+	}
+
+	ids, err := svc.GetPageIDsByProperty("status", "published")
+	if err != nil {
+		t.Fatalf("GetPageIDsByProperty: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "page-1" {
+		t.Errorf("expected [page-1] for published, got %v", ids)
+	}
+
+	old, err := svc.GetPageIDsByProperty("status", "draft")
+	if err != nil {
+		t.Fatalf("GetPageIDsByProperty: %v", err)
+	}
+	if len(old) != 0 {
+		t.Errorf("old value 'draft' should be gone, got %v", old)
 	}
 }
 

--- a/internal/tags/tags_service.go
+++ b/internal/tags/tags_service.go
@@ -4,47 +4,18 @@ import (
 	"strings"
 
 	"github.com/perber/wiki/internal/core/markdown"
-	"github.com/perber/wiki/internal/core/tree"
 )
 
 type TagsService struct {
 	store *TagsStore
-	tree  *tree.TreeService
 }
 
-func NewTagsService(treeService *tree.TreeService, store *TagsStore) *TagsService {
-	return &TagsService{store: store, tree: treeService}
+func NewTagsService(store *TagsStore) *TagsService {
+	return &TagsService{store: store}
 }
 
-// IndexAllPages rebuilds the entire tag index from the current tree state.
-func (s *TagsService) IndexAllPages() error {
-	if !s.tree.IsLoaded() {
-		return nil
-	}
-
-	if err := s.store.Clear(); err != nil {
-		return err
-	}
-
-	var ids []string
-	if err := s.tree.WalkNodes(func(id string) error {
-		ids = append(ids, id)
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	for _, id := range ids {
-		raw, err := s.tree.ReadPageRaw(id)
-		if err != nil {
-			return err
-		}
-		if err := s.IndexPageContent(id, raw); err != nil {
-			return err
-		}
-	}
-
-	return nil
+func (s *TagsService) ClearIndex() error {
+	return s.store.Clear()
 }
 
 // IndexPageContent extracts tags and excerpt from rawContent and stores both atomically.

--- a/internal/tags/tags_service_test.go
+++ b/internal/tags/tags_service_test.go
@@ -118,7 +118,7 @@ func setupTagsService(t *testing.T) (*TagsService, *tree.TreeService) {
 	}
 	t.Cleanup(func() { test_utils.WrapCloseWithErrorCheck(store.Close, t) })
 
-	return NewTagsService(ts, store), ts
+	return NewTagsService(store), ts
 }
 
 func pageKind() *tree.NodeKind {
@@ -147,15 +147,33 @@ func createPageWithTags(t *testing.T, ts *tree.TreeService, title, slug string, 
 	return *idPtr
 }
 
+func indexAllPages(t *testing.T, svc *TagsService, ts *tree.TreeService) {
+	t.Helper()
+	var ids []string
+	if err := ts.WalkNodes(func(id string) error {
+		ids = append(ids, id)
+		return nil
+	}); err != nil {
+		t.Fatalf("WalkNodes: %v", err)
+	}
+	pages, errs := ts.GetPages(ids)
+	for i, page := range pages {
+		if errs[i] != nil {
+			t.Fatalf("GetPages[%d]: %v", i, errs[i])
+		}
+		if err := svc.IndexPageContent(page.ID, page.RawContent); err != nil {
+			t.Fatalf("IndexPageContent %s: %v", page.ID, err)
+		}
+	}
+}
+
 func TestTagsService_IndexAllPages_BuildsIndex(t *testing.T) {
 	svc, ts := setupTagsService(t)
 
 	id1 := createPageWithTags(t, ts, "Page React", "react-page", []string{"react", "typescript"})
 	id2 := createPageWithTags(t, ts, "Page Go", "go-page", []string{"go"})
 
-	if err := svc.IndexAllPages(); err != nil {
-		t.Fatalf("IndexAllPages: %v", err)
-	}
+	indexAllPages(t, svc, ts)
 
 	pageIDs, err := svc.GetPageIDsByTags([]string{"react"})
 	if err != nil {
@@ -179,9 +197,10 @@ func TestTagsService_IndexAllPages_IsIdempotent(t *testing.T) {
 	createPageWithTags(t, ts, "Page A", "page-a", []string{"go"})
 
 	for i := 0; i < 3; i++ {
-		if err := svc.IndexAllPages(); err != nil {
-			t.Fatalf("IndexAllPages (run %d): %v", i, err)
+		if err := svc.ClearIndex(); err != nil {
+			t.Fatalf("ClearIndex (run %d): %v", i, err)
 		}
+		indexAllPages(t, svc, ts)
 	}
 
 	allTags, err := svc.GetAllTags("", 50)
@@ -205,9 +224,7 @@ func TestTagsService_IndexAllPages_PagesWithoutTagsAreSkipped(t *testing.T) {
 		t.Fatalf("UpdateNode: %v", err)
 	}
 
-	if err := svc.IndexAllPages(); err != nil {
-		t.Fatalf("IndexAllPages: %v", err)
-	}
+	indexAllPages(t, svc, ts)
 
 	allTags, err := svc.GetAllTags("", 50)
 	if err != nil {
@@ -222,9 +239,7 @@ func TestTagsService_IndexAllPages_NormalizesTagsToLowercase(t *testing.T) {
 	svc, ts := setupTagsService(t)
 	createPageWithTags(t, ts, "Mixed Case", "mixed", []string{"React", "TypeScript"})
 
-	if err := svc.IndexAllPages(); err != nil {
-		t.Fatalf("IndexAllPages: %v", err)
-	}
+	indexAllPages(t, svc, ts)
 
 	allTags, err := svc.GetAllTags("", 50)
 	if err != nil {
@@ -250,9 +265,7 @@ func TestTagsService_IndexAllPages_ReadsTagsFromRawFrontmatter(t *testing.T) {
 		t.Fatalf("expected parsed page content to exclude frontmatter tags, got %v", got)
 	}
 
-	if err := svc.IndexAllPages(); err != nil {
-		t.Fatalf("IndexAllPages: %v", err)
-	}
+	indexAllPages(t, svc, ts)
 
 	pageIDs, err := svc.GetPageIDsByTags([]string{"react"})
 	if err != nil {
@@ -352,8 +365,12 @@ func TestTagsService_IndexPageContent_NoFrontmatterStoresEmptyTags(t *testing.T)
 func TestTagsService_IndexPageContent_UpdatesExistingEntry(t *testing.T) {
 	svc, _ := setupTagsService(t)
 
-	_ = svc.IndexPageContent("page-1", "---\ntags:\n  - go\n---\n\nFirst version.")
-	_ = svc.IndexPageContent("page-1", "---\ntags:\n  - rust\n---\n\nSecond version.")
+	if err := svc.IndexPageContent("page-1", "---\ntags:\n  - go\n---\n\nFirst version."); err != nil {
+		t.Fatalf("IndexPageContent (first): %v", err)
+	}
+	if err := svc.IndexPageContent("page-1", "---\ntags:\n  - rust\n---\n\nSecond version."); err != nil {
+		t.Fatalf("IndexPageContent (second): %v", err)
+	}
 
 	tags, err := svc.GetPageIDsByTags([]string{"rust"})
 	if err != nil {
@@ -377,16 +394,14 @@ func TestTagsService_IndexAllPages_StoresExcerpts(t *testing.T) {
 
 	pageID := createPageWithTags(t, ts, "Excerpt Page", "excerpt-page", []string{"go"})
 
-	if err := svc.IndexAllPages(); err != nil {
-		t.Fatalf("IndexAllPages: %v", err)
-	}
+	indexAllPages(t, svc, ts)
 
 	exc, err := svc.GetExcerptsForPages([]string{pageID})
 	if err != nil {
 		t.Fatalf("GetExcerptsForPages: %v", err)
 	}
 	if exc[pageID] == "" {
-		t.Errorf("expected non-empty excerpt after IndexAllPages")
+		t.Errorf("expected non-empty excerpt after indexing")
 	}
 }
 

--- a/internal/wiki/pagesave/properties_effect_test.go
+++ b/internal/wiki/pagesave/properties_effect_test.go
@@ -23,7 +23,7 @@ func setupPropertiesEffectTest(t *testing.T) (*tree.TreeService, *properties.Pro
 	}
 	t.Cleanup(func() { test_utils.WrapCloseWithErrorCheck(store.Close, t) })
 
-	svc := properties.NewPropertiesService(treeSvc, store)
+	svc := properties.NewPropertiesService(store)
 	effect := NewPropertiesSideEffect(svc, nil)
 	return treeSvc, svc, effect
 }

--- a/internal/wiki/pagesave/tags_effect_test.go
+++ b/internal/wiki/pagesave/tags_effect_test.go
@@ -23,7 +23,7 @@ func setupTagsEffectTest(t *testing.T) (*tree.TreeService, *tags.TagsService, *T
 	}
 	t.Cleanup(func() { test_utils.WrapCloseWithErrorCheck(store.Close, t) })
 
-	svc := tags.NewTagsService(treeSvc, store)
+	svc := tags.NewTagsService(store)
 	effect := NewTagsSideEffect(svc, nil)
 	return treeSvc, svc, effect
 }

--- a/internal/wiki/tags/use_cases_test.go
+++ b/internal/wiki/tags/use_cases_test.go
@@ -26,7 +26,7 @@ func setupUseCases(t *testing.T) (*GetPagesByTagsUseCase, *coretags.TagsService,
 	}
 	t.Cleanup(func() { test_utils.WrapCloseWithErrorCheck(store.Close, t) })
 
-	svc := coretags.NewTagsService(ts, store)
+	svc := coretags.NewTagsService(store)
 	uc := NewGetPagesByTagsUseCase(svc, ts, nil)
 	return uc, svc, ts
 }

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -96,6 +96,7 @@ func NewWiki(options *WikiOptions) (*Wiki, error) {
 	if err := w.initPropertiesService(); err != nil {
 		return nil, err
 	}
+	w.bootstrapTagsAndProperties()
 	if err := w.initSearch(); err != nil {
 		return nil, err
 	}
@@ -203,10 +204,7 @@ func (w *Wiki) initTagsService() error {
 	if err != nil {
 		return fmt.Errorf("failed to init tags store: %w", err)
 	}
-	w.tags = tags.NewTagsService(w.tree, tagsStore)
-	if err := w.tags.IndexAllPages(); err != nil {
-		w.log.Warn("failed to index tags on startup", "error", err)
-	}
+	w.tags = tags.NewTagsService(tagsStore)
 	return nil
 }
 
@@ -215,11 +213,42 @@ func (w *Wiki) initPropertiesService() error {
 	if err != nil {
 		return fmt.Errorf("failed to init properties store: %w", err)
 	}
-	w.props = properties.NewPropertiesService(w.tree, propsStore)
-	if err := w.props.IndexAllPages(); err != nil {
-		w.log.Warn("failed to index properties on startup", "error", err)
-	}
+	w.props = properties.NewPropertiesService(propsStore)
 	return nil
+}
+
+// bootstrapTagsAndProperties clears and rebuilds tag and property indexes in a single
+// parallel GetPages pass — avoids two sequential ReadPageRaw loops at startup.
+func (w *Wiki) bootstrapTagsAndProperties() {
+	if err := w.tags.ClearIndex(); err != nil {
+		w.log.Warn("failed to clear tags index before bootstrap", "error", err)
+		return
+	}
+	if err := w.props.ClearIndex(); err != nil {
+		w.log.Warn("failed to clear properties index before bootstrap", "error", err)
+		return
+	}
+	var ids []string
+	if err := w.tree.WalkNodes(func(id string) error {
+		ids = append(ids, id)
+		return nil
+	}); err != nil {
+		w.log.Warn("failed to walk pages for tags/properties bootstrap", "error", err)
+		return
+	}
+	pages, errs := w.tree.GetPages(ids)
+	for i, page := range pages {
+		if errs[i] != nil {
+			w.log.Warn("skipping page during bootstrap", "pageID", ids[i], "error", errs[i])
+			continue
+		}
+		if err := w.tags.IndexPageContent(page.ID, page.RawContent); err != nil {
+			w.log.Warn("failed to index tags", "pageID", page.ID, "error", err)
+		}
+		if err := w.props.IndexPageContent(page.ID, page.RawContent); err != nil {
+			w.log.Warn("failed to index properties", "pageID", page.ID, "error", err)
+		}
+	}
 }
 
 func (w *Wiki) initSearch() error {


### PR DESCRIPTION
Both services only used tree for their IndexAllPages bootstrap — no runtime dependency. IndexAllPages is removed from both services; wiki.go now runs a single parallel GetPages pass at startup that feeds both indexes instead of two sequential ReadPageRaw loops