### PR TITLE
fix(ui): improve editor and asset layouts

### DIFF
--- a/ui/leafwiki-ui/src/features/assets/AssetItem.tsx
+++ b/ui/leafwiki-ui/src/features/assets/AssetItem.tsx
@@ -170,7 +170,7 @@ export function AssetItem({
       onDoubleClick={handleInsertMarkdown}
       data-testid="asset-item"
     >
-      <div className="flex flex-1 items-center gap-1">
+      <div className="flex min-w-0 flex-1 items-center gap-1">
         {isImage ? (
           <AssetPreviewTooltip url={assetUrl} name={baseName}>
             <img
@@ -199,102 +199,104 @@ export function AssetItem({
         )}
       </div>
 
-      {isEditing ? (
-        <>
-          <Button
-            variant="outline"
-            size="icon"
-            className="asset-item__action-button asset-item__action-button--save"
-            onClick={handleRename}
-            title="Save"
-          >
-            <Check size={16} />
-          </Button>
-          <Button
-            variant="outline"
-            size="icon"
-            className="asset-item__action-button asset-item__action-button--cancel"
-            onClick={() => {
-              setEditingFilename(null)
-              setNewName(baseName.replace(/\.[^/.]+$/, ''))
-            }}
-            title="Cancel"
-          >
-            <X size={16} />
-          </Button>
-        </>
-      ) : (
-        <>
-          {isImage && (
+      <div className="asset-item__actions">
+        {isEditing ? (
+          <>
+            <Button
+              variant="outline"
+              size="icon"
+              className="asset-item__action-button asset-item__action-button--save"
+              onClick={handleRename}
+              title="Save"
+            >
+              <Check size={16} />
+            </Button>
+            <Button
+              variant="outline"
+              size="icon"
+              className="asset-item__action-button asset-item__action-button--cancel"
+              onClick={() => {
+                setEditingFilename(null)
+                setNewName(baseName.replace(/\.[^/.]+$/, ''))
+              }}
+              title="Cancel"
+            >
+              <X size={16} />
+            </Button>
+          </>
+        ) : (
+          <>
+            {isImage && (
+              <Button
+                variant="outline"
+                size="icon"
+                className="asset-item__action-button"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  handleInsertLink()
+                }}
+                title="Insert image link"
+                data-testid="asset-insert-link-button"
+              >
+                <Link2 size={16} />
+              </Button>
+            )}
+            {isPlayableMedia && (
+              <Button
+                variant="outline"
+                size="icon"
+                className="asset-item__action-button"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  handleInsertPlayer()
+                }}
+                title={isAudio ? 'Insert audio player' : 'Insert video player'}
+                data-testid="asset-insert-player-button"
+              >
+                <Play size={16} />
+              </Button>
+            )}
             <Button
               variant="outline"
               size="icon"
               className="asset-item__action-button"
               onClick={(e) => {
                 e.stopPropagation()
-                handleInsertLink()
+                handleInsertMarkdown()
               }}
-              title="Insert image link"
-              data-testid="asset-insert-link-button"
+              title={isImage ? 'Insert image' : 'Insert link'}
+              data-testid="asset-insert-default-button"
             >
-              <Link2 size={16} />
+              <FileText size={16} />
             </Button>
-          )}
-          {isPlayableMedia && (
             <Button
               variant="outline"
               size="icon"
               className="asset-item__action-button"
               onClick={(e) => {
                 e.stopPropagation()
-                handleInsertPlayer()
+                setNewName(baseName.replace(/\.[^/.]+$/, ''))
+                setEditingFilename(filename)
               }}
-              title={isAudio ? 'Insert audio player' : 'Insert video player'}
-              data-testid="asset-insert-player-button"
+              title="Rename"
             >
-              <Play size={16} />
+              <Pencil size={16} />
             </Button>
-          )}
-          <Button
-            variant="outline"
-            size="icon"
-            className="asset-item__action-button"
-            onClick={(e) => {
-              e.stopPropagation()
-              handleInsertMarkdown()
-            }}
-            title={isImage ? 'Insert image' : 'Insert link'}
-            data-testid="asset-insert-default-button"
-          >
-            <FileText size={16} />
-          </Button>
-          <Button
-            variant="outline"
-            size="icon"
-            className="asset-item__action-button"
-            onClick={(e) => {
-              e.stopPropagation()
-              setNewName(baseName.replace(/\.[^/.]+$/, ''))
-              setEditingFilename(filename)
-            }}
-            title="Rename"
-          >
-            <Pencil size={16} />
-          </Button>
-          <Button
-            variant="outline"
-            size="icon"
-            className="asset-item__action-button asset-item__action-button--delete"
-            onClick={(e) => {
-              e.stopPropagation()
-              handleDelete()
-            }}
-            title="Delete"
-          >
-            <Trash2 size={16} />
-          </Button>
-        </>
-      )}
+            <Button
+              variant="outline"
+              size="icon"
+              className="asset-item__action-button asset-item__action-button--delete"
+              onClick={(e) => {
+                e.stopPropagation()
+                handleDelete()
+              }}
+              title="Delete"
+            >
+              <Trash2 size={16} />
+            </Button>
+          </>
+        )}
+      </div>
     </li>
   )
 }

--- a/ui/leafwiki-ui/src/features/tree/TreeViewActionButton.tsx
+++ b/ui/leafwiki-ui/src/features/tree/TreeViewActionButton.tsx
@@ -1,25 +1,28 @@
 import { TooltipWrapper } from '@/components/TooltipWrapper'
+import { ComponentPropsWithoutRef, forwardRef } from 'react'
 
 type TreeViewActionButtonProps = {
-  onClick?: () => void
   actionName: string
   icon: React.ReactNode
   tooltip: string
-}
+} & ComponentPropsWithoutRef<'button'>
 
-export function TreeViewActionButton({
-  onClick,
-  icon,
-  actionName,
-  tooltip,
-}: TreeViewActionButtonProps) {
+export const TreeViewActionButton = forwardRef<
+  HTMLButtonElement,
+  TreeViewActionButtonProps
+>(function TreeViewActionButton(
+  { onClick, icon, actionName, tooltip, type = 'button', ...props },
+  ref,
+) {
   return (
     <div className="group mr-2 flex">
       <TooltipWrapper label={tooltip} side="top" align="start">
         <button
-          type="button"
+          {...props}
+          ref={ref}
+          type={type}
           onClick={(e) => {
-            onClick?.()
+            onClick?.(e)
             e.stopPropagation()
           }}
           className="btn-treeview"
@@ -31,4 +34,4 @@ export function TreeViewActionButton({
       </TooltipWrapper>
     </div>
   )
-}
+})

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -663,7 +663,7 @@
   /* AssetItem Component */
 
   .asset-item {
-    @apply bg-surface hover:bg-surface-alt flex cursor-pointer items-center justify-between gap-2 rounded-md px-2 py-1 transition;
+    @apply bg-surface hover:bg-surface-alt flex flex-wrap items-start gap-2 rounded-md px-2 py-1 transition sm:flex-nowrap sm:items-center sm:justify-between;
   }
 
   .asset-item__preview-image {
@@ -680,6 +680,10 @@
 
   .asset-item__filename--editing-input {
     @apply border-surface-border text-interface-text w-full border-b bg-transparent text-sm focus:outline-hidden;
+  }
+
+  .asset-item__actions {
+    @apply flex w-full shrink-0 flex-wrap justify-end gap-2 sm:w-auto sm:flex-nowrap;
   }
 
   .asset-item__action-button {
@@ -748,12 +752,12 @@
   }
 
   .asset-manager__tip {
-    @apply text-muted mt-2 text-xs italic;
+    @apply text-muted mt-2 text-xs break-words italic;
   }
 
   /** AssetManager Dialog **/
   .asset-manager-dialog__content {
-    @apply max-w-4xl;
+    @apply max-w-2xl;
   }
 
   /* AssetPreviewTooltip */
@@ -795,7 +799,7 @@
   }
 
   .editor-title-bar {
-    @apply flex flex-1 flex-col items-center;
+    @apply flex flex-1 flex-col items-center justify-center;
   }
 
   .history-title-bar {
@@ -819,7 +823,7 @@
   }
 
   .editor-title-bar__icon {
-    @apply text-muted absolute top-1/2 -right-6 -translate-y-1/2 transition-transform duration-200 ease-in-out;
+    @apply text-muted ml-1 shrink-0 transition-transform duration-200 ease-in-out sm:absolute sm:top-1/2 sm:-right-6 sm:ml-0 sm:-translate-y-1/2;
   }
 
   .editor-title-bar__button:hover .editor-title-bar__icon {
@@ -831,7 +835,7 @@
   }
 
   .editor-title-bar__slug {
-    @apply bg-surface-alt text-interface-text mt-1 inline-block max-w-[15vw] truncate rounded px-2 py-0.5 font-mono text-xs sm:max-w-[40vw];
+    @apply bg-surface-alt text-interface-text mt-0.5 inline-block max-w-[15vw] truncate rounded px-2 py-0.5 font-mono text-xs sm:max-w-[40vw];
   }
 
   .history-title-bar__slug {

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -663,7 +663,7 @@
   /* AssetItem Component */
 
   .asset-item {
-    @apply bg-surface hover:bg-surface-alt flex flex-wrap items-start gap-2 rounded-md px-2 py-1 transition sm:flex-nowrap sm:items-center sm:justify-between;
+    @apply bg-surface hover:bg-surface-alt flex cursor-pointer flex-wrap items-start gap-2 rounded-md px-2 py-1 transition sm:flex-nowrap sm:items-center sm:justify-between;
   }
 
   .asset-item__preview-image {


### PR DESCRIPTION
Tighten the asset manager dialog and make asset rows wrap cleanly on smaller screens. Repair the tree view action trigger so its dropdown menu opens reliably again. Adjust the editor title bar spacing to improve mobile alignment without changing the surrounding header structure.