### PR TITLE
fix(editor): stop unsaved dialog flicker

### DIFF
--- a/e2e/pages/EditPage.ts
+++ b/e2e/pages/EditPage.ts
@@ -56,6 +56,14 @@ export default class EditPage {
     await this.page.waitForLoadState('networkidle');
   }
 
+  async clickUnsavedChangesCancel() {
+    const cancelButton = this.page.locator(
+      'button[data-testid="unsaved-changes-dialog-button-cancel"]',
+    );
+    await cancelButton.waitFor({ state: 'visible' });
+    await cancelButton.click();
+  }
+
   async openAssetManager() {
     const assetManagerButton = this.page.locator('button[data-testid="open-asset-manager-button"]');
     await assetManagerButton.click();

--- a/e2e/tests/page.spec.ts
+++ b/e2e/tests/page.spec.ts
@@ -2128,6 +2128,68 @@ for the page edited at ${new Date().toISOString()}
     await expect(unsavedDialog).toBeHidden();
   });
 
+  test('canceling unsaved changes keeps editor open without reopening dialog', async ({ page }) => {
+    const title = `Page Cancel Unsaved Changes ${Date.now()}`;
+    const newContent = `Unsaved content for cancel ${new Date().toISOString()}`;
+
+    const treeView = new TreeView(page);
+    const curNodeCount = await treeView.getNumberOfTreeNodes();
+    await treeView.clickRootAddButton();
+
+    const addPageDialog = new AddPageDialog(page);
+    await addPageDialog.fillTitle(title);
+    await addPageDialog.submitWithoutRedirect();
+
+    await treeView.expectNumberOfTreeNodes(curNodeCount + 1);
+    await treeView.clickPageByTitle(title);
+
+    const viewPage = new ViewPage(page);
+    test.expect(await viewPage.getTitle()).toBe(title);
+    await viewPage.clickEditPageButton();
+
+    const editPage = new EditPage(page);
+    await editPage.writeContent(newContent);
+
+    const closeButton = page.locator('button[data-testid="close-editor-button"]');
+    const unsavedDialog = page.locator('[data-testid="unsaved-changes-dialog-button-confirm"]');
+
+    await closeButton.click();
+    await expect(unsavedDialog).toBeVisible();
+    await expect(unsavedDialog).toHaveCount(1);
+
+    await editPage.clickUnsavedChangesCancel();
+
+    await editPage.expectEditorStillOpen();
+    await expect(unsavedDialog).toBeHidden();
+
+    const dialogReopened = await page.evaluate(async () => {
+      const selector = '[data-testid="unsaved-changes-dialog-button-confirm"]';
+      const isVisible = (element: Element | null) => {
+        if (!(element instanceof HTMLElement)) return false;
+        const style = window.getComputedStyle(element);
+        return (
+          style.display !== 'none' &&
+          style.visibility !== 'hidden' &&
+          style.opacity !== '0' &&
+          element.getClientRects().length > 0
+        );
+      };
+
+      const deadline = performance.now() + 500;
+      while (performance.now() < deadline) {
+        if (isVisible(document.querySelector(selector))) {
+          return true;
+        }
+        await new Promise((resolve) => window.setTimeout(resolve, 25));
+      }
+      return false;
+    });
+
+    test.expect(dialogReopened).toBe(false);
+    await expect(unsavedDialog).toHaveCount(0);
+    await editPage.expectEditorStillOpen();
+  });
+
   test('create-page-with-mermaid', async ({ page }) => {
     const title = `Page With Mermaid ${Date.now()}`;
     const mermaidContent = `\`\`\`mermaid

--- a/ui/leafwiki-ui/src/components/DialogManager.tsx
+++ b/ui/leafwiki-ui/src/components/DialogManager.tsx
@@ -30,7 +30,7 @@ export function DialogManager() {
       setRenderProps(null)
     }, 200)
     return () => clearTimeout(timeoutId)
-  }, [dialogType, dialogProps])
+  }, [dialogType, dialogProps, renderType])
 
   return (
     <>

--- a/ui/leafwiki-ui/src/features/editor/useNavigationGuard.tsx
+++ b/ui/leafwiki-ui/src/features/editor/useNavigationGuard.tsx
@@ -19,6 +19,7 @@ export default function useNavigationGuard({
   onNavigate,
 }: UseNavigationGuardProps) {
   const allowNextNavigationRef = useRef(false)
+  const suppressNextDialogRef = useRef(false)
   const shouldBlock = useCallback(() => {
     if (allowNextNavigationRef.current) {
       return false
@@ -38,6 +39,7 @@ export default function useNavigationGuard({
       return
     }
     allowNextNavigationRef.current = false
+    suppressNextDialogRef.current = true
     if (blocker.state === 'blocked' && blocker.reset) {
       blocker.reset()
     }
@@ -63,13 +65,15 @@ export default function useNavigationGuard({
   useEffect(() => {
     if (blocker.state === 'unblocked') {
       allowNextNavigationRef.current = false
+      suppressNextDialogRef.current = false
       closeDialog()
     }
-  }, [blocker.state, closeDialog])
+  }, [blocker.location, blocker.state, closeDialog])
 
   useEffect(() => {
     return () => {
       allowNextNavigationRef.current = false
+      suppressNextDialogRef.current = false
       const dialogsState = useDialogsStore.getState()
       if (dialogsState.dialogType === DIALOG_UNSAVED_CHANGES) {
         dialogsState.closeDialog()
@@ -84,6 +88,8 @@ export default function useNavigationGuard({
     if (blocker.state !== 'blocked') return
 
     if (allowNextNavigationRef.current) return
+
+    if (suppressNextDialogRef.current) return
 
     openDialog(DIALOG_UNSAVED_CHANGES, {
       onConfirm,


### PR DESCRIPTION
Prevent the unsaved changes dialog from reopening while the router blocker is still transitioning after cancel.

Add end-to-end coverage for the cancel path so the dialog cannot briefly reappear without failing tests.