### PR TITLE
feat: add health endpoint at GET /api/health

### DIFF
--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -112,7 +112,7 @@ start_local() {
       --allow-insecure=true \
       --enable-revision=true \
       --enable-link-refactor=true \
-      --jwt-secret=e2e-tests-secret \
+        --jwt-secret=e2e-tests-secret \
       --admin-password=admin
   ) >"$server_log" 2>&1 &
 

--- a/e2e/tests/health.spec.ts
+++ b/e2e/tests/health.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test';
+
+test('GET /api/health returns 200 with valid check fields', async ({ request }) => {
+  const resp = await request.get('/api/health');
+  expect(resp.status()).toBe(200);
+
+  const body = (await resp.json()) as { status: string; checks: Record<string, string> };
+  expect(body.status).toBe('ok');
+  expect(body.checks.sqlite).toBe('ok');
+  expect(body.checks.data_dir).toBe('ok');
+  // search may still be indexing on a fresh server
+  expect(['ok', 'indexing']).toContain(body.checks.search);
+});
+
+test('GET /api/health does not require authentication', async ({ request }) => {
+  const resp = await request.get('/api/health');
+  // Must never redirect to login or return 401/403
+  expect([200, 503]).toContain(resp.status());
+});

--- a/internal/search/indexing_status.go
+++ b/internal/search/indexing_status.go
@@ -56,6 +56,20 @@ func (s *IndexingStatus) IsActive() bool {
 	return s.Active
 }
 
+// IsFailed returns true if the last indexing run ended with failures.
+func (s *IndexingStatus) IsFailed() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return !s.Active && s.Failed > 0 && !s.FinishedAt.IsZero()
+}
+
+// IsReady returns true if indexing completed successfully.
+func (s *IndexingStatus) IsReady() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return !s.Active && s.Failed == 0 && !s.FinishedAt.IsZero()
+}
+
 func (s *IndexingStatus) Snapshot() *IndexingStatus {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/search/sqlite_index.go
+++ b/internal/search/sqlite_index.go
@@ -157,6 +157,12 @@ func (s *SQLiteIndex) Clear() error {
 	})
 }
 
+func (s *SQLiteIndex) Ping() error {
+	return s.withDB(func(db *sql.DB) error {
+		return db.Ping()
+	})
+}
+
 func (s *SQLiteIndex) Close() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/wiki/auth/use_cases.go
+++ b/internal/wiki/auth/use_cases.go
@@ -31,7 +31,9 @@ type LoginUseCase struct {
 	auth *coreauth.AuthService
 }
 
-func NewLoginUseCase(a *coreauth.AuthService) *LoginUseCase { return &LoginUseCase{auth: a} }
+func NewLoginUseCase(a *coreauth.AuthService) *LoginUseCase {
+	return &LoginUseCase{auth: a}
+}
 
 func (uc *LoginUseCase) Execute(_ context.Context, in LoginInput) (*LoginOutput, error) {
 	if uc.auth == nil {

--- a/internal/wiki/health/routes.go
+++ b/internal/wiki/health/routes.go
@@ -1,0 +1,45 @@
+package health
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	httpinternal "github.com/perber/wiki/internal/http"
+	"github.com/perber/wiki/internal/search"
+)
+
+type Routes struct {
+	health *HealthUseCase
+}
+
+type RoutesConfig struct {
+	Index      *search.SQLiteIndex
+	Status     *search.IndexingStatus
+	StorageDir string
+}
+
+func NewRoutes(cfg RoutesConfig) *Routes {
+	return &Routes{
+		health: NewHealthUseCase(cfg.Index, cfg.Status, cfg.StorageDir),
+	}
+}
+
+func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
+	ctx.Base.GET("/api/health", r.handleHealth)
+}
+
+func (r *Routes) handleHealth(c *gin.Context) {
+	healthy, checks := r.health.Execute()
+
+	status := "ok"
+	code := http.StatusOK
+	if !healthy {
+		status = "degraded"
+		code = http.StatusServiceUnavailable
+	}
+
+	c.JSON(code, gin.H{
+		"status": status,
+		"checks": checks,
+	})
+}

--- a/internal/wiki/health/use_cases.go
+++ b/internal/wiki/health/use_cases.go
@@ -1,0 +1,61 @@
+package health
+
+import (
+	"os"
+
+	"github.com/perber/wiki/internal/search"
+)
+
+type checkResult struct {
+	sqlite  string
+	dataDir string
+	search  string
+}
+
+type HealthUseCase struct {
+	index      *search.SQLiteIndex
+	status     *search.IndexingStatus
+	storageDir string
+}
+
+func NewHealthUseCase(index *search.SQLiteIndex, status *search.IndexingStatus, storageDir string) *HealthUseCase {
+	return &HealthUseCase{
+		index:      index,
+		status:     status,
+		storageDir: storageDir,
+	}
+}
+
+func (uc *HealthUseCase) Execute() (bool, map[string]string) {
+	r := checkResult{}
+
+	if err := uc.index.Ping(); err != nil {
+		r.sqlite = "failed"
+	} else {
+		r.sqlite = "ok"
+	}
+
+	if info, err := os.Stat(uc.storageDir); err != nil || !info.IsDir() {
+		r.dataDir = "failed"
+	} else {
+		r.dataDir = "ok"
+	}
+
+	switch {
+	case uc.status.IsFailed():
+		r.search = "failed"
+	case uc.status.IsReady():
+		r.search = "ok"
+	default:
+		r.search = "indexing"
+	}
+
+	checks := map[string]string{
+		"sqlite":   r.sqlite,
+		"data_dir": r.dataDir,
+		"search":   r.search,
+	}
+
+	healthy := r.sqlite == "ok" && r.dataDir == "ok" && r.search != "failed"
+	return healthy, checks
+}

--- a/internal/wiki/importer/use_cases.go
+++ b/internal/wiki/importer/use_cases.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"io"
 
-	coreimporter "github.com/perber/wiki/internal/importer"
 	sharederrors "github.com/perber/wiki/internal/core/shared/errors"
+	coreimporter "github.com/perber/wiki/internal/importer"
 )
 
 // ─── CreateImportPlanUseCase ─────────────────────────────────────────────────

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -22,6 +22,7 @@ import (
 	wikiassets "github.com/perber/wiki/internal/wiki/assets"
 	wikiauth "github.com/perber/wiki/internal/wiki/auth"
 	wikibranding "github.com/perber/wiki/internal/wiki/branding"
+	wikihealth "github.com/perber/wiki/internal/wiki/health"
 	wikiimporter "github.com/perber/wiki/internal/wiki/importer"
 	wikilinks "github.com/perber/wiki/internal/wiki/links"
 	wikipages "github.com/perber/wiki/internal/wiki/pages"
@@ -42,7 +43,7 @@ type Wiki struct {
 	branding     *branding.BrandingService
 	searchIndex  *search.SQLiteIndex
 	status       *search.IndexingStatus
-	storageDir   string
+	storageDir string
 
 	// Domain route registrars (populated by NewWiki).
 	pagesRoutes      *wikipages.Routes
@@ -55,6 +56,7 @@ type Wiki struct {
 	propertiesRoutes *wikiproperties.Routes
 	brandingRoutes   *wikibranding.Routes
 	importerRoutes   *wikiimporter.Routes
+	healthRoutes     *wikihealth.Routes
 	revision         *revision.Service
 	links            *links.LinkService
 	tags             *tags.TagsService
@@ -65,15 +67,15 @@ type Wiki struct {
 const SYSTEM_USER_ID = "system"
 
 type WikiOptions struct {
-	StorageDir              string        // Path to storage directory
-	AdminPassword           string        // Initial admin password
-	JWTSecret               string        // JWT secret for authentication
-	AccessTokenTimeout      time.Duration // Access token timeout duration
-	RefreshTokenTimeout     time.Duration // Refresh token timeout duration
-	AuthDisabled            bool          // Whether authentication is disabled
-	EnableRevision          bool          // Whether revision recording/storage is enabled
-	MaxRevisionHistory      int           // Max revisions kept per page; 0 = unlimited
-	MaxAssetUploadSizeBytes int64         // Maximum allowed size in bytes for asset/import uploads; 0 = default
+	StorageDir              string           // Path to storage directory
+	AdminPassword           string           // Initial admin password
+	JWTSecret               string           // JWT secret for authentication
+	AccessTokenTimeout      time.Duration    // Access token timeout duration
+	RefreshTokenTimeout     time.Duration    // Refresh token timeout duration
+	AuthDisabled            bool             // Whether authentication is disabled
+	EnableRevision          bool             // Whether revision recording/storage is enabled
+	MaxRevisionHistory      int              // Max revisions kept per page; 0 = unlimited
+	MaxAssetUploadSizeBytes int64 // Maximum allowed size in bytes for asset/import uploads; 0 = default
 }
 
 func NewWiki(options *WikiOptions) (*Wiki, error) {
@@ -292,6 +294,11 @@ func (w *Wiki) buildRoutes(options *WikiOptions) {
 	w.propertiesRoutes = w.buildPropertiesRoutes()
 	w.brandingRoutes = w.buildBrandingRoutes()
 	w.importerRoutes = w.buildImporterRoutes(options)
+	w.healthRoutes = wikihealth.NewRoutes(wikihealth.RoutesConfig{
+		Index:      w.searchIndex,
+		Status:     w.status,
+		StorageDir: w.storageDir,
+	})
 }
 
 // ─── Domain route builder helpers ────────────────────────────────────────────
@@ -448,6 +455,7 @@ func (w *Wiki) Registrars() []httpinternal.RouteRegistrar {
 		w.propertiesRoutes,
 		w.brandingRoutes,
 		w.importerRoutes,
+		w.healthRoutes,
 	}
 }
 


### PR DESCRIPTION
Adds a lightweight health check endpoint that verifies SQLite connectivity, the data directory, and search index status. Returns 200 OK with check details or 503 if degraded. No authentication required. Prometheus dependency removed.

Includes e2e tests for the health endpoint.