### PR TITLE
fix: GET /api/auth/me never returns 401 to avoid Basic Auth credential reset

### DIFF
--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -1,9 +1,52 @@
-import test from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import LoginPage from '../pages/LoginPage';
 import ViewPage from '../pages/ViewPage';
 
 const user = process.env.E2E_ADMIN_USER || 'admin';
 const password = process.env.E2E_ADMIN_PASSWORD || 'admin';
+
+// GET /api/auth/me must never return 401, even without a session.
+// A 401 causes browsers behind a Basic Auth reverse proxy (e.g. Traefik
+// basicAuth middleware) to discard their cached credentials and re-prompt.
+test('GET /api/auth/me without session returns 200 with null body, not 401', async ({
+  request,
+}) => {
+  const resp = await request.get('/api/auth/me');
+  expect(resp.status()).toBe(200);
+  const body = await resp.json();
+  expect(body).toBeNull();
+});
+
+test('GET /api/auth/me with valid session returns the authenticated user', async ({ request }) => {
+  const login = await request.post('/api/auth/login', {
+    data: { identifier: user, password },
+  });
+  expect(login.status()).toBe(200);
+
+  const resp = await request.get('/api/auth/me');
+  expect(resp.status()).toBe(200);
+  const body = await resp.json();
+  expect(body).not.toBeNull();
+  expect(body.username).toBe(user);
+  expect(body.role).toBe('admin');
+});
+
+test('GET /api/auth/me has Cache-Control: no-store on unauthenticated requests', async ({
+  request,
+}) => {
+  const resp = await request.get('/api/auth/me');
+  expect(resp.headers()['cache-control']).toBe('no-store');
+});
+
+test('GET /api/auth/me has Cache-Control: no-store on authenticated requests', async ({
+  request,
+}) => {
+  await request.post('/api/auth/login', {
+    data: { identifier: user, password },
+  });
+  const resp = await request.get('/api/auth/me');
+  expect(resp.headers()['cache-control']).toBe('no-store');
+});
 
 test('failed login', async ({ page }) => {
   const loginPage = new LoginPage(page);

--- a/internal/http/middleware/auth/auth.go
+++ b/internal/http/middleware/auth/auth.go
@@ -112,6 +112,32 @@ func RequireSelfOrAdmin(authDisabled bool) gin.HandlerFunc {
 	}
 }
 
+// OptionalAuth validates the session cookie if present and stores the user in context,
+// but unlike RequireAuth it does not abort the request for unauthenticated callers.
+// Exception: a token IS present but authService is nil — that is a misconfiguration
+// and aborts with 500, matching RequireAuth's behaviour for the same case.
+func OptionalAuth(authService *auth.AuthService, authCookies *AuthCookies) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if _, exists := c.Get("user"); exists {
+			c.Next()
+			return
+		}
+		token, err := authCookies.ReadAccess(c)
+		if err != nil || token == "" {
+			c.Next()
+			return
+		}
+		if authService == nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Authentication service unavailable"})
+			return
+		}
+		if user, err := authService.ValidateToken(token); err == nil {
+			c.Set("user", user)
+		}
+		c.Next()
+	}
+}
+
 func RequireEditorOrAdmin() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userValue, exists := c.Get("user")

--- a/internal/http/middleware/auth/auth_test.go
+++ b/internal/http/middleware/auth/auth_test.go
@@ -580,3 +580,153 @@ func TestRequireAuth_ComprehensiveScenarios(t *testing.T) {
 		})
 	}
 }
+
+func TestOptionalAuth_NoToken_PassesThrough(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	authCookies := authmw.NewAuthCookies(true, time.Hour, time.Hour*24)
+	router := gin.New()
+	router.Use(authmw.OptionalAuth(nil, authCookies))
+	router.GET("/test", func(c *gin.Context) {
+		_, exists := c.Get("user")
+		if exists {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "unexpected user in context"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"user": nil})
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for no token, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestOptionalAuth_ValidToken_SetsUser(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	fixture := createTestAuthFixture(t)
+	defer func() {
+		if err := fixture.close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+	}()
+
+	authCookies := authmw.NewAuthCookies(true, time.Hour, time.Hour*24)
+	authToken, err := fixture.auth.Login("admin", "admin")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+
+	router := gin.New()
+	router.Use(authmw.OptionalAuth(fixture.auth, authCookies))
+	router.GET("/test", func(c *gin.Context) {
+		v, exists := c.Get("user")
+		if !exists {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "user not in context"})
+			return
+		}
+		u, ok := v.(*coreauth.User)
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "wrong type"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"username": u.Username})
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.AddCookie(&http.Cookie{Name: "leafwiki_at", Value: authToken.Token})
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if w.Body.String() != `{"username":"admin"}` {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestOptionalAuth_InvalidToken_PassesThrough(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	fixture := createTestAuthFixture(t)
+	defer func() {
+		if err := fixture.close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+	}()
+
+	authCookies := authmw.NewAuthCookies(true, time.Hour, time.Hour*24)
+	router := gin.New()
+	router.Use(authmw.OptionalAuth(fixture.auth, authCookies))
+	router.GET("/test", func(c *gin.Context) {
+		_, exists := c.Get("user")
+		if exists {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "unexpected user for invalid token"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"user": nil})
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.AddCookie(&http.Cookie{Name: "leafwiki_at", Value: "invalid-token"})
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for invalid token, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestOptionalAuth_NilAuthService_WithToken_Returns500(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	authCookies := authmw.NewAuthCookies(true, time.Hour, time.Hour*24)
+	router := gin.New()
+	router.Use(authmw.OptionalAuth(nil, authCookies))
+	router.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.AddCookie(&http.Cookie{Name: "leafwiki_at", Value: "some-token"})
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500 for nil authService with token, got %d: %s", w.Code, w.Body.String())
+	}
+	expected := `{"error":"Authentication service unavailable"}`
+	if w.Body.String() != expected {
+		t.Errorf("expected %s, got %s", expected, w.Body.String())
+	}
+}
+
+func TestOptionalAuth_UserAlreadyInContext_ShortCircuits(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	authCookies := authmw.NewAuthCookies(true, time.Hour, time.Hour*24)
+	injected := &coreauth.User{ID: "proxy-user", Username: "proxy", Role: coreauth.RoleViewer}
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("user", injected)
+		c.Next()
+	})
+	router.Use(authmw.OptionalAuth(nil, authCookies))
+	router.GET("/test", func(c *gin.Context) {
+		v, _ := c.Get("user")
+		u := v.(*coreauth.User)
+		c.JSON(http.StatusOK, gin.H{"username": u.Username})
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	if w.Body.String() != `{"username":"proxy"}` {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}

--- a/internal/http/middleware/auth/current_user.go
+++ b/internal/http/middleware/auth/current_user.go
@@ -23,3 +23,16 @@ func MustGetUser(c *gin.Context) *auth.User {
 
 	return user
 }
+
+// TryGetUser returns the authenticated user from context, or nil if not set.
+func TryGetUser(c *gin.Context) *auth.User {
+	v, exists := c.Get("user")
+	if !exists {
+		return nil
+	}
+	user, ok := v.(*auth.User)
+	if !ok {
+		return nil
+	}
+	return user
+}

--- a/internal/http/router_test.go
+++ b/internal/http/router_test.go
@@ -610,6 +610,75 @@ func createZipFromDir(t *testing.T, root string) []byte {
 	return body.Bytes()
 }
 
+func TestMeEndpoint_Unauthenticated_Returns200WithNullBody(t *testing.T) {
+	w := createWikiTestInstance(t)
+	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
+	router := createRouterTestInstance(w, t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/me", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for unauthenticated /auth/me, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if body := strings.TrimSpace(rec.Body.String()); body != "null" {
+		t.Errorf("expected null body for unauthenticated request, got %q", body)
+	}
+}
+
+func TestMeEndpoint_Authenticated_ReturnsUser(t *testing.T) {
+	w := createWikiTestInstance(t)
+	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
+	router := createRouterTestInstance(w, t)
+
+	rec := authenticatedRequest(t, router, http.MethodGet, "/api/auth/me", nil)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for authenticated /auth/me, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode /auth/me response: %v", err)
+	}
+	if body["username"] != "admin" {
+		t.Errorf("expected username=admin, got %v", body["username"])
+	}
+	if body["role"] != "admin" {
+		t.Errorf("expected role=admin, got %v", body["role"])
+	}
+}
+
+func TestMeEndpoint_HasNoCacheHeaders(t *testing.T) {
+	w := createWikiTestInstance(t)
+	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
+	router := createRouterTestInstance(w, t)
+
+	for _, name := range []string{"unauthenticated", "authenticated"} {
+		t.Run(name, func(t *testing.T) {
+			var rec *httptest.ResponseRecorder
+			if name == "authenticated" {
+				rec = authenticatedRequest(t, router, http.MethodGet, "/api/auth/me", nil)
+			} else {
+				req := httptest.NewRequest(http.MethodGet, "/api/auth/me", nil)
+				rec = httptest.NewRecorder()
+				router.ServeHTTP(rec, req)
+			}
+
+			if cc := rec.Header().Get("Cache-Control"); cc != "no-store" {
+				t.Errorf("expected Cache-Control: no-store, got %q", cc)
+			}
+			if p := rec.Header().Get("Pragma"); p != "no-cache" {
+				t.Errorf("expected Pragma: no-cache, got %q", p)
+			}
+			if exp := rec.Header().Get("Expires"); exp == "" {
+				t.Error("expected Expires header to be set")
+			}
+		})
+	}
+}
+
 func TestCreatePageEndpoint(t *testing.T) {
 	w := createWikiTestInstance(t)
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)

--- a/internal/wiki/auth/routes.go
+++ b/internal/wiki/auth/routes.go
@@ -80,6 +80,16 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	// Config endpoint also lives here as it issues the CSRF cookie.
 	nonAuth.GET("/config", r.handleConfig(ctx))
 
+	// /auth/me uses optional auth so that unauthenticated callers get 200+null
+	// instead of 401, which would cause browsers behind a Basic Auth reverse
+	// proxy to discard their cached credentials.
+	meGroup := ctx.Base.Group("/api")
+	meGroup.Use(
+		authmw.InjectPublicEditor(opts.AuthDisabled),
+		authmw.OptionalAuth(r.authService, ctx.AuthCookies),
+	)
+	meGroup.GET("/auth/me", r.handleMe)
+
 	authGroup := ctx.Base.Group("/api")
 	authGroup.Use(
 		authmw.InjectPublicEditor(opts.AuthDisabled),
@@ -87,7 +97,6 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 		security.CSRFMiddleware(ctx.CSRFCookie),
 	)
 
-	authGroup.GET("/auth/me", r.handleMe)
 	authGroup.POST("/auth/logout", r.handleLogout(ctx))
 
 	authGroup.POST("/users", authmw.RequireAdmin(opts.AuthDisabled), r.handleCreateUser)
@@ -136,12 +145,18 @@ func (r *Routes) handleConfig(ctx httpinternal.RouterContext) gin.HandlerFunc {
 	}
 }
 
-// handleMe returns the currently authenticated user from the Gin context.
-// The user is already resolved and validated by the middleware chain
-// (InjectRemoteUser for proxy auth, RequireAuth for JWT) — no DB lookup needed.
+// handleMe returns the currently authenticated user or null.
+// Uses TryGetUser (not MustGetUser) so unauthenticated callers receive 200+null
+// instead of 401, avoiding the Basic Auth credential-reset issue (RFC 9110 §15.5.2).
+// Cache headers prevent reverse proxies from caching the identity response.
 func (r *Routes) handleMe(c *gin.Context) {
-	user := authmw.MustGetUser(c)
+	c.Header("Cache-Control", "no-store")
+	c.Header("Pragma", "no-cache")
+	c.Header("Expires", time.Unix(0, 0).UTC().Format(http.TimeFormat))
+
+	user := authmw.TryGetUser(c)
 	if user == nil {
+		c.JSON(http.StatusOK, nil)
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -263,13 +263,13 @@ func (w *Wiki) initSearch() error {
 	searchEffect := pagesave.NewSearchIndexSideEffect(w.searchIndex, w.tree, w.log)
 	go func() {
 		w.status.Start()
+		defer w.status.Finish()
 		if err := searchEffect.IndexAllPages(); err != nil {
 			w.log.Warn("search bootstrap failed", "error", err)
 			w.status.Fail()
 		} else {
 			w.status.Success()
 		}
-		w.status.Finish()
 	}()
 	return nil
 }

--- a/ui/leafwiki-ui/src/lib/api/auth.ts
+++ b/ui/leafwiki-ui/src/lib/api/auth.ts
@@ -42,14 +42,15 @@ function getCsrfTokenFromCookie(): string | null {
   }
 }
 
-export async function fetchMe(): Promise<AuthResponse['user']> {
+export async function fetchMe(): Promise<AuthResponse['user'] | null> {
   const res = await fetch(`${API_BASE_URL}/api/auth/me`, {
     credentials: 'include',
   })
   if (!res.ok) {
-    throw new Error('Not authenticated')
+    throw new ApiError(`/api/auth/me returned ${res.status}`, res.status)
   }
-  return res.json()
+  const user = await res.json()
+  return user ?? null
 }
 
 export async function login(identifier: string, password: string) {
@@ -283,7 +284,7 @@ async function refreshAccessToken() {
     })
 
     if (!res.ok) {
-      throw new Error('Refresh failed')
+      throw new ApiError('Refresh failed', res.status)
     }
 
     const data: AuthResponse = await res.json()

--- a/ui/leafwiki-ui/src/lib/bootstrapAuth.ts
+++ b/ui/leafwiki-ui/src/lib/bootstrapAuth.ts
@@ -1,7 +1,7 @@
 import { useConfigStore } from '@/stores/config'
 import { useSessionStore } from '@/stores/session'
 import { useEffect } from 'react'
-import { ensureRefresh, fetchMe } from './api/auth'
+import { ApiError, ensureRefresh, fetchMe } from './api/auth'
 
 export function useBootstrapAuth(enabled = true) {
   const setUser = useSessionStore((s) => s.setUser)
@@ -27,7 +27,13 @@ export function useBootstrapAuth(enabled = true) {
           await ensureRefresh()
         }
       } catch (err) {
-        if (!cancelled) setUser(null)
+        // Only clear the session for explicit auth failures (4xx).
+        // Server errors (5xx) and network failures must not log the user out —
+        // the backend returns 200 for both authenticated and unauthenticated
+        // states, so a throw always indicates a genuine server problem.
+        const isAuthFailure =
+          err instanceof ApiError && err.status >= 400 && err.status < 500
+        if (!cancelled && isAuthFailure) setUser(null)
         console.debug('[bootstrapAuth] Auth bootstrap failed:', err)
       } finally {
         if (!cancelled) setRefreshing(false)


### PR DESCRIPTION
Unauthenticated requests to /api/auth/me previously returned 401, causing browsers behind a Basic Auth reverse proxy (e.g. Traefik basicAuth) to discard their cached credentials. Moves the endpoint to an OptionalAuth group that returns 200+null when no session is present. Adds Cache-Control: no-store to prevent reverse proxies from caching the identity response. Preserves the frontend session on 5xx/network errors (only clears on 4xx).

Closes #1013