### PR TITLE
fix(auth): refresh before token expiry

### DIFF
--- a/internal/core/auth/auth_service.go
+++ b/internal/core/auth/auth_service.go
@@ -29,9 +29,10 @@ func NewAuthService(userService *UserService, sessionStore *SessionStore, secret
 }
 
 type AuthToken struct {
-	Token        string      `json:"token"`
-	RefreshToken string      `json:"refresh_token"`
-	User         *PublicUser `json:"user"`
+	Token                string      `json:"token"`
+	RefreshToken         string      `json:"refresh_token"`
+	AccessTokenExpiresAt int64       `json:"accessTokenExpiresAt"`
+	User                 *PublicUser `json:"user"`
 }
 
 func (a *AuthService) Login(identifier, password string) (*AuthToken, error) {
@@ -43,12 +44,12 @@ func (a *AuthService) Login(identifier, password string) (*AuthToken, error) {
 	// Clear sensitive information from user object
 	user.Password = "" // Clear password from user object
 
-	accessToken, _, err := a.generateToken(user, a.accessTokenLifetime, "access")
+	accessToken, _, accessTokenExpiresAt, err := a.generateToken(user, a.accessTokenLifetime, "access")
 	if err != nil {
 		return nil, err
 	}
 
-	refreshToken, refreshJTI, err := a.generateToken(user, a.refreshTokenLifetime, "refresh")
+	refreshToken, refreshJTI, _, err := a.generateToken(user, a.refreshTokenLifetime, "refresh")
 	if err != nil {
 		return nil, err
 	}
@@ -64,9 +65,10 @@ func (a *AuthService) Login(identifier, password string) (*AuthToken, error) {
 	}
 
 	return &AuthToken{
-		Token:        accessToken,
-		RefreshToken: refreshToken,
-		User:         user.ToPublicUser(),
+		Token:                accessToken,
+		RefreshToken:         refreshToken,
+		AccessTokenExpiresAt: accessTokenExpiresAt,
+		User:                 user.ToPublicUser(),
 	}, nil
 }
 
@@ -104,12 +106,12 @@ func (a *AuthService) RefreshToken(refreshToken string) (*AuthToken, error) {
 
 	user.Password = "" // Clear password from user object
 
-	newAccessToken, _, err := a.generateToken(user, a.accessTokenLifetime, "access")
+	newAccessToken, _, accessTokenExpiresAt, err := a.generateToken(user, a.accessTokenLifetime, "access")
 	if err != nil {
 		return nil, err
 	}
 
-	newRefreshToken, newRefreshJTI, err := a.generateToken(user, a.refreshTokenLifetime, "refresh")
+	newRefreshToken, newRefreshJTI, _, err := a.generateToken(user, a.refreshTokenLifetime, "refresh")
 	if err != nil {
 		return nil, err
 	}
@@ -134,9 +136,10 @@ func (a *AuthService) RefreshToken(refreshToken string) (*AuthToken, error) {
 	}
 
 	return &AuthToken{
-		Token:        newAccessToken,
-		RefreshToken: newRefreshToken,
-		User:         user.ToPublicUser(),
+		Token:                newAccessToken,
+		RefreshToken:         newRefreshToken,
+		AccessTokenExpiresAt: accessTokenExpiresAt,
+		User:                 user.ToPublicUser(),
 	}, nil
 }
 
@@ -191,13 +194,14 @@ func (a *AuthService) parseClaims(tokenString string) (jwt.MapClaims, error) {
 	return claims, nil
 }
 
-func (a *AuthService) generateToken(user *User, duration time.Duration, typ string) (string, string, error) {
+func (a *AuthService) generateToken(user *User, duration time.Duration, typ string) (string, string, int64, error) {
 	jti := generateJTI()
+	expiresAt := time.Now().Add(duration).Unix()
 	claims := jwt.MapClaims{
 		"sub":   user.ID,
 		"role":  user.Role,
 		"email": user.Email,
-		"exp":   time.Now().Add(duration).Unix(),
+		"exp":   expiresAt,
 		"iat":   time.Now().Unix(),
 		"typ":   typ,
 		"jti":   jti, // Unique identifier for the token
@@ -205,9 +209,9 @@ func (a *AuthService) generateToken(user *User, duration time.Duration, typ stri
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	signed, err := token.SignedString(a.secretKey)
 	if err != nil {
-		return "", "", err
+		return "", "", 0, err
 	}
-	return signed, jti, nil
+	return signed, jti, expiresAt, nil
 }
 
 func (a *AuthService) ValidateToken(tokenString string) (*User, error) {

--- a/internal/http/router_test.go
+++ b/internal/http/router_test.go
@@ -2842,6 +2842,10 @@ func TestAuthRefreshToken(t *testing.T) {
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
 	router := createRouterTestInstance(w, t)
 
+	type authResponse struct {
+		AccessTokenExpiresAt int64 `json:"accessTokenExpiresAt"`
+	}
+
 	// 1) Login
 	loginBody := `{"identifier": "admin", "password": "admin"}`
 	loginReq := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(loginBody))
@@ -2851,6 +2855,14 @@ func TestAuthRefreshToken(t *testing.T) {
 
 	if loginRec.Code != http.StatusOK {
 		t.Fatalf("Expected 200 OK on login, got %d", loginRec.Code)
+	}
+
+	var loginPayload authResponse
+	if err := json.Unmarshal(loginRec.Body.Bytes(), &loginPayload); err != nil {
+		t.Fatalf("Expected valid login JSON response, got error: %v", err)
+	}
+	if loginPayload.AccessTokenExpiresAt <= time.Now().Unix() {
+		t.Fatalf("Expected login response to include a future access token expiry, got %d", loginPayload.AccessTokenExpiresAt)
 	}
 
 	loginRes := loginRec.Result()
@@ -2886,6 +2898,14 @@ func TestAuthRefreshToken(t *testing.T) {
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("Expected 200 OK on refresh, got %d - %s", rec.Code, rec.Body.String())
+	}
+
+	var refreshPayload authResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &refreshPayload); err != nil {
+		t.Fatalf("Expected valid refresh JSON response, got error: %v", err)
+	}
+	if refreshPayload.AccessTokenExpiresAt <= time.Now().Unix() {
+		t.Fatalf("Expected refresh response to include a future access token expiry, got %d", refreshPayload.AccessTokenExpiresAt)
 	}
 
 	// optional: check if new cookies are set

--- a/internal/wiki/auth/routes.go
+++ b/internal/wiki/auth/routes.go
@@ -123,15 +123,15 @@ func (r *Routes) handleConfig(ctx httpinternal.RouterContext) gin.HandlerFunc {
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{
-			"publicAccess":              opts.PublicAccess,
-			"hideLinkMetadataSection":   opts.HideLinkMetadataSection,
-			"authDisabled":              opts.AuthDisabled,
-			"basePath":                  opts.BasePath,
-			"maxAssetUploadSizeBytes":   opts.MaxAssetUploadSizeBytes,
-			"enableRevision":            opts.EnableRevision,
-			"enableLinkRefactor":        opts.EnableLinkRefactor,
-			"httpRemoteUserEnabled":     opts.HTTPRemoteUser.Enabled,
-			"httpRemoteUserLogoutUrl":   opts.HTTPRemoteUser.LogoutURL,
+			"publicAccess":            opts.PublicAccess,
+			"hideLinkMetadataSection": opts.HideLinkMetadataSection,
+			"authDisabled":            opts.AuthDisabled,
+			"basePath":                opts.BasePath,
+			"maxAssetUploadSizeBytes": opts.MaxAssetUploadSizeBytes,
+			"enableRevision":          opts.EnableRevision,
+			"enableLinkRefactor":      opts.EnableLinkRefactor,
+			"httpRemoteUserEnabled":   opts.HTTPRemoteUser.Enabled,
+			"httpRemoteUserLogoutUrl": opts.HTTPRemoteUser.LogoutURL,
 		})
 	}
 }
@@ -187,7 +187,11 @@ func (r *Routes) handleLogin(rctx httpinternal.RouterContext) gin.HandlerFunc {
 			respondWithAuthStatusError(c, http.StatusBadRequest, ErrCodeAuthCookieFailed, "Failed to set authentication cookies", "failed to set authentication cookies")
 			return
 		}
-		c.JSON(http.StatusOK, gin.H{"message": "Login successful", "user": out.Token.User})
+		c.JSON(http.StatusOK, gin.H{
+			"message":              "Login successful",
+			"user":                 out.Token.User,
+			"accessTokenExpiresAt": out.Token.AccessTokenExpiresAt,
+		})
 	}
 }
 
@@ -243,7 +247,11 @@ func (r *Routes) handleRefreshToken(rctx httpinternal.RouterContext) gin.Handler
 			respondWithAuthStatusError(c, http.StatusInternalServerError, ErrCodeAuthCookieFailed, "Failed to set authentication cookies", "failed to set authentication cookies")
 			return
 		}
-		c.JSON(http.StatusOK, gin.H{"message": "Token refreshed", "user": out.Token.User})
+		c.JSON(http.StatusOK, gin.H{
+			"message":              "Token refreshed",
+			"user":                 out.Token.User,
+			"accessTokenExpiresAt": out.Token.AccessTokenExpiresAt,
+		})
 	}
 }
 

--- a/ui/leafwiki-ui/src/lib/api/auth.ts
+++ b/ui/leafwiki-ui/src/lib/api/auth.ts
@@ -4,6 +4,7 @@ import { API_BASE_URL } from '../config'
 import { ApiLocalizedError, isApiLocalizedErrorResponse } from './errors'
 
 export type AuthResponse = {
+  accessTokenExpiresAt: number
   message: string
   user: {
     id: string
@@ -14,6 +15,7 @@ export type AuthResponse = {
 }
 
 const REFRESH_TIMEOUT_MS = 15000
+const REFRESH_THRESHOLD_SECONDS = 60
 
 export class ApiError extends Error {
   status: number
@@ -83,7 +85,8 @@ export async function login(identifier: string, password: string) {
 
   const data: AuthResponse = await res.json()
 
-  const { setUser } = useSessionStore.getState()
+  const { setAccessTokenExpiresAt, setUser } = useSessionStore.getState()
+  setAccessTokenExpiresAt(data.accessTokenExpiresAt)
   setUser(data.user)
 
   return data
@@ -110,7 +113,9 @@ export async function fetchWithAuth(
 ): Promise<unknown> {
   const store = useSessionStore.getState()
   const sessionLogout = store.logout
-  const authDisabled = useConfigStore.getState().authDisabled
+  const config = useConfigStore.getState()
+  const authDisabled = config.authDisabled
+  const httpRemoteUserEnabled = config.httpRemoteUserEnabled
 
   const headers = new Headers(options.headers || {})
   if (!(options.body instanceof FormData)) {
@@ -143,18 +148,30 @@ export async function fetchWithAuth(
     })
   }
 
+  if (
+    shouldRefreshBeforeRequest(
+      store.user,
+      store.accessTokenExpiresAt,
+      authDisabled,
+      httpRemoteUserEnabled,
+    )
+  ) {
+    try {
+      await ensureRefresh()
+    } catch {
+      await clearSessionState(sessionLogout)
+      throw new Error('Unauthorized')
+    }
+  }
+
   let res = await doFetch()
 
-  if (res.status === 401 && retry && !authDisabled) {
+  if (res.status === 401 && retry && !authDisabled && !httpRemoteUserEnabled) {
     try {
       await ensureRefresh()
       res = await doFetch()
     } catch {
-      if (!authDisabled) {
-        sessionLogout()
-        const { setUser } = useSessionStore.getState()
-        setUser(null)
-      }
+      await clearSessionState(sessionLogout)
       throw new Error('Unauthorized')
     }
   }
@@ -214,6 +231,31 @@ if (typeof globalThis.__leafwikiRefreshPromise === 'undefined') {
   globalThis.__leafwikiRefreshPromise = null
 }
 
+function shouldRefreshBeforeRequest(
+  user: AuthResponse['user'] | null,
+  accessTokenExpiresAt: number | null,
+  authDisabled: boolean,
+  httpRemoteUserEnabled: boolean,
+): boolean {
+  if (authDisabled || httpRemoteUserEnabled || user === null) {
+    return false
+  }
+
+  if (accessTokenExpiresAt === null) {
+    return true
+  }
+
+  const nowInSeconds = Math.floor(Date.now() / 1000)
+  return accessTokenExpiresAt - nowInSeconds <= REFRESH_THRESHOLD_SECONDS
+}
+
+async function clearSessionState(sessionLogout: () => Promise<void>) {
+  await sessionLogout()
+  const { setAccessTokenExpiresAt, setUser } = useSessionStore.getState()
+  setAccessTokenExpiresAt(null)
+  setUser(null)
+}
+
 export function ensureRefresh(): Promise<void> {
   const { authDisabled } = useConfigStore.getState()
   if (authDisabled) {
@@ -247,7 +289,8 @@ async function refreshAccessToken() {
       throw new Error('Refresh failed')
     }
 
-    const data = await res.json()
+    const data: AuthResponse = await res.json()
+    store.setAccessTokenExpiresAt(data.accessTokenExpiresAt)
     store.setUser(data.user)
   } catch (error) {
     if (error instanceof DOMException && error.name === 'AbortError') {

--- a/ui/leafwiki-ui/src/lib/api/auth.ts
+++ b/ui/leafwiki-ui/src/lib/api/auth.ts
@@ -251,9 +251,6 @@ function shouldRefreshBeforeRequest(
 
 async function clearSessionState(sessionLogout: () => Promise<void>) {
   await sessionLogout()
-  const { setAccessTokenExpiresAt, setUser } = useSessionStore.getState()
-  setAccessTokenExpiresAt(null)
-  setUser(null)
 }
 
 export function ensureRefresh(): Promise<void> {

--- a/ui/leafwiki-ui/src/stores/session.ts
+++ b/ui/leafwiki-ui/src/stores/session.ts
@@ -11,7 +11,9 @@ type UserInfo = {
 
 type SessionState = {
   isRefreshing: boolean
+  accessTokenExpiresAt: number | null
   user: UserInfo | null
+  setAccessTokenExpiresAt: (value: number | null) => void
   setUser: (user: UserInfo | null) => void
   setRefreshing: (value: boolean) => void
   logout: () => Promise<void>
@@ -22,6 +24,8 @@ export const useSessionStore = create<SessionState>()(
     (set) => ({
       user: null,
       isRefreshing: false,
+      accessTokenExpiresAt: null,
+      setAccessTokenExpiresAt: (value) => set({ accessTokenExpiresAt: value }),
       setRefreshing: (value) => set({ isRefreshing: value }),
       setUser: (user) => set({ user }),
       logout: async () => {
@@ -30,13 +34,14 @@ export const useSessionStore = create<SessionState>()(
         } catch (err) {
           console.warn('Logout failed:', err)
         } finally {
-          set({ user: null })
+          set({ user: null, accessTokenExpiresAt: null })
         }
       },
     }),
     {
       name: 'session-storage',
       partialize: (state) => ({
+        accessTokenExpiresAt: state.accessTokenExpiresAt,
         user: state.user,
       }),
     },

--- a/ui/leafwiki-ui/src/stores/session.ts
+++ b/ui/leafwiki-ui/src/stores/session.ts
@@ -9,11 +9,14 @@ type UserInfo = {
   role: 'admin' | 'editor' | 'viewer'
 }
 
+// Unix timestamp in seconds, matching the backend's use of time.Now().Unix().
+type UnixTimestampSeconds = number
+
 type SessionState = {
   isRefreshing: boolean
-  accessTokenExpiresAt: number | null
+  accessTokenExpiresAt: UnixTimestampSeconds | null
   user: UserInfo | null
-  setAccessTokenExpiresAt: (value: number | null) => void
+  setAccessTokenExpiresAt: (value: UnixTimestampSeconds | null) => void
   setUser: (user: UserInfo | null) => void
   setRefreshing: (value: boolean) => void
   logout: () => Promise<void>


### PR DESCRIPTION
Return access token expiry metadata from login and refresh responses so the frontend can refresh proactively before protected requests.

This reduces visible 401 responses for expiring sessions while keeping the existing refresh-on-401 fallback in place.