### PR TITLE
feat(update): make update script more verbose

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -34,7 +34,7 @@ get_version(){
 
 download_binary(){
     TMP_FILE="/tmp/leafwiki-v${VERSION}-linux-${ARCH}"
-    wget -q -O "$TMP_FILE" "${RELEASE_LINK}releases/download/v${VERSION}/leafwiki-v${VERSION}-linux-${ARCH}" || {
+    wget -O "$TMP_FILE" "${RELEASE_LINK}releases/download/v${VERSION}/leafwiki-v${VERSION}-linux-${ARCH}" || {
         echo "Download failed. Aborting update." >&2
         exit 1
     }
@@ -60,6 +60,7 @@ if [[ $EXIST == "false" ]]; then
     exit 1
 fi
 
+echo "Update in progress..."
 get_version
 download_binary
 


### PR DESCRIPTION
After using the update script several times, I realized that the lack of progress logs can make it feel like the script isn't doing anything.

To improve the user experience, I removed the `-q` option from the download command so that progress is displayed, and I also added a log message indicating that the update process has started.

What do you think?
