### PR TITLE
security: harden supply chain across CI, Docker and dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,42 +1,72 @@
 version: 2
 updates:
-  # Backend dependencies
+  # GitHub Actions — supply chain: track action versions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore"
+    open-pull-requests-limit: 3
+
+  # Backend (Go)
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      go-dependencies:
+        patterns: ["*"]
     labels:
       - "dependencies"
       - "go"
     commit-message:
       prefix: "chore"
+    open-pull-requests-limit: 3
 
-  # Docker dependencies
+  # Docker base images
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels:
       - "dependencies"
+    commit-message:
+      prefix: "chore"
+    open-pull-requests-limit: 3
 
-  # Frontend dependencies
+  # Frontend (npm)
   - package-ecosystem: "npm"
     directory: "/ui/leafwiki-ui"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      npm-dependencies:
+        patterns: ["*"]
     labels:
       - "dependencies"
       - "frontend"
     commit-message:
       prefix: "chore"
+    open-pull-requests-limit: 3
 
-  # End-to-end tests
+  # End-to-end tests (npm)
   - package-ecosystem: "npm"
     directory: "/e2e"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      e2e-dependencies:
+        patterns: ["*"]
     labels:
       - "dependencies"
       - "e2e"
     commit-message:
       prefix: "chore"
+    open-pull-requests-limit: 3

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Lint with golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
-          version: v2.3.0
           args: --timeout=5m
     
   test-go:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -7,15 +7,18 @@ on:
       - release/*
       - releases/*
 
-jobs: 
+permissions:
+  contents: read
+
+jobs:
   lint-go:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.25.x'
 
@@ -23,19 +26,19 @@ jobs:
         run: go mod download
 
       - name: Lint with golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
-          version: latest
+          version: v2.3.0
           args: --timeout=5m
     
   test-go:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.25.x'
 
@@ -49,13 +52,19 @@ jobs:
           go tool cover -func=coverage/coverage.out
 
       - name: Upload coverage report as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-report
           path: coverage/coverage.out
       
+      - name: Run govulncheck
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        with:
+          go-version-input: '1.25.x'
+          go-package: './...'
+
       - name: Scan dependencies with Trivy
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-type: fs
           scan-ref: '.'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,25 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release/*
+      - releases/*
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: high
+          deny-licenses: AGPL-3.0, GPL-2.0, GPL-3.0

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,9 @@ on:
       - release/*
       - releases/*
 
+permissions:
+  contents: read
+
 jobs:
   lint-e2e-tests:
     name: format & lint check
@@ -17,10 +20,10 @@ jobs:
 
     steps: 
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
 
       - name: 📦 Install dependencies
         run: npm ci
@@ -35,10 +38,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install node & dependencies
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
 
       - name: 📦 Install dependencies
         run: npm ci

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -7,6 +7,9 @@ on:
       - release/*
       - releases/*
 
+permissions:
+  contents: read
+
 jobs:
   lint-frontend:
     runs-on: ubuntu-latest
@@ -17,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
 
@@ -34,7 +37,7 @@ jobs:
         run: npm run format:check
 
       - name: Scan dependencies with Trivy
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-type: fs
           scan-ref: 'ui/leafwiki-ui'

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -23,22 +23,36 @@ jobs:
 
       - name: Check all actions are SHA-pinned
         run: |
-          UNPINNED=$(grep -rn '^\s*uses:' .github/workflows/ \
+          FAILED=0
+          while IFS= read -r match; do
+            [ -z "$match" ] && continue
+            file=$(echo "$match" | cut -d: -f1)
+            line=$(echo "$match" | cut -d: -f2)
+            content=$(echo "$match" | cut -d: -f3-)
+            echo "::error file=${file},line=${line}::Unpinned action: ${content}"
+            FAILED=1
+          done <<< "$(grep -rn '^\s*uses:' .github/workflows/ \
             | grep -v 'uses: \.' \
-            | grep -vE '@[0-9a-f]{40}')
-          if [ -n "$UNPINNED" ]; then
-            echo "::error::Unpinned GitHub Actions found — use SHA hashes instead of tags:"
-            echo "$UNPINNED"
+            | grep -vE '@[0-9a-f]{40}')"
+          if [ "$FAILED" -eq 1 ]; then
+            echo "Fix: replace tags (@v4) with SHA hashes. Run: pinact run"
             exit 1
           fi
           echo "All GitHub Actions are properly SHA-pinned."
 
       - name: Check all Docker base images are digest-pinned
         run: |
-          UNPINNED=$(grep -rn '^FROM ' Dockerfile Dockerfile.builder | grep -v '@sha256:')
-          if [ -n "$UNPINNED" ]; then
-            echo "::error::Unpinned Docker base images found — use @sha256: digests:"
-            echo "$UNPINNED"
+          FAILED=0
+          while IFS= read -r match; do
+            [ -z "$match" ] && continue
+            file=$(echo "$match" | cut -d: -f1)
+            line=$(echo "$match" | cut -d: -f2)
+            content=$(echo "$match" | cut -d: -f3-)
+            echo "::error file=${file},line=${line}::Unpinned Docker image: ${content}"
+            FAILED=1
+          done <<< "$(grep -rn '^FROM ' Dockerfile Dockerfile.builder | grep -v '@sha256:')"
+          if [ "$FAILED" -eq 1 ]; then
+            echo "Fix: add @sha256: digest to each FROM line."
             exit 1
           fi
           echo "All Docker base images are properly digest-pinned."

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -1,0 +1,44 @@
+name: Lint Actions
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release/*
+      - releases/*
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  pinact-check:
+    name: Check pinned GitHub Actions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Check all actions are SHA-pinned
+        run: |
+          UNPINNED=$(grep -rn '^\s*uses:' .github/workflows/ \
+            | grep -v 'uses: \.' \
+            | grep -vE '@[0-9a-f]{40}')
+          if [ -n "$UNPINNED" ]; then
+            echo "::error::Unpinned GitHub Actions found — use SHA hashes instead of tags:"
+            echo "$UNPINNED"
+            exit 1
+          fi
+          echo "All GitHub Actions are properly SHA-pinned."
+
+      - name: Check all Docker base images are digest-pinned
+        run: |
+          UNPINNED=$(grep -rn '^FROM ' Dockerfile Dockerfile.builder | grep -v '@sha256:')
+          if [ -n "$UNPINNED" ]; then
+            echo "::error::Unpinned Docker base images found — use @sha256: digests:"
+            echo "$UNPINNED"
+            exit 1
+          fi
+          echo "All Docker base images are properly digest-pinned."

--- a/.github/workflows/lint-dependabot.yml
+++ b/.github/workflows/lint-dependabot.yml
@@ -1,0 +1,31 @@
+name: Lint Dependabot Config
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release/*
+      - releases/*
+    paths:
+      - '.github/dependabot.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/dependabot.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate Dependabot Configuration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Validate dependabot.yml against schema
+        uses: python-jsonschema/check-jsonschema@f805888065fdb6162e1f800e50bb9460cbd223d6 # 0.37.2
+        with:
+          builtin-checks: dependabot

--- a/.github/workflows/lint-dependabot.yml
+++ b/.github/workflows/lint-dependabot.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
+      - name: Install check-jsonschema
+        run: pip install check-jsonschema==0.37.2
+
       - name: Validate dependabot.yml against schema
-        uses: python-jsonschema/check-jsonschema@f805888065fdb6162e1f800e50bb9460cbd223d6 # 0.37.2
-        with:
-          builtin-checks: dependabot
+        run: check-jsonschema --builtin-schema vendor.dependabot .github/dependabot.yml

--- a/.github/workflows/proxy-auth-e2e.yml
+++ b/.github/workflows/proxy-auth-e2e.yml
@@ -7,6 +7,9 @@ on:
       - release/*
       - releases/*
 
+permissions:
+  contents: read
+
 jobs:
   proxy-auth-e2e:
     name: Reverse-Proxy Auth Integration Test
@@ -14,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25.x'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,20 +6,25 @@ on:
       - 'v*.*.*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write     # required for OIDC token (provenance attestation)
+  attestations: write # required to write attestation to GitHub
+
 jobs:
   release-binaries:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0  # Fetch all history for accurate changelog generation
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.25.x'
 
@@ -29,8 +34,13 @@ jobs:
           echo "Using version: $VERSION"
           make release VERSION=$VERSION
 
+      - name: Attest release binaries
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: 'releases/leafwiki-${{ github.ref_name }}-*'
+
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -68,7 +78,7 @@ jobs:
       - name: Publish GitHub Release
         # use pinned version because of issue described here:
         # https://github.com/softprops/action-gh-release/issues/628
-        uses: softprops/action-gh-release@v2.2.2
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
         if: github.ref_type == 'tag'
         with:
           tag_name: ${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 # Step 1: Frontend
-FROM node:26-alpine AS frontend-build
+FROM node:26-alpine@sha256:95034e722cecec716c00830160848aab85c7b8180a131bb4f4fed9d5278f0989 AS frontend-build
 WORKDIR /app
 ARG APP_VERSION
 COPY ./ui/leafwiki-ui/package*.json ./
-RUN npm install
+RUN npm ci --ignore-scripts
 COPY ./ui/leafwiki-ui/ ./
 RUN VITE_API_URL=/ APP_VERSION=${APP_VERSION} npm run build
 
 # Step 2: Backend + Build binary
-FROM golang:1.26-alpine AS backend-build
+FROM golang:1.26-alpine@sha256:f44b851aa23dfa219d18db6eab743203245429d355cb619cf96a2ffe2a84ba7a AS backend-build
 WORKDIR /app
 ARG DISABLE_REFRESH_TOKEN_RATE_LIMIT=false
 COPY go.mod go.sum ./
@@ -20,7 +20,7 @@ RUN CGO_ENABLED=0 go build \
 	-o /out/leafwiki ./cmd/leafwiki/main.go
 
 # Step 3: Final image (small)
-FROM alpine:3.23 AS final
+FROM alpine:3.23@sha256:4d889c14e7d5a73929ab00be2ef8ff22437e7cbc545931e52554a7b00e123d8b AS final
 WORKDIR /app
 COPY --from=backend-build /out/leafwiki /app/leafwiki
 

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,18 +1,18 @@
 # Stage 1: Frontend build
-FROM node:26-alpine AS frontend
+FROM node:26-alpine@sha256:95034e722cecec716c00830160848aab85c7b8180a131bb4f4fed9d5278f0989 AS frontend
 
 WORKDIR /ui
 ARG APP_VERSION
 
 COPY ./ui/leafwiki-ui/package.json ./package.json
 COPY ./ui/leafwiki-ui/package-lock.json ./package-lock.json
-RUN npm install
+RUN npm ci --ignore-scripts
 
 COPY ./ui/leafwiki-ui/ ./
 RUN VITE_API_URL=/ APP_VERSION=${APP_VERSION} npm run build
 
 # Stage 2: Go backend build
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26-alpine@sha256:f44b851aa23dfa219d18db6eab743203245429d355cb619cf96a2ffe2a84ba7a AS builder
 
 ARG GOOS
 ARG GOARCH

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,8 @@ endif
 		--tag ghcr.io/$(REPO_OWNER)/leafwiki:latest \
 		--annotation "index:org.opencontainers.image.title=LeafWiki" \
 		--annotation "index:org.opencontainers.image.description=LeafWiki – A fast wiki for people who think in folders, not feeds" \
+		--sbom=true \
+		--provenance=mode=max \
 		--push .
 
 # Generate markdown changelog between two tags

--- a/e2e/.npmrc
+++ b/e2e/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/ui/leafwiki-ui/.npmrc
+++ b/ui/leafwiki-ui/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
- Pin all GitHub Actions to SHA hashes (prevent tag-hijacking attacks)
- Pin all Docker base images to digest hashes in Dockerfile and Dockerfile.builder
- Add lint-actions.yml CI check that fails on any unpinned action or image
- Switch npm install to npm ci --ignore-scripts in both Dockerfiles
- Add .npmrc with ignore-scripts=true for frontend and e2e
- Add permissions: contents: read to all workflows (limit blast radius)
- Add govulncheck to backend CI for transitive Go dependency scanning
- Add dependency-review workflow to block PRs introducing HIGH/CRITICAL CVEs
- Add SLSA provenance attestation for release binaries
- Add --sbom and --provenance=mode=max to Docker image builds
- Update dependabot: monthly schedule, grouping, add github-actions ecosystem
- Pin golangci-lint to v2.3.0 (remove version: latest)