### PR TITLE
feat(pages): add FindPagesByTitle and GET /api/pages/by-title endpoint

### DIFF
--- a/internal/core/tree/tree_service.go
+++ b/internal/core/tree/tree_service.go
@@ -375,6 +375,31 @@ func (t *TreeService) rollbackCreatedNodeLocked(parent *PageNode, entry *PageNod
 	return nil
 }
 
+// FindPagesByTitle returns all nodes whose title matches the given string
+// (case-insensitive). The returned slice is ordered depth-first. Returns an
+// empty slice when the tree is not loaded or no node matches.
+func (t *TreeService) FindPagesByTitle(title string) []*PageNode {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if t.tree == nil {
+		return nil
+	}
+
+	lowerTitle := strings.ToLower(strings.TrimSpace(title))
+	if lowerTitle == "" {
+		return nil
+	}
+
+	var results []*PageNode
+	for _, node := range t.nodesByID {
+		if strings.ToLower(node.Title) == lowerTitle {
+			results = append(results, node)
+		}
+	}
+	return results
+}
+
 // FindPageByID finds a page in the tree by its ID.
 func (t *TreeService) FindPageByID(id string) (*PageNode, error) {
 	var result *PageNode

--- a/internal/core/tree/tree_service.go
+++ b/internal/core/tree/tree_service.go
@@ -376,8 +376,9 @@ func (t *TreeService) rollbackCreatedNodeLocked(parent *PageNode, entry *PageNod
 }
 
 // FindPagesByTitle returns all nodes whose title matches the given string
-// (case-insensitive). The returned slice is ordered depth-first. Returns an
-// empty slice when the tree is not loaded or no node matches.
+// (case-insensitive) in pre-order (depth-first) tree order, so results are
+// stable across calls. Returns nil when the tree is not loaded or the title
+// is empty.
 func (t *TreeService) FindPagesByTitle(title string) []*PageNode {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
@@ -386,17 +387,22 @@ func (t *TreeService) FindPagesByTitle(title string) []*PageNode {
 		return nil
 	}
 
-	lowerTitle := strings.ToLower(strings.TrimSpace(title))
-	if lowerTitle == "" {
+	title = strings.TrimSpace(title)
+	if title == "" {
 		return nil
 	}
 
 	var results []*PageNode
-	for _, node := range t.nodesByID {
-		if strings.ToLower(node.Title) == lowerTitle {
+	var walk func(*PageNode)
+	walk = func(node *PageNode) {
+		if node.ID != "root" && strings.EqualFold(node.Title, title) {
 			results = append(results, node)
 		}
+		for _, child := range node.Children {
+			walk(child)
+		}
 	}
+	walk(t.tree)
 	return results
 }
 

--- a/internal/core/tree/tree_service_test.go
+++ b/internal/core/tree/tree_service_test.go
@@ -3298,6 +3298,87 @@ func TestTreeService_GetPages_RawContent_PopulatedForAll(t *testing.T) {
 	}
 }
 
+// ─── FindPagesByTitle ─────────────────────────────────────────────────────────
+
+func TestFindPagesByTitle_SingleMatch(t *testing.T) {
+	svc, _ := newLoadedService(t)
+
+	id, err := svc.CreateNode("system", nil, "My Page", "my-page", ptrKind(NodeKindPage))
+	if err != nil {
+		t.Fatalf("CreateNode: %v", err)
+	}
+
+	results := svc.FindPagesByTitle("My Page")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].ID != *id {
+		t.Errorf("unexpected ID: got %q, want %q", results[0].ID, *id)
+	}
+}
+
+func TestFindPagesByTitle_CaseInsensitive(t *testing.T) {
+	svc, _ := newLoadedService(t)
+
+	_, err := svc.CreateNode("system", nil, "My Page", "my-page", ptrKind(NodeKindPage))
+	if err != nil {
+		t.Fatalf("CreateNode: %v", err)
+	}
+
+	for _, variant := range []string{"my page", "MY PAGE", "My PAGE", "  My Page  "} {
+		results := svc.FindPagesByTitle(variant)
+		if len(results) != 1 {
+			t.Errorf("title %q: expected 1 result, got %d", variant, len(results))
+		}
+	}
+}
+
+func TestFindPagesByTitle_MultipleMatches(t *testing.T) {
+	svc, _ := newLoadedService(t)
+
+	parentID, err := svc.CreateNode("system", nil, "Parent", "parent", ptrKind(NodeKindSection))
+	if err != nil {
+		t.Fatalf("CreateNode parent: %v", err)
+	}
+
+	_, err = svc.CreateNode("system", nil, "Notes", "notes-root", ptrKind(NodeKindPage))
+	if err != nil {
+		t.Fatalf("CreateNode root notes: %v", err)
+	}
+	_, err = svc.CreateNode("system", parentID, "Notes", "notes-child", ptrKind(NodeKindPage))
+	if err != nil {
+		t.Fatalf("CreateNode child notes: %v", err)
+	}
+
+	results := svc.FindPagesByTitle("Notes")
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+}
+
+func TestFindPagesByTitle_NoMatch(t *testing.T) {
+	svc, _ := newLoadedService(t)
+
+	_, err := svc.CreateNode("system", nil, "Existing Page", "existing-page", ptrKind(NodeKindPage))
+	if err != nil {
+		t.Fatalf("CreateNode: %v", err)
+	}
+
+	results := svc.FindPagesByTitle("Nonexistent")
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestFindPagesByTitle_EmptyTitle(t *testing.T) {
+	svc, _ := newLoadedService(t)
+
+	results := svc.FindPagesByTitle("")
+	if results != nil {
+		t.Fatalf("expected nil for empty title, got %v", results)
+	}
+}
+
 func TestTreeService_GetPage_RawContent_NotSerializedToJSON(t *testing.T) {
 	svc, _ := newLoadedService(t)
 

--- a/internal/wiki/pages/get_page.go
+++ b/internal/wiki/pages/get_page.go
@@ -128,6 +128,48 @@ func (uc *ResolvePermalinkUseCase) Execute(_ context.Context, in ResolvePermalin
 	return &ResolvePermalinkOutput{Target: target}, nil
 }
 
+// ─── FindByTitle ─────────────────────────────────────────────────────────────
+
+// WikiLinkMatch is a lightweight page descriptor returned by the by-title API.
+type WikiLinkMatch struct {
+	ID    string          `json:"id"`
+	Title string          `json:"title"`
+	Path  string          `json:"path"`
+	Kind  tree.NodeKind   `json:"kind"`
+}
+
+// FindByTitleOutput is the output of FindByTitleUseCase.
+type FindByTitleOutput struct {
+	Matches []WikiLinkMatch `json:"matches"`
+	Count   int             `json:"count"`
+}
+
+// FindByTitleUseCase finds all pages whose title matches a given string
+// (case-insensitive).
+type FindByTitleUseCase struct {
+	tree *tree.TreeService
+}
+
+// NewFindByTitleUseCase constructs a FindByTitleUseCase.
+func NewFindByTitleUseCase(t *tree.TreeService) *FindByTitleUseCase {
+	return &FindByTitleUseCase{tree: t}
+}
+
+// Execute searches the tree for all pages matching the given title.
+func (uc *FindByTitleUseCase) Execute(_ context.Context, title string) *FindByTitleOutput {
+	nodes := uc.tree.FindPagesByTitle(title)
+	matches := make([]WikiLinkMatch, 0, len(nodes))
+	for _, n := range nodes {
+		matches = append(matches, WikiLinkMatch{
+			ID:    n.ID,
+			Title: n.Title,
+			Path:  n.CalculatePath(),
+			Kind:  n.Kind,
+		})
+	}
+	return &FindByTitleOutput{Matches: matches, Count: len(matches)}
+}
+
 // ─── SortPages ──────────────────────────────────────────────────────────────
 
 // SortPagesInput is the input for SortPagesUseCase.

--- a/internal/wiki/pages/routes.go
+++ b/internal/wiki/pages/routes.go
@@ -27,6 +27,7 @@ type Routes struct {
 	copyPage         *CopyPageUseCase
 	getPage          *GetPageUseCase
 	findByPath       *FindByPathUseCase
+	findByTitle      *FindByTitleUseCase
 	lookupPath       *LookupPagePathUseCase
 	resolvePermalink *ResolvePermalinkUseCase
 	sortPages        *SortPagesUseCase
@@ -49,6 +50,7 @@ type RoutesConfig struct {
 	CopyPage         *CopyPageUseCase
 	GetPage          *GetPageUseCase
 	FindByPath       *FindByPathUseCase
+	FindByTitle      *FindByTitleUseCase
 	LookupPath       *LookupPagePathUseCase
 	ResolvePermalink *ResolvePermalinkUseCase
 	SortPages        *SortPagesUseCase
@@ -72,6 +74,7 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 		copyPage:         cfg.CopyPage,
 		getPage:          cfg.GetPage,
 		findByPath:       cfg.FindByPath,
+		findByTitle:      cfg.FindByTitle,
 		lookupPath:       cfg.LookupPath,
 		resolvePermalink: cfg.ResolvePermalink,
 		sortPages:        cfg.SortPages,
@@ -92,6 +95,7 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 		pub := ctx.Base.Group("/api")
 		pub.GET("/tree", r.handleGetTree)
 		pub.GET("/pages/by-path", r.handleGetByPath)
+		pub.GET("/pages/by-title", r.handleFindByTitle)
 		pub.GET("/pages/lookup", r.handleLookupPath)
 		pub.GET("/pages/permalink/:id", r.handleResolvePermalink)
 		pub.GET("/pages/:id", r.handleGetPage)
@@ -109,6 +113,7 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 		authGroup.GET("/pages/:id", r.handleGetPage)
 		authGroup.GET("/pages/lookup", r.handleLookupPath)
 		authGroup.GET("/pages/by-path", r.handleGetByPath)
+		authGroup.GET("/pages/by-title", r.handleFindByTitle)
 		authGroup.GET("/pages/permalink/:id", r.handleResolvePermalink)
 	}
 
@@ -169,6 +174,16 @@ func (r *Routes) handleGetByPath(c *gin.Context) {
 		depth = 1
 	}
 	r.respondPageWithDepth(c, http.StatusOK, out.Page, depth)
+}
+
+func (r *Routes) handleFindByTitle(c *gin.Context) {
+	title := strings.TrimSpace(c.Query("title"))
+	if title == "" {
+		respondWithPageStatusError(c, http.StatusBadRequest, ErrCodePageMissingTitle, "Missing title query parameter", "missing title")
+		return
+	}
+	out := r.findByTitle.Execute(c.Request.Context(), title)
+	c.JSON(http.StatusOK, out)
 }
 
 func (r *Routes) handleLookupPath(c *gin.Context) {

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -326,6 +326,7 @@ func (w *Wiki) buildPagesRoutes() *wikipages.Routes {
 		CopyPage:         wikipages.NewCopyPageUseCase(w.tree, w.slug, o, w.asset, w.log),
 		GetPage:          wikipages.NewGetPageUseCase(w.tree),
 		FindByPath:       wikipages.NewFindByPathUseCase(w.tree),
+		FindByTitle:      wikipages.NewFindByTitleUseCase(w.tree),
 		LookupPath:       wikipages.NewLookupPagePathUseCase(w.tree),
 		ResolvePermalink: wikipages.NewResolvePermalinkUseCase(w.tree),
 		SortPages:        wikipages.NewSortPagesUseCase(w.tree),


### PR DESCRIPTION
Adds case-insensitive title-based page lookup to the TreeService. Required as the resolution backbone for upcoming [[Title]] wiki-link syntax.