### PR TITLE
fix: recover from corrupt SQLite database files on startup

### DIFF
--- a/internal/core/shared/sqliteutil/sqlite.go
+++ b/internal/core/shared/sqliteutil/sqlite.go
@@ -1,0 +1,44 @@
+package sqliteutil
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+
+	sqlite "modernc.org/sqlite"
+)
+
+// IsSQLiteRecoverableError reports whether err is a SQLite I/O or corruption
+// error that may be resolved by deleting the database files and retrying.
+// Transient errors (SQLITE_BUSY, SQLITE_LOCKED) and resource errors
+// (SQLITE_IOERR_NOMEM) are not considered recoverable.
+func IsSQLiteRecoverableError(err error) bool {
+	var e *sqlite.Error
+	if !errors.As(err, &e) {
+		return false
+	}
+	code := e.Code()
+	// SQLITE_IOERR_NOMEM (10 | 12<<8 = 3082): SQLite could not allocate
+	// memory during an I/O operation. The file itself is not corrupt;
+	// deleting it would not help and would destroy the index unnecessarily.
+	if code == 10|(12<<8) {
+		return false
+	}
+	// Primary error code lives in the low 8 bits of the extended code.
+	// SQLITE_IOERR=10, SQLITE_CORRUPT=11, SQLITE_NOTADB=26
+	switch code & 0xFF {
+	case 10, 11, 26:
+		return true
+	}
+	return false
+}
+
+// RemoveSQLiteFiles deletes a SQLite database and any sidecar files
+// (-journal, -wal, -shm) that may have been left behind by a crashed run.
+func RemoveSQLiteFiles(dbPath string) {
+	for _, path := range []string{dbPath, dbPath + "-journal", dbPath + "-wal", dbPath + "-shm"} {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			slog.Default().Warn("failed to remove database file", "path", path, "error", err)
+		}
+	}
+}

--- a/internal/core/shared/sqliteutil/sqlite_test.go
+++ b/internal/core/shared/sqliteutil/sqlite_test.go
@@ -1,0 +1,104 @@
+package sqliteutil
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"unsafe"
+
+	sqlite "modernc.org/sqlite"
+)
+
+func TestIsSQLiteRecoverableError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "SQLITE_IOERR",
+			err:  sqliteErrorWithCode(10),
+			want: true,
+		},
+		{
+			name: "SQLITE_CORRUPT",
+			err:  sqliteErrorWithCode(11),
+			want: true,
+		},
+		{
+			name: "SQLITE_NOTADB",
+			err:  sqliteErrorWithCode(26),
+			want: true,
+		},
+		{
+			name: "SQLITE_IOERR_NOMEM",
+			err:  sqliteErrorWithCode(10 | (12 << 8)),
+			want: false,
+		},
+		{
+			name: "SQLITE_BUSY",
+			err:  sqliteErrorWithCode(5),
+			want: false,
+		},
+		{
+			name: "SQLITE_LOCKED",
+			err:  sqliteErrorWithCode(6),
+			want: false,
+		},
+		{
+			name: "non-sqlite error",
+			err:  errors.New("boom"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsSQLiteRecoverableError(tt.err); got != tt.want {
+				t.Fatalf("IsSQLiteRecoverableError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRemoveSQLiteFiles(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "search.db")
+	paths := []string{dbPath, dbPath + "-journal", dbPath + "-wal", dbPath + "-shm"}
+
+	for _, path := range paths {
+		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+			t.Fatalf("failed to create %q: %v", path, err)
+		}
+	}
+
+	RemoveSQLiteFiles(dbPath)
+
+	for _, path := range paths {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("expected %q to be removed, err=%v", path, err)
+		}
+	}
+}
+
+func TestRemoveSQLiteFiles_NoOpWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "missing.db")
+
+	RemoveSQLiteFiles(dbPath)
+
+	for _, path := range []string{dbPath, dbPath + "-journal", dbPath + "-wal", dbPath + "-shm"} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("expected %q to remain absent, err=%v", path, err)
+		}
+	}
+}
+
+func sqliteErrorWithCode(code int) error {
+	e := &sqlite.Error{}
+	v := reflect.ValueOf(e).Elem().FieldByName("code")
+	reflect.NewAt(v.Type(), unsafe.Pointer(v.UnsafeAddr())).Elem().SetInt(int64(code))
+	return e
+}

--- a/internal/core/shared/sqliteutil/sqlite_test.go
+++ b/internal/core/shared/sqliteutil/sqlite_test.go
@@ -98,6 +98,9 @@ func TestRemoveSQLiteFiles_NoOpWhenMissing(t *testing.T) {
 
 func sqliteErrorWithCode(code int) error {
 	e := &sqlite.Error{}
+	// modernc.org/sqlite does not expose a public constructor for sqlite.Error,
+	// so tests set the private `code` field directly to synthesize specific
+	// result codes.
 	v := reflect.ValueOf(e).Elem().FieldByName("code")
 	reflect.NewAt(v.Type(), unsafe.Pointer(v.UnsafeAddr())).Elem().SetInt(int64(code))
 	return e

--- a/internal/links/links_store.go
+++ b/internal/links/links_store.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/perber/wiki/internal/core/shared/sqliteutil"
 	_ "modernc.org/sqlite" // Import SQLite driver
 )
 
@@ -39,14 +40,26 @@ func NewLinksStore(storageDir string) (*LinksStore, error) {
 		filename:   "links.db",
 	}
 
-	err := s.Connect()
-	if err != nil {
+	if err := s.Connect(); err != nil {
 		return nil, err
 	}
 
-	// Ensure the schema is created
-	if err = s.ensureSchema(); err != nil {
-		return nil, err
+	if err := s.ensureSchema(); err != nil {
+		_ = s.db.Close()
+		s.db = nil
+		if !sqliteutil.IsSQLiteRecoverableError(err) {
+			return nil, err
+		}
+		slog.Default().Warn("links database corrupt, removing and retrying", "error", err)
+		sqliteutil.RemoveSQLiteFiles(linksDatabasePath(s.storageDir, s.filename))
+		if err2 := s.Connect(); err2 != nil {
+			return nil, err2
+		}
+		if err2 := s.ensureSchema(); err2 != nil {
+			_ = s.db.Close()
+			s.db = nil
+			return nil, err2
+		}
 	}
 
 	return s, nil

--- a/internal/properties/properties_store.go
+++ b/internal/properties/properties_store.go
@@ -3,11 +3,13 @@ package properties
 import (
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"path/filepath"
 	"strings"
 	"sync"
 
 	"github.com/perber/wiki/internal/core/shared"
+	"github.com/perber/wiki/internal/core/shared/sqliteutil"
 	_ "modernc.org/sqlite"
 )
 
@@ -40,7 +42,20 @@ func NewPropertiesStore(storageDir string) (*PropertiesStore, error) {
 	s := &PropertiesStore{db: db}
 	if err := s.ensureSchema(); err != nil {
 		_ = db.Close()
-		return nil, err
+		if !sqliteutil.IsSQLiteRecoverableError(err) {
+			return nil, err
+		}
+		slog.Default().Warn("properties database corrupt, removing and retrying", "error", err)
+		sqliteutil.RemoveSQLiteFiles(dbPath)
+		db, err = sql.Open("sqlite", dbPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to reopen properties database after recovery: %w", err)
+		}
+		s = &PropertiesStore{db: db}
+		if err = s.ensureSchema(); err != nil {
+			_ = db.Close()
+			return nil, err
+		}
 	}
 	return s, nil
 }

--- a/internal/search/sqlite_index.go
+++ b/internal/search/sqlite_index.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
-	"log"
 	"log/slog"
 	"path/filepath"
 	"strings"
@@ -12,11 +11,12 @@ import (
 
 	"github.com/perber/wiki/internal/core/excerpt"
 	"github.com/perber/wiki/internal/core/markdown"
+	"github.com/perber/wiki/internal/core/shared/sqliteutil"
 	"github.com/perber/wiki/internal/core/tree"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/text"
-	_ "modernc.org/sqlite" // Import SQLite driver
+	_ "modernc.org/sqlite"
 )
 
 type SQLiteIndex struct {
@@ -108,14 +108,27 @@ func NewSQLiteIndex(storageDir string) (*SQLiteIndex, error) {
 		filename:   "search.db",
 	}
 
-	// Ensure the schema is created
-	// Drops and recreates the pages table
 	if err := s.ensureSchema(); err != nil {
-		return nil, err
+		// Only attempt recovery for genuine SQLite I/O or corruption errors
+		// (SQLITE_IOERR=10, SQLITE_CORRUPT=11, SQLITE_NOTADB=26).
+		// Transient errors like SQLITE_BUSY are returned immediately.
+		if !sqliteutil.IsSQLiteRecoverableError(err) {
+			return nil, err
+		}
+		slog.Default().Warn("search index initialization failed, removing corrupt database and retrying", "error", err)
+		if closeErr := s.Close(); closeErr != nil {
+			slog.Default().Warn("failed to close corrupt search database before recovery", "error", closeErr)
+		}
+		sqliteutil.RemoveSQLiteFiles(searchIndexDatabasePath(s.storageDir, s.filename))
+		if err2 := s.ensureSchema(); err2 != nil {
+			_ = s.Close()
+			return nil, err2
+		}
 	}
 
 	return s, nil
 }
+
 
 func (s *SQLiteIndex) withDB(fn func(db *sql.DB) error) error {
 	s.mu.Lock()
@@ -317,8 +330,6 @@ func (s *SQLiteIndex) Search(query string, pageIDs []string, offset, limit int) 
 				}
 				r.Rank = 1.0 / (1.0 + bm25Score)
 			}
-
-			log.Printf("pageID=%s title=%q bm25=%f rank=%f", r.PageID, r.Title, bm25Score, r.Rank)
 
 			results = append(results, r)
 		}

--- a/internal/tags/tags_store.go
+++ b/internal/tags/tags_store.go
@@ -3,11 +3,13 @@ package tags
 import (
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"path/filepath"
 	"strings"
 	"sync"
 
 	"github.com/perber/wiki/internal/core/shared"
+	"github.com/perber/wiki/internal/core/shared/sqliteutil"
 	_ "modernc.org/sqlite"
 )
 
@@ -33,7 +35,20 @@ func NewTagsStore(storageDir string) (*TagsStore, error) {
 	s := &TagsStore{db: db}
 	if err := s.ensureSchema(); err != nil {
 		_ = db.Close()
-		return nil, err
+		if !sqliteutil.IsSQLiteRecoverableError(err) {
+			return nil, err
+		}
+		slog.Default().Warn("tags database corrupt, removing and retrying", "error", err)
+		sqliteutil.RemoveSQLiteFiles(dbPath)
+		db, err = sql.Open("sqlite", dbPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to reopen tags database after recovery: %w", err)
+		}
+		s = &TagsStore{db: db}
+		if err = s.ensureSchema(); err != nil {
+			_ = db.Close()
+			return nil, err
+		}
 	}
 	return s, nil
 }


### PR DESCRIPTION
LeafWiki failed to start after an upgrade if a previous run left a stale SQLite journal file (search.db-journal), causing disk I/O error 3338.

On startup, all four derived SQLite stores (search, links, tags, properties) now detect genuine I/O and corruption errors (SQLITE_IOERR, SQLITE_CORRUPT, SQLITE_NOTADB), delete the database and any sidecar files, and retry initialization once. Since these stores are always rebuilt from the Markdown files on disk, the delete is safe.

Transient errors (SQLITE_BUSY, SQLITE_LOCKED) and resource errors (SQLITE_IOERR_NOMEM) are not treated as recoverable — they are returned immediately without touching the database files.

Shared helpers (IsSQLiteRecoverableError, RemoveSQLiteFiles) live in internal/core/shared/sqliteutil to avoid coupling non-database packages to the SQLite module. The auth stores (users.db, sessions.db) are intentionally excluded from auto-recovery as they hold primary data.

Fixes #1072