### PR TITLE
fix(ui): enable dialog close animation

### DIFF
--- a/e2e/pages/DeletePageDialog.ts
+++ b/e2e/pages/DeletePageDialog.ts
@@ -3,12 +3,22 @@ import { expect, Page } from '@playwright/test';
 export default class DeletePageDialog {
   constructor(private page: Page) {}
 
+  dialogText() {
+    return this.page.getByText(
+      /Are you sure you want to delete this (page|section)\? This action cannot be undone\./,
+    );
+  }
+
   async dialogTextVisible() {
-    return this.page
-      .getByText(
-        /Are you sure you want to delete this (page|section)\? This action cannot be undone\./,
-      )
-      .isVisible();
+    return this.dialogText().isVisible();
+  }
+
+  async waitForVisible() {
+    await this.dialogText().waitFor({ state: 'visible' });
+  }
+
+  async waitForHidden() {
+    await this.dialogText().waitFor({ state: 'hidden' });
   }
 
   async checkboxRecursiveDelete() {

--- a/e2e/tests/page.spec.ts
+++ b/e2e/tests/page.spec.ts
@@ -2794,13 +2794,13 @@ Paragraph outside the list.
     await viewPage.clickDeletePageButton();
 
     const deletePageDialog = new DeletePageDialog(page);
-    test.expect(await deletePageDialog.dialogTextVisible()).toBeTruthy();
+    await deletePageDialog.waitForVisible();
     await deletePageDialog.expectNoBacklinksVisible();
     await deletePageDialog.abortDeletion();
     await treeView.expectNumberOfTreeNodes(curNodeCount + 1);
 
     await viewPage.clickDeletePageButton();
-    test.expect(await deletePageDialog.dialogTextVisible()).toBeTruthy();
+    await deletePageDialog.waitForVisible();
     await deletePageDialog.expectNoBacklinksVisible();
     await deletePageDialog.confirmDeletion();
     await treeView.expectNumberOfTreeNodes(curNodeCount);
@@ -2838,7 +2838,7 @@ Paragraph outside the list.
     await viewPage.clickDeletePageMenuItem();
 
     const deletePageDialog = new DeletePageDialog(page);
-    test.expect(await deletePageDialog.dialogTextVisible()).toBeTruthy();
+    await deletePageDialog.waitForVisible();
     await deletePageDialog.confirmDeletion();
     await page.getByText('Page deleted successfully').waitFor({ state: 'visible' });
     // After a successful delete the app performs a SPA navigation to the parent page.
@@ -2881,7 +2881,7 @@ Paragraph outside the list.
     await viewPage.clickDeletePageButton();
 
     const deletePageDialog = new DeletePageDialog(page);
-    test.expect(await deletePageDialog.dialogTextVisible()).toBeTruthy();
+    await deletePageDialog.waitForVisible();
     await deletePageDialog.expectBacklinksWarningVisible();
     await deletePageDialog.expectBacklinkTitle(referrerTitle);
     await deletePageDialog.abortDeletion();
@@ -2912,7 +2912,7 @@ Paragraph outside the list.
     await viewPage.clickDeletePageButton();
 
     const deletePageDialog = new DeletePageDialog(page);
-    test.expect(await deletePageDialog.dialogTextVisible()).toBeTruthy();
+    await deletePageDialog.waitForVisible();
     // Attempt delete without the recursive flag — the API rejects this because
     // the page has children. Use tryConfirmDeletion() so we wait for the API
     // response without blocking on the dialog button to detach (it won't,
@@ -2920,12 +2920,12 @@ Paragraph outside the list.
     await deletePageDialog.tryConfirmDeletion();
 
     // The dialog stays open, because we need to confirm nested deletion
-    test.expect(await deletePageDialog.dialogTextVisible()).toBeTruthy();
+    await deletePageDialog.waitForVisible();
 
     await deletePageDialog.confirmNestedDeletion();
     await treeView.expectNumberOfTreeNodes(curNodeCount);
     // Dialog should be closed now
-    test.expect(await deletePageDialog.dialogTextVisible()).toBeFalsy();
+    await deletePageDialog.waitForHidden();
   });
 
   // disable this test cases, because it is flaky
@@ -3318,8 +3318,8 @@ Paragraph outside the list.
     await deleteButton.click({ force: true });
 
     const deletePageDialog = new DeletePageDialog(page);
-    test.expect(await deletePageDialog.dialogTextVisible()).toBeFalsy();
     await page.getByText(warningText).waitFor({ state: 'visible' });
+    await deletePageDialog.waitForHidden();
     test.expect(await page.locator('.cm-editor').isVisible()).toBeTruthy();
   });
 

--- a/ui/leafwiki-ui/src/components/DialogManager.tsx
+++ b/ui/leafwiki-ui/src/components/DialogManager.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react'
+
 import { dialogRegistry } from '@/lib/registries'
 import { useDialogsStore } from '@/stores/dialogs'
 
@@ -7,13 +9,25 @@ export function DialogManager() {
   const dialogType = useDialogsStore((state) => state.dialogType)
   const dialogProps = useDialogsStore((state) => state.dialogProps)
 
+  // Keep the last non-null dialog in the render tree so Radix UI Presence
+  // can play the exit animation before the component unmounts.
+  // BaseDialog derives open={store.dialogType === ownType}, so it gets
+  // open=false and Radix handles the fade-out.
+  const [renderType, setRenderType] = useState(dialogType)
+  const [renderProps, setRenderProps] = useState(dialogProps)
+
+  useEffect(() => {
+    if (dialogType !== null) {
+      setRenderType(dialogType)
+      setRenderProps(dialogProps)
+    }
+  }, [dialogType, dialogProps])
+
   return (
     <>
       {dialogs.map((dialog) => {
-        if (dialog.type !== dialogType) {
-          return null
-        }
-        return dialog.render({ ...dialogProps })
+        if (dialog.type !== renderType) return null
+        return dialog.render({ ...renderProps })
       })}
     </>
   )

--- a/ui/leafwiki-ui/src/components/DialogManager.tsx
+++ b/ui/leafwiki-ui/src/components/DialogManager.tsx
@@ -17,10 +17,19 @@ export function DialogManager() {
   const [renderProps, setRenderProps] = useState(dialogProps)
 
   useEffect(() => {
+    // When opening (or updating props for) a dialog, render it immediately.
     if (dialogType !== null) {
       setRenderType(dialogType)
       setRenderProps(dialogProps)
+      return
     }
+    // When closing, keep the dialog mounted briefly so Radix UI Presence can
+    // play the exit animation, then unmount to avoid retaining dialog state.
+    const timeoutId = setTimeout(() => {
+      setRenderType(null)
+      setRenderProps(null)
+    }, 200)
+    return () => clearTimeout(timeoutId)
   }, [dialogType, dialogProps])
 
   return (

--- a/ui/leafwiki-ui/src/components/ui/alert-dialog.tsx
+++ b/ui/leafwiki-ui/src/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg',
+        'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 [animation-duration:200ms] sm:rounded-lg',
         className,
       )}
       {...props}

--- a/ui/leafwiki-ui/src/components/ui/dialog.tsx
+++ b/ui/leafwiki-ui/src/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg',
+        'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 [animation-duration:200ms] sm:rounded-lg',
         className,
       )}
       {...props}


### PR DESCRIPTION
DialogManager was unmounting dialogs immediately when closeDialog() set dialogType to null in the store, so Radix UI Presence never had a chance to play the exit animation.

Keep the last active dialog in the React tree by only updating renderType and renderProps when a new dialog opens (dialogType !== null). BaseDialog derives open from the store directly, so it correctly gets open=false and Radix runs the fade-out before Presence unmounts the content.

Also add [animation-duration:200ms] to dialog and alert-dialog: in Tailwind v4 the duration-200 utility only sets transition-duration, while tailwindcss-animate defaults to 150ms for animation-duration.