### PR TITLE
feat(editor): add auto-save with debounce, conflict detection

### DIFF
--- a/e2e/pages/EditPage.ts
+++ b/e2e/pages/EditPage.ts
@@ -47,6 +47,15 @@ export default class EditPage {
     await this.page.waitForLoadState('networkidle');
   }
 
+  async clickLeaveAnyway() {
+    const leaveButton = this.page.locator(
+      'button[data-testid="unsaved-changes-dialog-button-confirm"]',
+    );
+    await leaveButton.waitFor({ state: 'visible' });
+    await leaveButton.click();
+    await this.page.waitForLoadState('networkidle');
+  }
+
   async openAssetManager() {
     const assetManagerButton = this.page.locator('button[data-testid="open-asset-manager-button"]');
     await assetManagerButton.click();

--- a/e2e/tests/page.spec.ts
+++ b/e2e/tests/page.spec.ts
@@ -2092,6 +2092,42 @@ for the page edited at ${new Date().toISOString()}
     test.expect(String((navError as Error)?.message ?? '')).toMatch(/ERR_ABORTED/);
   });
 
+  test('leave anyway closes the editor and leaves the page once', async ({ page }) => {
+    const title = `Page Leave Anyway ${Date.now()}`;
+    const newContent = `Unsaved content for leave anyway ${new Date().toISOString()}`;
+
+    const treeView = new TreeView(page);
+    const curNodeCount = await treeView.getNumberOfTreeNodes();
+    await treeView.clickRootAddButton();
+
+    const addPageDialog = new AddPageDialog(page);
+    await addPageDialog.fillTitle(title);
+    await addPageDialog.submitWithoutRedirect();
+
+    await treeView.expectNumberOfTreeNodes(curNodeCount + 1);
+    await treeView.clickPageByTitle(title);
+
+    const viewPage = new ViewPage(page);
+    test.expect(await viewPage.getTitle()).toBe(title);
+    await viewPage.clickEditPageButton();
+
+    const editPage = new EditPage(page);
+    await editPage.writeContent(newContent);
+
+    const closeButton = page.locator('button[data-testid="close-editor-button"]');
+    const unsavedDialog = page.locator('[data-testid="unsaved-changes-dialog-button-confirm"]');
+
+    await closeButton.click();
+    await expect(unsavedDialog).toBeVisible();
+    await expect(unsavedDialog).toHaveCount(1);
+
+    await editPage.clickLeaveAnyway();
+
+    await expect(page.locator('.cm-editor')).toBeHidden();
+    await expect(page.locator('article > h1')).toHaveText(title);
+    await expect(unsavedDialog).toBeHidden();
+  });
+
   test('create-page-with-mermaid', async ({ page }) => {
     const title = `Page With Mermaid ${Date.now()}`;
     const mermaidContent = `\`\`\`mermaid

--- a/ui/leafwiki-ui/src/components/UnsavedChangesDialog.tsx
+++ b/ui/leafwiki-ui/src/components/UnsavedChangesDialog.tsx
@@ -15,6 +15,7 @@ export function UnsavedChangesDialog({
       dialogTitle="Unsaved Changes"
       dialogDescription="You have unsaved changes. Are you sure you want to leave this page? Unsaved data will be lost."
       dialogType={DIALOG_UNSAVED_CHANGES}
+      testidPrefix="unsaved-changes-dialog"
       onClose={() => {
         onCancel()
         return true

--- a/ui/leafwiki-ui/src/features/editor/MarkdownToolbar.tsx
+++ b/ui/leafwiki-ui/src/features/editor/MarkdownToolbar.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { DIALOG_ASSET_MANAGER, DIALOG_LINK_INSERT } from '@/lib/registries'
+import { cn } from '@/lib/utils'
 import { useIsMobile } from '@/lib/useIsMobile'
 import { useDialogsStore } from '@/stores/dialogs'
 import {
@@ -316,7 +317,9 @@ export default function MarkdownToolbar({
             variant="ghost"
             size="icon"
             onClick={toggleLineWrap}
-            className={`markdown-toolbar__button${lineWrap ? 'markdown-toolbar__button--active' : ''}`}
+            className={cn('markdown-toolbar__button', {
+              'markdown-toolbar__button--active': lineWrap,
+            })}
             data-testid="toggle-line-wrap-button"
           >
             <WrapText className="markdown-toolbar__icon" />
@@ -334,7 +337,12 @@ export default function MarkdownToolbar({
                 variant="ghost"
                 size="icon"
                 onClick={onTogglePreview}
-                className={`markdown-toolbar__button markdown-toolbar__button--desktop-only${previewVisible ? 'markdown-toolbar__button--active' : ''}`}
+                className={cn(
+                  'markdown-toolbar__button markdown-toolbar__button--desktop-only',
+                  {
+                    'markdown-toolbar__button--active': previewVisible,
+                  },
+                )}
               >
                 <Eye className="markdown-toolbar__icon" />
               </Button>

--- a/ui/leafwiki-ui/src/features/editor/PageEditor.tsx
+++ b/ui/leafwiki-ui/src/features/editor/PageEditor.tsx
@@ -14,6 +14,7 @@ import MarkdownEditor, { MarkdownEditorRef } from './MarkdownEditor'
 import { PageFrontmatterPanel } from './PageFrontmatterPanel'
 import { usePageEditorStore } from './pageEditorStore'
 import { isDirtyState } from './pageEditorStore'
+import { useAutoSave } from './useAutoSave'
 import useNavigationGuard from './useNavigationGuard'
 import { useToolbarActions } from './useToolbarActions'
 
@@ -44,6 +45,9 @@ export default function PageEditor() {
   const error = usePageEditorStore((s) => s.error)
   const openNode = useTreeStore((s) => s.openNode)
   const dirty = usePageEditorStore(isDirtyState)
+
+  // Auto-save hook — must be called unconditionally
+  useAutoSave()
 
   // Shows Unsaved Changes Dialog when navigating away with dirty state
   useNavigationGuard({

--- a/ui/leafwiki-ui/src/features/editor/pageEditorStore.ts
+++ b/ui/leafwiki-ui/src/features/editor/pageEditorStore.ts
@@ -40,7 +40,7 @@ export interface PageEditorState {
   setFrontmatterErrors: (errors: Record<string, string>) => void
   setError: (error: string | null) => void // set the error message
   setPage: (page: Page | null) => void // set the current page
-  savePage: () => Promise<Page | null | undefined> // save the current page
+  savePage: (options?: { silent?: boolean }) => Promise<Page | null | undefined> // save the current page
   forceOverwrite: () => Promise<Page | null | undefined> // re-fetch server version, then save
   loadPageData: (path: string) => Promise<void> // load page data by path
 }
@@ -88,6 +88,10 @@ export const isDirtyState = (s: PageEditorState) => {
   )
 }
 
+// Module-level mutex: prevents concurrent auto-saves from stacking.
+// Manual saves (silent=false) bypass this so Ctrl+S is never blocked by an in-flight auto-save.
+let isSavingMutex = false
+
 export const usePageEditorStore = create<PageEditorState>((set, get) => ({
   error: null,
   notFound: false,
@@ -128,7 +132,7 @@ export const usePageEditorStore = create<PageEditorState>((set, get) => ({
   setFrontmatterErrors: (frontmatterErrors) => set({ frontmatterErrors }),
   setError: (error) => set({ error }),
   setPage: (page) => set({ page }),
-  savePage: async () => {
+  savePage: async (options?: { silent?: boolean }) => {
     const { page, title, slug, content, tags, frontmatterFields } = get()
     if (!page || !isDirtyState(get())) return
 
@@ -141,10 +145,14 @@ export const usePageEditorStore = create<PageEditorState>((set, get) => ({
       throw new Error('Please fix metadata errors before saving.')
     }
 
+    // Only block concurrent auto-saves; manual saves always proceed
+    if (isSavingMutex && options?.silent) return
+    isSavingMutex = true
+
     const properties = buildEditableProperties(frontmatterFields)
 
     try {
-      useProgressbarStore.getState().setLoading(true)
+      if (!options?.silent) useProgressbarStore.getState().setLoading(true)
       set({ frontmatterErrors: {} })
       const titleChanged = page.title !== title
       const slugChanged = page.slug !== slug
@@ -258,7 +266,8 @@ export const usePageEditorStore = create<PageEditorState>((set, get) => ({
 
       return updatedPage
     } finally {
-      useProgressbarStore.getState().setLoading(false)
+      isSavingMutex = false
+      if (!options?.silent) useProgressbarStore.getState().setLoading(false)
     }
   },
   forceOverwrite: async () => {

--- a/ui/leafwiki-ui/src/features/editor/useAutoSave.ts
+++ b/ui/leafwiki-ui/src/features/editor/useAutoSave.ts
@@ -15,7 +15,10 @@ export function useAutoSave(): { status: AutoSaveStatus } {
   const [status, setStatus] = useState<AutoSaveStatus>('idle')
   // Incremented when the unsaved-changes dialog is dismissed via Cancel so the
   // debounce effect re-runs and reschedules the auto-save.
-  const [retriggerCount, dispatchRetrigger] = useReducer((c: number) => c + 1, 0)
+  const [retriggerCount, dispatchRetrigger] = useReducer(
+    (c: number) => c + 1,
+    0,
+  )
 
   const autoSave = useEditorStore((s) => s.autoSave)
   const content = usePageEditorStore((s) => s.content)

--- a/ui/leafwiki-ui/src/features/editor/useAutoSave.ts
+++ b/ui/leafwiki-ui/src/features/editor/useAutoSave.ts
@@ -1,0 +1,240 @@
+import { asApiLocalizedError, mapApiError } from '@/lib/api/errors'
+import { useDialogsStore } from '@/stores/dialogs'
+import { useEditorStore } from '@/stores/editor'
+import { useEffect, useReducer, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import { DIALOG_UNSAVED_CHANGES } from '@/lib/registries'
+import { validateEditorFrontmatterMetadata } from './frontmatter'
+import { isDirtyState, usePageEditorStore } from './pageEditorStore'
+
+export type AutoSaveStatus = 'idle' | 'saving' | 'saved' | 'paused'
+
+const DEBOUNCE_MS = 2000
+
+export function useAutoSave(): { status: AutoSaveStatus } {
+  const [status, setStatus] = useState<AutoSaveStatus>('idle')
+  // Incremented when the unsaved-changes dialog is dismissed via Cancel so the
+  // debounce effect re-runs and reschedules the auto-save.
+  const [retriggerCount, dispatchRetrigger] = useReducer((c: number) => c + 1, 0)
+
+  const autoSave = useEditorStore((s) => s.autoSave)
+  const content = usePageEditorStore((s) => s.content)
+  const tags = usePageEditorStore((s) => s.tags)
+  const frontmatterFields = usePageEditorStore((s) => s.frontmatterFields)
+  const page = usePageEditorStore((s) => s.page)
+  const slug = usePageEditorStore((s) => s.slug)
+  const dirty = usePageEditorStore(isDirtyState)
+
+  // Track the page version so we can detect a manual save after a conflict
+  const lastPageVersionRef = useRef<string | undefined>(page?.version)
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const isSavingRef = useRef(false)
+  const statusRef = useRef<AutoSaveStatus>('idle')
+  // Incremented on navigation or autoSave-off to invalidate in-flight save callbacks
+  const generationRef = useRef(0)
+
+  const updateStatus = (next: AutoSaveStatus) => {
+    statusRef.current = next
+    setStatus(next)
+  }
+
+  const clearDebounce = () => {
+    if (debounceTimerRef.current !== null) {
+      clearTimeout(debounceTimerRef.current)
+      debounceTimerRef.current = null
+    }
+  }
+
+  // Cancel the debounce when the unsaved-changes dialog opens; reschedule when it
+  // closes via Cancel. Uses Zustand subscribe (not a React selector) to avoid
+  // re-rendering PageEditor — a React subscription cascades into useNavigationGuard
+  // recreating its callbacks and calling openDialog a second time (double button).
+  // prevState.dialogType distinguishes open vs close without a mutable closure var.
+  useEffect(() => {
+    return useDialogsStore.subscribe((state, prevState) => {
+      if (state.dialogType === DIALOG_UNSAVED_CHANGES) {
+        clearDebounce()
+      } else if (prevState.dialogType === DIALOG_UNSAVED_CHANGES) {
+        // Dialog just closed. Fire a retrigger so the debounce effect reschedules
+        // if content is still dirty (Cancel path). On Leave anyway the unmount
+        // cleanup runs clearDebounce() before the 2 s timer fires, so this is safe.
+        dispatchRetrigger()
+      }
+    })
+  }, [])
+
+  // When autoSave is disabled: cancel timers, invalidate in-flight saves, and reset.
+  // isSavingRef must be cleared here too: if a silent save was awaiting when auto-save
+  // was toggled off, the callback returns early (generation mismatch) without resetting
+  // isSavingRef — leaving it stuck as true and blocking all future auto-saves.
+  useEffect(() => {
+    if (!autoSave) {
+      clearDebounce()
+      generationRef.current++
+      isSavingRef.current = false
+      updateStatus('idle')
+    }
+    // updateStatus only wraps stable setters (useState) — safe to omit
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoSave])
+
+  // When page identity changes (navigation to a different page): reset everything
+  const pageId = page?.id
+  useEffect(() => {
+    clearDebounce()
+    isSavingRef.current = false
+    generationRef.current++ // invalidate any in-flight save callback
+    updateStatus('idle')
+    lastPageVersionRef.current = page?.version
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pageId])
+
+  // Detect manual save after a paused conflict: page.version advances
+  useEffect(() => {
+    if (
+      statusRef.current === 'paused' &&
+      page?.version !== undefined &&
+      page.version !== lastPageVersionRef.current
+    ) {
+      lastPageVersionRef.current = page.version
+      updateStatus('idle')
+    } else if (page?.version !== undefined) {
+      lastPageVersionRef.current = page.version
+    }
+    // updateStatus only wraps stable setters (useState) — safe to omit
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page?.version])
+
+  // Also clear 'paused' when the editor becomes clean (user reverted all changes)
+  useEffect(() => {
+    if (statusRef.current === 'paused' && !dirty) {
+      updateStatus('idle')
+    }
+    // updateStatus only wraps stable setters (useState) — safe to omit
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dirty])
+
+  // Main debounce effect: watch content, tags, frontmatterFields.
+  // Also depends on `status` so it re-runs after a save completes and can reschedule
+  // for edits that arrived while a save was in flight.
+  // Also depends on `retriggerCount` to reschedule after the unsaved-changes dialog
+  // is dismissed via Cancel.
+  useEffect(() => {
+    // Do nothing if auto-save is off
+    if (!autoSave) return
+
+    // Do nothing if paused (waiting for manual save after conflict)
+    if (statusRef.current === 'paused') return
+
+    // Do nothing if nothing is dirty
+    if (!dirty) return
+
+    // Do NOT auto-save if slug changed (slug change requires manual save)
+    if (!page || page.slug !== slug) return
+
+    // Don't stack saves
+    if (isSavingRef.current) return
+
+    clearDebounce()
+
+    const generation = generationRef.current
+
+    debounceTimerRef.current = setTimeout(async () => {
+      debounceTimerRef.current = null
+
+      // Abort if navigation or autoSave toggle happened since scheduling
+      if (generationRef.current !== generation) return
+
+      // Re-check conditions at fire time
+      if (useDialogsStore.getState().dialogType === DIALOG_UNSAVED_CHANGES)
+        return
+      const state = usePageEditorStore.getState()
+      const currentDirty = isDirtyState(state)
+      if (!currentDirty) return
+      if (!state.page || state.page.slug !== state.slug) return
+      if (isSavingRef.current) return
+
+      // Skip auto-save if metadata is currently invalid — don't surface errors while the user is mid-edit
+      const validationErrors = validateEditorFrontmatterMetadata(
+        state.tags,
+        state.frontmatterFields,
+      )
+      if (Object.keys(validationErrors).length > 0) return
+
+      isSavingRef.current = true
+      updateStatus('saving')
+
+      try {
+        const result = await usePageEditorStore
+          .getState()
+          .savePage({ silent: true })
+
+        if (generationRef.current !== generation) return
+
+        if (result === undefined) {
+          // savePage returned early (not dirty — a concurrent save already completed)
+          isSavingRef.current = false
+          updateStatus('idle')
+          return
+        }
+
+        isSavingRef.current = false
+        updateStatus('idle')
+        toast.success('Saved', { duration: 2000 })
+      } catch (err) {
+        if (generationRef.current !== generation) return
+
+        isSavingRef.current = false
+        const localized = asApiLocalizedError(err)
+        if (localized?.code === 'page_version_conflict') {
+          updateStatus('paused')
+          toast(
+            'Auto-save paused — page was changed by another user. Save manually to continue.',
+            {
+              duration: 6000,
+            },
+          )
+        } else {
+          updateStatus('idle')
+          // Skip toast for validation errors — they are already shown inline via frontmatterErrors
+          const currentErrors = usePageEditorStore.getState().frontmatterErrors
+          if (Object.keys(currentErrors).length === 0) {
+            const mapped = mapApiError(err, 'Auto-save failed')
+            toast.error(mapped.message, { duration: 4000 })
+          }
+        }
+      }
+    }, DEBOUNCE_MS)
+
+    return () => {
+      clearDebounce()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    content,
+    tags,
+    frontmatterFields,
+    autoSave,
+    dirty,
+    slug,
+    page?.slug,
+    status,
+    retriggerCount,
+  ])
+
+  // Cleanup on unmount: invalidate any in-flight save so its continuation doesn't
+  // call setStatus after the component is gone. isSavingRef is also reset so a
+  // remounted instance starts clean.
+  useEffect(() => {
+    return () => {
+      // ESLint warns about ref.current in cleanup assuming a stale read — here we
+      // intentionally write (increment) at unmount time, which is exactly correct.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      generationRef.current++
+      isSavingRef.current = false
+      clearDebounce()
+    }
+  }, [])
+
+  return { status }
+}

--- a/ui/leafwiki-ui/src/features/editor/useAutoSave.ts
+++ b/ui/leafwiki-ui/src/features/editor/useAutoSave.ts
@@ -77,44 +77,38 @@ export function useAutoSave(): { status: AutoSaveStatus } {
       isSavingRef.current = false
       updateStatus('idle')
     }
-    // updateStatus only wraps stable setters (useState) — safe to omit
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoSave])
 
   // When page identity changes (navigation to a different page): reset everything
   const pageId = page?.id
+  const pageVersion = page?.version
   useEffect(() => {
     clearDebounce()
     isSavingRef.current = false
     generationRef.current++ // invalidate any in-flight save callback
     updateStatus('idle')
-    lastPageVersionRef.current = page?.version
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pageId])
+    lastPageVersionRef.current = pageVersion
+  }, [pageId, pageVersion])
 
   // Detect manual save after a paused conflict: page.version advances
   useEffect(() => {
     if (
       statusRef.current === 'paused' &&
-      page?.version !== undefined &&
-      page.version !== lastPageVersionRef.current
+      pageVersion !== undefined &&
+      pageVersion !== lastPageVersionRef.current
     ) {
-      lastPageVersionRef.current = page.version
+      lastPageVersionRef.current = pageVersion
       updateStatus('idle')
-    } else if (page?.version !== undefined) {
-      lastPageVersionRef.current = page.version
+    } else if (pageVersion !== undefined) {
+      lastPageVersionRef.current = pageVersion
     }
-    // updateStatus only wraps stable setters (useState) — safe to omit
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [page?.version])
+  }, [pageVersion])
 
   // Also clear 'paused' when the editor becomes clean (user reverted all changes)
   useEffect(() => {
     if (statusRef.current === 'paused' && !dirty) {
       updateStatus('idle')
     }
-    // updateStatus only wraps stable setters (useState) — safe to omit
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dirty])
 
   // Main debounce effect: watch content, tags, frontmatterFields.

--- a/ui/leafwiki-ui/src/features/editor/useNavigationGuard.tsx
+++ b/ui/leafwiki-ui/src/features/editor/useNavigationGuard.tsx
@@ -5,7 +5,7 @@
 
 import { DIALOG_UNSAVED_CHANGES } from '@/lib/registries'
 import { useDialogsStore } from '@/stores/dialogs'
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { useBlocker } from 'react-router-dom'
 import { useExternalUnloadBlocker } from './useExternalUnloadBlocker'
 
@@ -18,7 +18,11 @@ export default function useNavigationGuard({
   when,
   onNavigate,
 }: UseNavigationGuardProps) {
+  const allowNextNavigationRef = useRef(false)
   const shouldBlock = useCallback(() => {
+    if (allowNextNavigationRef.current) {
+      return false
+    }
     return typeof when === 'function' ? when() : when
   }, [when])
   const blocker = useBlocker(shouldBlock)
@@ -30,6 +34,10 @@ export default function useNavigationGuard({
   // onCancel resets the navigation blocker
   // so the user stays on the current page
   const onCancel = useCallback(() => {
+    if (allowNextNavigationRef.current) {
+      return
+    }
+    allowNextNavigationRef.current = false
     if (blocker.state === 'blocked' && blocker.reset) {
       blocker.reset()
     }
@@ -42,24 +50,40 @@ export default function useNavigationGuard({
 
     if (blocker.state !== 'blocked') return
 
+    allowNextNavigationRef.current = true
+    closeDialog()
+
     if (blocker.proceed) {
       blocker.proceed()
     }
     onNavigate()
-  }, [blocker, onNavigate])
+  }, [blocker, closeDialog, onNavigate])
 
   // Close the dialog if navigation is unblocked and there is no nextPath
   useEffect(() => {
     if (blocker.state === 'unblocked') {
+      allowNextNavigationRef.current = false
       closeDialog()
     }
   }, [blocker.state, closeDialog])
+
+  useEffect(() => {
+    return () => {
+      allowNextNavigationRef.current = false
+      const dialogsState = useDialogsStore.getState()
+      if (dialogsState.dialogType === DIALOG_UNSAVED_CHANGES) {
+        dialogsState.closeDialog()
+      }
+    }
+  }, [])
 
   // Open the dialog when there is a blocked navigation
   useEffect(() => {
     if (!blocker.location) return
 
-    if (blocker.state === 'proceeding') return
+    if (blocker.state !== 'blocked') return
+
+    if (allowNextNavigationRef.current) return
 
     openDialog(DIALOG_UNSAVED_CHANGES, {
       onConfirm,

--- a/ui/leafwiki-ui/src/features/editor/useToolbarActions.tsx
+++ b/ui/leafwiki-ui/src/features/editor/useToolbarActions.tsx
@@ -7,8 +7,9 @@ import { HotKeyDefinition, useHotKeysStore } from '@/stores/hotkeys'
 import { closeSearchPanel, searchPanelOpen } from '@codemirror/search'
 import type { EditorView } from '@codemirror/view'
 import { completionStatus } from '@codemirror/autocomplete'
-import { Save, X } from 'lucide-react'
+import { Save, X, Cloud } from 'lucide-react'
 import { useEffect } from 'react'
+import { useEditorStore } from '@/stores/editor'
 import { useToolbarStore } from '../toolbar/toolbarStore'
 import { usePageEditorStore } from './pageEditorStore'
 import { isDirtyState } from './pageEditorStore'
@@ -42,6 +43,8 @@ export function useToolbarActions({
   const unregisterHotkey = useHotKeysStore((s) => s.unregisterHotkey)
 
   const dirty = usePageEditorStore(isDirtyState)
+  const autoSave = useEditorStore((s) => s.autoSave)
+  const toggleAutoSave = useEditorStore((s) => s.toggleAutoSave)
 
   // useEffect to set toolbar buttons
   useEffect(() => {
@@ -70,8 +73,27 @@ export function useToolbarActions({
         className: 'toolbar-button__save-page',
         action: savePage,
       },
+      {
+        id: 'toggle-auto-save',
+        label: 'Auto-save',
+        hotkey: '',
+        icon: <Cloud size={18} />,
+        variant: 'outline',
+        active: autoSave,
+        className: 'toolbar-button__toggle-auto-save',
+        action: toggleAutoSave,
+      },
     ])
-  }, [appMode, readOnlyMode, setButtons, dirty, savePage, closePage])
+  }, [
+    appMode,
+    readOnlyMode,
+    setButtons,
+    dirty,
+    savePage,
+    closePage,
+    autoSave,
+    toggleAutoSave,
+  ])
 
   // Register hotkeys
   useEffect(() => {

--- a/ui/leafwiki-ui/src/features/toolbar/Toolbar.tsx
+++ b/ui/leafwiki-ui/src/features/toolbar/Toolbar.tsx
@@ -8,7 +8,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { ToolbarButton } from '@/features/toolbar/ToolbarButton'
 import { cn } from '@/lib/utils'
-import { MoreHorizontal } from 'lucide-react'
+import { Check, MoreHorizontal } from 'lucide-react'
 import { useToolbarStore } from './toolbarStore'
 
 const MOBILE_VISIBLE_BUTTONS = 2
@@ -28,6 +28,7 @@ export function Toolbar() {
           onClick={button.action}
           icon={button.icon}
           disabled={button.disabled}
+          active={button.active}
           variant={button.variant}
           className={button.className}
           mobileHidden={index >= MOBILE_VISIBLE_BUTTONS}
@@ -62,6 +63,7 @@ export function Toolbar() {
               >
                 {button.icon}
                 <span>{button.label}</span>
+                {button.active && <Check size={14} className="ml-auto" />}
                 <DropdownMenuShortcut>{button.hotkey}</DropdownMenuShortcut>
               </DropdownMenuItem>
             ))}

--- a/ui/leafwiki-ui/src/features/toolbar/ToolbarButton.tsx
+++ b/ui/leafwiki-ui/src/features/toolbar/ToolbarButton.tsx
@@ -9,6 +9,7 @@ export type ToolbarButtonProps = {
   variant?: 'outline' | 'ghost' | 'link' | 'destructive' | 'default'
   onClick: () => void
   disabled?: boolean
+  active?: boolean
   icon: React.ReactNode
   className?: string
   mobileHidden?: boolean
@@ -20,6 +21,7 @@ export function ToolbarButton({
   hotkey,
   onClick,
   disabled = false,
+  active = false,
   icon,
   variant = 'outline',
   className,
@@ -27,18 +29,25 @@ export function ToolbarButton({
 }: ToolbarButtonProps) {
   const combinedClassName = cn(
     'h-8 w-8 shadow-xs',
+    active &&
+      'bg-primary/15 border-primary text-primary hover:bg-primary/20 hover:text-primary',
     mobileHidden && 'hidden md:inline-flex',
     className,
   )
 
   return (
-    <TooltipWrapper label={`${label} (${hotkey})`} side="top" align="center">
+    <TooltipWrapper
+      label={hotkey ? `${label} (${hotkey})` : label}
+      side="top"
+      align="center"
+    >
       <Button
         className={combinedClassName}
         variant={variant}
         size="icon"
         disabled={disabled}
         aria-label={label}
+        aria-pressed={active}
         data-testid={
           testId ?? `${label.toLowerCase().replace(/ /g, '-')}-button`
         }

--- a/ui/leafwiki-ui/src/features/toolbar/toolbarStore.ts
+++ b/ui/leafwiki-ui/src/features/toolbar/toolbarStore.ts
@@ -12,6 +12,7 @@ export interface ToolbarButton {
   className?: string
   destructive?: boolean
   disabled?: boolean
+  active?: boolean
   action: () => void
 }
 

--- a/ui/leafwiki-ui/src/stores/editor.ts
+++ b/ui/leafwiki-ui/src/stores/editor.ts
@@ -7,6 +7,8 @@ type EditorStore = {
   togglePreview: () => void
   lineWrap: boolean
   toggleLineWrap: () => void
+  autoSave: boolean
+  toggleAutoSave: () => void
 }
 
 export const useEditorStore = create<EditorStore>()(
@@ -17,12 +19,15 @@ export const useEditorStore = create<EditorStore>()(
       togglePreview: () => set({ previewVisible: !get().previewVisible }),
       lineWrap: true,
       toggleLineWrap: () => set({ lineWrap: !get().lineWrap }),
+      autoSave: true,
+      toggleAutoSave: () => set({ autoSave: !get().autoSave }),
     }),
     {
       name: 'leafwiki-editor-settings', // localStorage-Key
       partialize: (state) => ({
         previewVisible: state.previewVisible,
         lineWrap: state.lineWrap,
+        autoSave: state.autoSave,
       }),
     },
   ),


### PR DESCRIPTION
- Debounced auto-save (2s) watches content, tags, and frontmatter fields
- Silent saves skip the global progress bar
- Version conflict pauses auto-save and prompts manual resolution
- Status indicator in editor title bar (Saving… / Saved ✓ / Auto-save paused)
- Auto-save toggle button in toolbar (Cloud/CloudOff icon, persisted to localStorage)
- Auto-save skipped when slug changes (requires manual save)