### PR TITLE
fix(branding): validate file paths before deletion to prevent path traversal

### DIFF
--- a/internal/branding/branding_service.go
+++ b/internal/branding/branding_service.go
@@ -82,6 +82,15 @@ func (s *BrandingService) UpdateBranding(siteName string) error {
 	return nil
 }
 
+func containsPathTraversal(s string) bool {
+	return strings.Contains(s, "..") ||
+		strings.Contains(s, "/") ||
+		strings.Contains(s, "\\") ||
+		filepath.IsAbs(s) ||
+		filepath.VolumeName(s) != "" ||
+		strings.Contains(s, "\x00")
+}
+
 // containsControlCharacters checks if a string contains control characters
 // that could break UI layout or cause display issues.
 // Blocks all control characters (unicode.IsControl) except common whitespace:
@@ -90,13 +99,6 @@ func (s *BrandingService) UpdateBranding(siteName string) error {
 // - \r (carriage return, U+000D)
 // These exceptions allow for normal text formatting while preventing
 // null bytes, vertical tabs, form feeds, and other problematic characters.
-func containsPathTraversal(s string) bool {
-	return strings.Contains(s, "..") ||
-		strings.Contains(s, "/") ||
-		strings.Contains(s, "\\") ||
-		strings.Contains(s, "\x00")
-}
-
 func containsControlCharacters(s string) bool {
 	for _, r := range s {
 		// Disallow control characters except for common whitespace

--- a/internal/branding/branding_service.go
+++ b/internal/branding/branding_service.go
@@ -90,6 +90,13 @@ func (s *BrandingService) UpdateBranding(siteName string) error {
 // - \r (carriage return, U+000D)
 // These exceptions allow for normal text formatting while preventing
 // null bytes, vertical tabs, form feeds, and other problematic characters.
+func containsPathTraversal(s string) bool {
+	return strings.Contains(s, "..") ||
+		strings.Contains(s, "/") ||
+		strings.Contains(s, "\\") ||
+		strings.Contains(s, "\x00")
+}
+
 func containsControlCharacters(s string) bool {
 	for _, r := range s {
 		// Disallow control characters except for common whitespace
@@ -156,6 +163,15 @@ func (s *BrandingService) DeleteLogo() error {
 
 	if s.brandingConfig.LogoFile == "" {
 		return nil // No logo to delete
+	}
+
+	if containsPathTraversal(s.brandingConfig.LogoFile) {
+		return sharederrors.NewLocalizedError(
+			"branding_logo_delete_failed",
+			"Failed to delete logo",
+			"invalid logo file path",
+			nil,
+		)
 	}
 
 	logoPath := filepath.Join(s.store.brandingAssetsDir(), s.brandingConfig.LogoFile)
@@ -237,6 +253,15 @@ func (s *BrandingService) DeleteFavicon() error {
 
 	if s.brandingConfig.FaviconFile == "" {
 		return nil // No favicon to delete
+	}
+
+	if containsPathTraversal(s.brandingConfig.FaviconFile) {
+		return sharederrors.NewLocalizedError(
+			"branding_favicon_delete_failed",
+			"Failed to delete favicon",
+			"invalid favicon file path",
+			nil,
+		)
 	}
 
 	faviconPath := filepath.Join(s.store.brandingAssetsDir(), s.brandingConfig.FaviconFile)

--- a/internal/branding/branding_service_test.go
+++ b/internal/branding/branding_service_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -176,6 +177,42 @@ func TestBrandingService_DeleteLogo_FileMissingStillClearsConfig(t *testing.T) {
 	}
 }
 
+func TestBrandingService_DeleteLogo_InvalidPath_ReturnsErrorAndDoesNotDeleteExternalFile(t *testing.T) {
+	svc, _ := newTestBrandingService(t)
+	externalFile := filepath.Join(t.TempDir(), "logo.png")
+	if err := os.WriteFile(externalFile, []byte("logo"), 0644); err != nil {
+		t.Fatalf("seed external logo file: %v", err)
+	}
+
+	svc.mu.Lock()
+	svc.brandingConfig.LogoFile = externalFile
+	if err := svc.store.Save(svc.brandingConfig); err != nil {
+		svc.mu.Unlock()
+		t.Fatalf("store.Save() error: %v", err)
+	}
+	svc.mu.Unlock()
+
+	err := svc.DeleteLogo()
+	if err == nil {
+		t.Fatalf("expected DeleteLogo() to fail for invalid path")
+	}
+	if _, ok := err.(*errors.LocalizedError); !ok {
+		t.Fatalf("expected LocalizedError, got %T", err)
+	}
+	if _, err := os.Stat(externalFile); err != nil {
+		t.Fatalf("expected external logo file to remain, stat error: %v", err)
+	}
+
+	store := NewBrandingStore(svc.store.storageDir)
+	cfg, err := store.Load()
+	if err != nil {
+		t.Fatalf("store.Load() error: %v", err)
+	}
+	if cfg.LogoFile != externalFile {
+		t.Fatalf("expected LogoFile to remain unchanged, got %q", cfg.LogoFile)
+	}
+}
+
 func TestBrandingService_DeleteFavicon_FileMissingStillClearsConfig(t *testing.T) {
 	svc, dir := newTestBrandingService(t)
 
@@ -198,6 +235,52 @@ func TestBrandingService_DeleteFavicon_FileMissingStillClearsConfig(t *testing.T
 	}
 	if cfg.FaviconFile != "" {
 		t.Fatalf("expected FaviconFile cleared even if file missing, got %q", cfg.FaviconFile)
+	}
+}
+
+func TestBrandingService_DeleteFavicon_InvalidPath_ReturnsErrorAndDoesNotDeleteExternalFile(t *testing.T) {
+	svc, _ := newTestBrandingService(t)
+	externalFile := filepath.Join(t.TempDir(), "favicon.ico")
+	if err := os.WriteFile(externalFile, []byte("fav"), 0644); err != nil {
+		t.Fatalf("seed external favicon file: %v", err)
+	}
+
+	svc.mu.Lock()
+	svc.brandingConfig.FaviconFile = externalFile
+	if err := svc.store.Save(svc.brandingConfig); err != nil {
+		svc.mu.Unlock()
+		t.Fatalf("store.Save() error: %v", err)
+	}
+	svc.mu.Unlock()
+
+	err := svc.DeleteFavicon()
+	if err == nil {
+		t.Fatalf("expected DeleteFavicon() to fail for invalid path")
+	}
+	if _, ok := err.(*errors.LocalizedError); !ok {
+		t.Fatalf("expected LocalizedError, got %T", err)
+	}
+	if _, err := os.Stat(externalFile); err != nil {
+		t.Fatalf("expected external favicon file to remain, stat error: %v", err)
+	}
+
+	store := NewBrandingStore(svc.store.storageDir)
+	cfg, err := store.Load()
+	if err != nil {
+		t.Fatalf("store.Load() error: %v", err)
+	}
+	if cfg.FaviconFile != externalFile {
+		t.Fatalf("expected FaviconFile to remain unchanged, got %q", cfg.FaviconFile)
+	}
+}
+
+func TestContainsPathTraversal_RejectsWindowsVolumePath(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("filepath volume paths are only recognized on Windows")
+	}
+
+	if !containsPathTraversal("C:logo.png") {
+		t.Fatalf("expected Windows volume path to be rejected")
 	}
 }
 

--- a/internal/wiki/branding/routes.go
+++ b/internal/wiki/branding/routes.go
@@ -232,12 +232,18 @@ func (r *Routes) handleServeCurrentFavicon(c *gin.Context) {
 	c.Data(http.StatusOK, "image/svg+xml", []byte(httpinternal.DefaultFaviconSVG))
 }
 
-func (r *Routes) resolveBrandingAssetPath(filename string, cfg *corebanding.BrandingConfigResponse) (string, int) {
-	// Prevent path traversal or poisoned config values.
-	if strings.Contains(filename, "..") ||
+func containsInvalidBrandingAssetPath(filename string) bool {
+	return strings.Contains(filename, "..") ||
 		strings.Contains(filename, "/") ||
 		strings.Contains(filename, "\\") ||
-		strings.Contains(filename, "\x00") {
+		filepath.IsAbs(filename) ||
+		filepath.VolumeName(filename) != "" ||
+		strings.Contains(filename, "\x00")
+}
+
+func (r *Routes) resolveBrandingAssetPath(filename string, cfg *corebanding.BrandingConfigResponse) (string, int) {
+	// Prevent path traversal or poisoned config values.
+	if containsInvalidBrandingAssetPath(filename) {
 		return "", http.StatusForbidden
 	}
 

--- a/internal/wiki/branding/routes_test.go
+++ b/internal/wiki/branding/routes_test.go
@@ -1,0 +1,54 @@
+package branding
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	corebranding "github.com/perber/wiki/internal/branding"
+)
+
+func newTestRoutes(t *testing.T) (*Routes, *corebranding.BrandingConfigResponse) {
+	t.Helper()
+
+	svc, err := corebranding.NewBrandingService(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewBrandingService() error: %v", err)
+	}
+
+	cfg, err := svc.GetBranding()
+	if err != nil {
+		t.Fatalf("GetBranding() error: %v", err)
+	}
+
+	return &Routes{
+		brandingService: svc,
+		log:             slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}, cfg
+}
+
+func TestResolveBrandingAssetPath_RejectsAbsolutePath(t *testing.T) {
+	routes, cfg := newTestRoutes(t)
+
+	absolutePath := filepath.Join(t.TempDir(), "logo.png")
+	_, status := routes.resolveBrandingAssetPath(absolutePath, cfg)
+	if status != http.StatusForbidden {
+		t.Fatalf("expected forbidden for absolute path, got %d", status)
+	}
+}
+
+func TestResolveBrandingAssetPath_RejectsWindowsVolumePath(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("filepath volume paths are only recognized on Windows")
+	}
+
+	routes, cfg := newTestRoutes(t)
+
+	_, status := routes.resolveBrandingAssetPath("C:logo.png", cfg)
+	if status != http.StatusForbidden {
+		t.Fatalf("expected forbidden for Windows volume path, got %d", status)
+	}
+}


### PR DESCRIPTION
Add containsPathTraversal check in DeleteLogo and DeleteFavicon, mirroring the same guard already present in resolveBrandingAssetPath for asset serving.