### PR TITLE
fix(ui): reset metadata dirty state

### DIFF
--- a/e2e/tests/editor.spec.ts
+++ b/e2e/tests/editor.spec.ts
@@ -127,6 +127,10 @@ async function addProperty(page: Page, key: string, value: string) {
   await page.locator(`[data-testid="page-frontmatter-field-value-${lastIndex}"]`).fill(value);
 }
 
+async function removeProperty(page: Page, index: number) {
+  await page.locator('.page-frontmatter-panel__field-remove').nth(index).click();
+}
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 test.describe('Editor', () => {
@@ -319,6 +323,99 @@ test.describe('Editor', () => {
     await expect(
       page.locator('.page-metadata__prop-value').filter({ hasText: 'two' }),
     ).toBeVisible();
+  });
+
+  test('editor-saves-properties-without-tags-and-resets-dirty-state', async ({ page }) => {
+    const stamp = Date.now();
+    const slug = `editor-properties-only-${stamp}`;
+
+    await createPageWithMetadata(page, {
+      title: `Editor Properties Only ${stamp}`,
+      slug,
+      content: 'Properties only content.',
+    });
+
+    const viewPage = new ViewPage(page);
+    await viewPage.goto(`/${slug}`);
+    await viewPage.clickEditPageButton();
+
+    const saveButton = page.locator('button[data-testid="save-page-button"]');
+    await saveButton.waitFor({ state: 'visible' });
+
+    await openFrontmatterPanel(page);
+    await addProperty(page, 'status', 'draft');
+    await expect(saveButton).toBeEnabled();
+
+    const editPage = new EditPage(page);
+    await editPage.savePage();
+    await expect(saveButton).toBeDisabled();
+    await editPage.closeEditor();
+
+    const propsToggle = page.locator('.page-metadata__props-toggle');
+    await propsToggle.waitFor({ state: 'visible' });
+
+    await expect(page.locator('.page-metadata')).toHaveClass(/page-metadata--two-col/);
+    await expect(page.locator('.page-metadata__tag-chip')).toHaveCount(0);
+
+    await propsToggle.click();
+    await expect(
+      page.locator('.page-metadata__prop-key').filter({ hasText: 'status' }),
+    ).toBeVisible();
+    await expect(
+      page.locator('.page-metadata__prop-value').filter({ hasText: 'draft' }),
+    ).toBeVisible();
+  });
+
+  test('editor-removes-all-properties-saves-and-resets-dirty-state', async ({ page }) => {
+    const stamp = Date.now();
+    const slug = `editor-remove-properties-${stamp}`;
+
+    await createPageWithMetadata(page, {
+      title: `Editor Remove Properties ${stamp}`,
+      slug,
+      content: 'Remove properties content.',
+      properties: { status: 'draft', owner: 'alice' },
+    });
+
+    const viewPage = new ViewPage(page);
+    await viewPage.goto(`/${slug}`);
+    await viewPage.clickEditPageButton();
+
+    const saveButton = page.locator('button[data-testid="save-page-button"]');
+    await saveButton.waitFor({ state: 'visible' });
+
+    await openFrontmatterPanel(page);
+    await expect(page.locator('[data-testid^="page-frontmatter-field-key-"]')).toHaveCount(2);
+    await removeProperty(page, 1);
+    await removeProperty(page, 0);
+    await expect(saveButton).toBeEnabled();
+
+    const editPage = new EditPage(page);
+    await editPage.savePage();
+    await expect(saveButton).toBeDisabled();
+    await editPage.closeEditor();
+
+    await expect(page.locator('.page-metadata')).toHaveCount(0);
+
+    const fetchedProperties = await page.evaluate(
+      async ({ path, csrfScript }) => {
+        const csrfToken = new Function(csrfScript)() as string;
+        const response = await fetch(`/api/pages/by-path?path=${encodeURIComponent(path)}`, {
+          credentials: 'include',
+          headers: { 'X-CSRF-Token': csrfToken },
+        });
+        if (!response.ok) {
+          throw new Error(`load failed: ${response.status}`);
+        }
+        const data = (await response.json()) as {
+          properties?: Record<string, string>;
+        };
+        return data.properties ?? {};
+      },
+      { path: slug, csrfScript: getCsrfScript() },
+    );
+
+    expect(fetchedProperties).toEqual({});
   });
 
   // ── Dirty state ─────────────────────────────────────────────────────────────

--- a/ui/leafwiki-ui/src/features/editor/pageEditorStore.ts
+++ b/ui/leafwiki-ui/src/features/editor/pageEditorStore.ts
@@ -62,6 +62,20 @@ function propertiesChanged(
   return editable.some((f) => String(original[f.key] ?? '') !== f.value)
 }
 
+function buildEditableProperties(
+  fields: EditorFrontmatterField[],
+): Record<string, string> {
+  const properties: Record<string, string> = {}
+
+  for (const field of fields) {
+    if (!field.internal && field.type === 'text' && field.key) {
+      properties[field.key] = field.value
+    }
+  }
+
+  return properties
+}
+
 export const isDirtyState = (s: PageEditorState) => {
   const { page, title, slug, content, tags, frontmatterFields } = s
   if (!page) return false
@@ -127,12 +141,7 @@ export const usePageEditorStore = create<PageEditorState>((set, get) => ({
       throw new Error('Please fix metadata errors before saving.')
     }
 
-    const properties: Record<string, string> = {}
-    for (const field of frontmatterFields) {
-      if (!field.internal && field.type === 'text' && field.key) {
-        properties[field.key] = field.value
-      }
-    }
+    const properties = buildEditableProperties(frontmatterFields)
 
     try {
       useProgressbarStore.getState().setLoading(true)
@@ -189,7 +198,14 @@ export const usePageEditorStore = create<PageEditorState>((set, get) => ({
         )
       }
 
-      // only update the page.content to avoid overwriting other fields
+      const nextTags = updatedPage?.tags ?? tags
+      const nextProperties =
+        updatedPage && updatedPage.properties
+          ? updatedPage.properties
+          : properties
+
+      // Keep the local page snapshot canonical after save so metadata-only
+      // updates do not remain dirty when the API omits empty collections.
       set((state) => {
         if (!state.page) return {}
 
@@ -204,10 +220,23 @@ export const usePageEditorStore = create<PageEditorState>((set, get) => ({
         state.page.content = updatedPage.content
         state.page.path = updatedPage.path
         state.page.version = updatedPage.version
-        state.page.tags = updatedPage.tags ?? tags
-        state.page.properties = updatedPage.properties ?? properties
+        state.page.tags = nextTags
+        state.page.properties = nextProperties
 
-        return { page: state.page }
+        return {
+          page: state.page,
+          tags: nextTags,
+          frontmatterFields: state.frontmatterFields.map((field) => {
+            if (field.internal || field.type !== 'text') {
+              return field
+            }
+
+            return {
+              ...field,
+              value: nextProperties[field.key] ?? field.value,
+            }
+          }),
+        }
       })
 
       // sync tree: full reload on structural changes, version-only patch otherwise

--- a/ui/leafwiki-ui/src/features/viewer/PageMetadata.tsx
+++ b/ui/leafwiki-ui/src/features/viewer/PageMetadata.tsx
@@ -29,6 +29,9 @@ export function PageMetadata({ page }: Props) {
 
   const hasTags = tags.length > 0
   const hasProperties = editableProps.length > 0
+  const metadataClassName = hasProperties
+    ? 'page-metadata page-metadata--two-col'
+    : 'page-metadata'
 
   if (!hasTags && !hasProperties) return null
 
@@ -47,13 +50,7 @@ export function PageMetadata({ page }: Props) {
   }
 
   return (
-    <div
-      className={
-        hasTags && hasProperties
-          ? 'page-metadata page-metadata--two-col'
-          : 'page-metadata'
-      }
-    >
+    <div className={metadataClassName}>
       {hasTags && (
         <div className="page-metadata__tags">
           <Tag size={13} className="page-metadata__tags-icon" />
@@ -73,7 +70,14 @@ export function PageMetadata({ page }: Props) {
       )}
 
       {hasProperties && (
-        <div className="page-metadata__properties">
+        <div
+          className={[
+            'page-metadata__properties',
+            !hasTags ? 'page-metadata__properties--standalone' : '',
+          ]
+            .filter(Boolean)
+            .join(' ')}
+        >
           <button
             type="button"
             className="page-metadata__props-toggle"

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -2667,6 +2667,10 @@
     @apply items-end;
   }
 
+  .page-metadata--two-col .page-metadata__properties--standalone {
+    @apply col-start-2;
+  }
+
   .page-metadata__tags {
     @apply flex items-center gap-1.5;
   }


### PR DESCRIPTION
Keep metadata-only saves from staying dirty after a successful save. Preserve the two-column metadata layout when only properties exist. Add E2E coverage for saving only properties and removing all properties.