### PR TITLE
feat(ui): add [[Title]] wiki-link rendering and disambiguation dialog

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   lint-frontend:
     runs-on: ubuntu-latest
-    
+
     defaults:
       run:
         working-directory: ui/leafwiki-ui
@@ -45,4 +45,26 @@ jobs:
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           exit-code: 1
+
+  test-frontend:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ui/leafwiki-ui
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test
           

--- a/ui/leafwiki-ui/package-lock.json
+++ b/ui/leafwiki-ui/package-lock.json
@@ -66,22 +66,35 @@
         "@eslint/js": "^10.0.1",
         "@tailwindcss/postcss": "^4.3.0",
         "@tailwindcss/vite": "^4.3.0",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^25.9.1",
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.2",
+        "@vitest/coverage-v8": "^4.1.8",
         "eslint": "^10.4.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.6.0",
+        "jsdom": "^29.1.1",
         "postcss": "^8.5.15",
         "prettier": "^3.8.3",
         "prettier-plugin-tailwindcss": "^0.8.0",
         "tailwindcss": "^4.3.0",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.4",
-        "vite": "^8.0.14"
+        "vite": "^8.0.14",
+        "vitest": "^4.1.8"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -108,6 +121,57 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -242,9 +306,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -252,9 +316,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -286,19 +350,29 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -336,17 +410,27 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@braintree/sanitize-url": {
@@ -354,6 +438,19 @@
       "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
       "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
       "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
     },
     "node_modules/@chevrotain/types": {
       "version": "11.1.2",
@@ -512,6 +609,146 @@
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -727,6 +964,24 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -2362,6 +2617,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
@@ -2726,6 +2988,96 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -2735,6 +3087,25 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/codemirror": {
@@ -3007,6 +3378,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -3409,6 +3787,150 @@
         }
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.8",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.8",
+        "vitest": "4.1.8"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3448,6 +3970,31 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -3459,6 +4006,45 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
+      "integrity": "sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bail": {
       "version": "2.0.2",
@@ -3491,6 +4077,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -3569,6 +4165,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/character-entities": {
@@ -3712,6 +4318,27 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -4230,6 +4857,20 @@
         "lodash-es": "^4.17.21"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/date-fns": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.3.0.tgz",
@@ -4262,6 +4903,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -4330,6 +4978,14 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/dompurify": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
@@ -4371,6 +5027,13 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-toolkit": {
       "version": "1.46.1",
@@ -4587,6 +5250,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4595,6 +5268,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -4792,6 +5475,16 @@
       "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
       "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
       "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/hast-util-from-dom": {
       "version": "5.0.1",
@@ -5046,6 +5739,26 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -5124,6 +5837,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inline-style-parser": {
@@ -5220,12 +5943,58 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -5243,6 +6012,83 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -5678,6 +6524,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5686,6 +6543,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/markdown-table": {
@@ -6010,6 +6908,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mermaid": {
       "version": "11.15.0",
@@ -6672,6 +7577,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -6763,6 +7678,20 @@
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
+      "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -7083,6 +8012,22 @@
         }
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -7123,6 +8068,14 @@
       "peerDependencies": {
         "react": "^19.2.6"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -7256,6 +8209,20 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/rehype-highlight": {
@@ -7430,6 +8397,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/robust-predicates": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
@@ -7494,6 +8471,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -7539,6 +8529,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sonner": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
@@ -7569,6 +8566,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -7581,6 +8592,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/style-mod": {
@@ -7611,6 +8635,26 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
       "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tailwind-merge": {
@@ -7652,6 +8696,13 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -7676,6 +8727,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.2"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -7782,6 +8889,16 @@
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.1.tgz",
+      "integrity": "sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.24.6",
@@ -8150,11 +9267,114 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
@@ -8164,6 +9384,41 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -8182,6 +9437,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -8191,6 +9463,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/ui/leafwiki-ui/package.json
+++ b/ui/leafwiki-ui/package.json
@@ -10,7 +10,10 @@
     "lint:fix": "eslint . --fix",
     "preview": "vite preview",
     "format": "prettier --write \"src/**/*.{css,ts,tsx}\"",
-    "format:check": "prettier --check \"src/**/*.{css,ts,tsx}\""
+    "format:check": "prettier --check \"src/**/*.{css,ts,tsx}\"",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.2",
@@ -70,21 +73,27 @@
     "@eslint/js": "^10.0.1",
     "@tailwindcss/postcss": "^4.3.0",
     "@tailwindcss/vite": "^4.3.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^25.9.1",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
+    "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^10.4.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.6.0",
+    "jsdom": "^29.1.1",
     "postcss": "^8.5.15",
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "tailwindcss": "^4.3.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.4",
-    "vite": "^8.0.14"
+    "vite": "^8.0.14",
+    "vitest": "^4.1.8"
   },
   "overrides": {
     "lodash-es": "4.18.1"

--- a/ui/leafwiki-ui/src/features/preview/MarkdownLink.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownLink.tsx
@@ -9,6 +9,7 @@ import {
   resolveWikiLinkPath,
   toWikiLookupPath,
 } from '@/lib/wikiPath'
+import { suggestSlug } from '@/lib/api/pages'
 import { useAppMode } from '@/lib/useAppMode'
 import { useDialogsStore } from '@/stores/dialogs'
 import { useSessionStore } from '@/stores/session'
@@ -61,12 +62,16 @@ export function MarkdownLink({
       return (
         <Button
           variant="link"
-          onClick={() =>
+          onClick={async () => {
+            // Ask the server for a valid slug so the create-page dialog
+            // receives a proper path instead of the raw title (which may
+            // contain spaces or special characters).
+            const slug = await suggestSlug('', title).catch(() => '')
             openDialog(DIALOG_CREATE_PAGE_BY_PATH, {
-              initialPath: title,
+              initialPath: slug || title,
               forwardToEditMode: !editMode,
             })
-          }
+          }}
           className="text-error hover:text-error/80 m-0 p-0 text-base no-underline hover:no-underline"
         >
           {children}

--- a/ui/leafwiki-ui/src/features/preview/MarkdownLink.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownLink.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom'
 
 import { Button } from '@/components/ui/button'
 import { createNavigationVisitState } from '@/lib/navigationVisit'
-import { DIALOG_CREATE_PAGE_BY_PATH } from '@/lib/registries'
+import { DIALOG_CREATE_PAGE_BY_PATH, DIALOG_WIKILINK_DISAMBIGUATION } from '@/lib/registries'
 import { buildViewUrl, stripBasePath, withBasePath } from '@/lib/routePath'
 import {
   normalizeWikiRoutePath,
@@ -40,6 +40,42 @@ export function MarkdownLink({
 
   if (href === undefined) {
     return <>{children}</>
+  }
+
+  if (href.startsWith('wikilink-ambiguous:')) {
+    const title = decodeURIComponent(href.slice('wikilink-ambiguous:'.length))
+    return (
+      <Button
+        variant="link"
+        onClick={() => openDialog(DIALOG_WIKILINK_DISAMBIGUATION, { title })}
+        className="text-warning hover:text-warning/80 m-0 p-0 text-base no-underline hover:no-underline"
+      >
+        {children}
+      </Button>
+    )
+  }
+
+  if (href.startsWith('wikilink-notfound:')) {
+    const title = decodeURIComponent(href.slice('wikilink-notfound:'.length))
+    if (user) {
+      return (
+        <Button
+          variant="link"
+          onClick={() =>
+            openDialog(DIALOG_CREATE_PAGE_BY_PATH, {
+              initialPath: title,
+              forwardToEditMode: !editMode,
+            })
+          }
+          className="text-error hover:text-error/80 m-0 p-0 text-base no-underline hover:no-underline"
+        >
+          {children}
+        </Button>
+      )
+    }
+    return (
+      <span className="text-error cursor-default">{children}</span>
+    )
   }
 
   const isInternal =

--- a/ui/leafwiki-ui/src/features/preview/MarkdownLink.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownLink.tsx
@@ -2,7 +2,10 @@ import { Link } from 'react-router-dom'
 
 import { Button } from '@/components/ui/button'
 import { createNavigationVisitState } from '@/lib/navigationVisit'
-import { DIALOG_CREATE_PAGE_BY_PATH, DIALOG_WIKILINK_DISAMBIGUATION } from '@/lib/registries'
+import {
+  DIALOG_CREATE_PAGE_BY_PATH,
+  DIALOG_WIKILINK_DISAMBIGUATION,
+} from '@/lib/registries'
 import { buildViewUrl, stripBasePath, withBasePath } from '@/lib/routePath'
 import {
   normalizeWikiRoutePath,
@@ -52,7 +55,9 @@ export function MarkdownLink({
   }
 
   if (href.startsWith('wikilink-ambiguous:')) {
-    const title = safeDecodeURIComponent(href.slice('wikilink-ambiguous:'.length))
+    const title = safeDecodeURIComponent(
+      href.slice('wikilink-ambiguous:'.length),
+    )
     return (
       <Button
         variant="link"
@@ -65,7 +70,9 @@ export function MarkdownLink({
   }
 
   if (href.startsWith('wikilink-notfound:')) {
-    const title = safeDecodeURIComponent(href.slice('wikilink-notfound:'.length))
+    const title = safeDecodeURIComponent(
+      href.slice('wikilink-notfound:'.length),
+    )
     if (user) {
       return (
         <Button
@@ -86,9 +93,7 @@ export function MarkdownLink({
         </Button>
       )
     }
-    return (
-      <span className="text-error cursor-default">{children}</span>
-    )
+    return <span className="text-error cursor-default">{children}</span>
   }
 
   const isInternal =

--- a/ui/leafwiki-ui/src/features/preview/MarkdownLink.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownLink.tsx
@@ -17,6 +17,14 @@ import { useTreeStore } from '@/stores/tree'
 import clsx from 'clsx'
 import { AnchorHTMLAttributes, ReactNode } from 'react'
 
+function safeDecodeURIComponent(s: string): string {
+  try {
+    return decodeURIComponent(s)
+  } catch {
+    return s
+  }
+}
+
 interface MarkdownLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   href?: string
   children?: ReactNode
@@ -44,7 +52,7 @@ export function MarkdownLink({
   }
 
   if (href.startsWith('wikilink-ambiguous:')) {
-    const title = decodeURIComponent(href.slice('wikilink-ambiguous:'.length))
+    const title = safeDecodeURIComponent(href.slice('wikilink-ambiguous:'.length))
     return (
       <Button
         variant="link"
@@ -57,7 +65,7 @@ export function MarkdownLink({
   }
 
   if (href.startsWith('wikilink-notfound:')) {
-    const title = decodeURIComponent(href.slice('wikilink-notfound:'.length))
+    const title = safeDecodeURIComponent(href.slice('wikilink-notfound:'.length))
     if (user) {
       return (
         <Button

--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
@@ -47,6 +47,14 @@ import 'katex/dist/katex.min.css'
 const schema = {
   ...defaultSchema,
   clobberPrefix: '',
+  protocols: {
+    ...defaultSchema.protocols,
+    href: [
+      ...(defaultSchema.protocols?.href ?? []),
+      'wikilink-notfound',
+      'wikilink-ambiguous',
+    ],
+  },
   tagNames: [...(defaultSchema.tagNames || []), 'audio', 'video'],
   attributes: {
     ...defaultSchema.attributes,
@@ -241,7 +249,6 @@ export default function MarkdownPreview({
   tocClickable = true,
   onStickyTocChange,
 }: Props) {
-  const getPagesByTitle = useTreeStore((s) => s.getPagesByTitle)
   const treeById = useTreeStore((s) => s.byId)
   const designMode = useDesignModeStore((state) => state.mode)
   const prefersLight = useSyncExternalStore(
@@ -551,12 +558,15 @@ export default function MarkdownPreview({
     () =>
       normalizeMarkdownListIndentation(
         normalizeMarkdownShoutouts(
-          preprocessWikilinks(content, getPagesByTitle),
+          preprocessWikilinks(content, (title) => {
+            const lower = title.toLowerCase()
+            return Object.values(treeById).filter(
+              (n) => n.title.toLowerCase() === lower,
+            )
+          }),
         ),
       ),
-    // treeById is included so wiki-links re-resolve when the tree reloads.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [content, getPagesByTitle, treeById],
+    [content, treeById],
   )
 
   const tocEntries = useMemo(

--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
@@ -1,5 +1,6 @@
 import { useDesignModeStore } from '@/features/designtoggle/designmode'
 import { withBasePath } from '@/lib/routePath'
+import { useTreeStore } from '@/stores/tree'
 import {
   AnchorHTMLAttributes,
   AudioHTMLAttributes,
@@ -38,6 +39,7 @@ import './markdownPreviewCodeTheme.css'
 import MermaidBlock from './MermaidBlock'
 import { normalizeMarkdownListIndentation } from './normalizeMarkdownListIndentation'
 import { normalizeMarkdownShoutouts } from './normalizeMarkdownShoutouts'
+import { preprocessWikilinks } from '@/lib/preprocessWikilinks'
 import { rehypeLineNumber } from './rehypeLineNumber'
 import { rehypeWhitelistStyles } from './rehypeWhitelistStyles'
 import 'katex/dist/katex.min.css'
@@ -239,6 +241,8 @@ export default function MarkdownPreview({
   tocClickable = true,
   onStickyTocChange,
 }: Props) {
+  const getPagesByTitle = useTreeStore((s) => s.getPagesByTitle)
+  const treeById = useTreeStore((s) => s.byId)
   const designMode = useDesignModeStore((state) => state.mode)
   const prefersLight = useSyncExternalStore(
     (onStoreChange) => {
@@ -544,8 +548,15 @@ export default function MarkdownPreview({
   )
 
   const normalizedContent = useMemo(
-    () => normalizeMarkdownListIndentation(normalizeMarkdownShoutouts(content)),
-    [content],
+    () =>
+      normalizeMarkdownListIndentation(
+        normalizeMarkdownShoutouts(
+          preprocessWikilinks(content, getPagesByTitle),
+        ),
+      ),
+    // treeById is included so wiki-links re-resolve when the tree reloads.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [content, getPagesByTitle, treeById],
   )
 
   const tocEntries = useMemo(

--- a/ui/leafwiki-ui/src/features/wikilinks/WikiLinkDisambiguationDialog.tsx
+++ b/ui/leafwiki-ui/src/features/wikilinks/WikiLinkDisambiguationDialog.tsx
@@ -25,10 +25,10 @@ export function WikiLinkDisambiguationDialog({
   const isOpen = useDialogsStore(
     (s) => s.dialogType === DIALOG_WIKILINK_DISAMBIGUATION,
   )
-  const getPagesByTitle = useTreeStore((s) => s.getPagesByTitle)
+  const matches: PageNode[] = useTreeStore((s) =>
+    title ? s.getPagesByTitle(title) : [],
+  )
   const openAncestorsForPath = useTreeStore((s) => s.openAncestorsForPath)
-
-  const matches: PageNode[] = title ? getPagesByTitle(title) : []
 
   const handleSelect = (path: string) => {
     openAncestorsForPath(path)

--- a/ui/leafwiki-ui/src/features/wikilinks/WikiLinkDisambiguationDialog.tsx
+++ b/ui/leafwiki-ui/src/features/wikilinks/WikiLinkDisambiguationDialog.tsx
@@ -1,0 +1,82 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { createNavigationVisitState } from '@/lib/navigationVisit'
+import { PageNode } from '@/lib/api/pages'
+import { DIALOG_WIKILINK_DISAMBIGUATION } from '@/lib/registries'
+import { useDialogsStore } from '@/stores/dialogs'
+import { useTreeStore } from '@/stores/tree'
+import { File, FolderTree } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
+
+type WikiLinkDisambiguationDialogProps = {
+  title: string
+}
+
+export function WikiLinkDisambiguationDialog({
+  title,
+}: WikiLinkDisambiguationDialogProps) {
+  const navigate = useNavigate()
+  const closeDialog = useDialogsStore((s) => s.closeDialog)
+  const isOpen = useDialogsStore(
+    (s) => s.dialogType === DIALOG_WIKILINK_DISAMBIGUATION,
+  )
+  const getPagesByTitle = useTreeStore((s) => s.getPagesByTitle)
+  const openAncestorsForPath = useTreeStore((s) => s.openAncestorsForPath)
+
+  const matches: PageNode[] = title ? getPagesByTitle(title) : []
+
+  const handleSelect = (path: string) => {
+    openAncestorsForPath(path)
+    navigate(`/${path}`, { state: createNavigationVisitState() })
+    closeDialog()
+  }
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) queueMicrotask(() => closeDialog())
+      }}
+    >
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Multiple pages found</DialogTitle>
+          <DialogDescription>
+            Several pages match <strong>[[{title}]]</strong>. Choose which one
+            you meant.
+          </DialogDescription>
+        </DialogHeader>
+
+        <ul className="space-y-1">
+          {matches.map((page) => {
+            const Icon = page.kind === 'section' ? FolderTree : File
+            return (
+              <li key={page.id}>
+                <button
+                  type="button"
+                  onClick={() => handleSelect(page.path)}
+                  className="hover:bg-accent flex w-full items-start gap-3 rounded-md px-3 py-2 text-left"
+                >
+                  <Icon className="mt-0.5 h-4 w-4 shrink-0" />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm font-medium">
+                      {page.title}
+                    </span>
+                    <span className="text-muted-foreground block truncate text-xs">
+                      /{page.path}
+                    </span>
+                  </span>
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/ui/leafwiki-ui/src/lib/preprocessWikilinks.test.ts
+++ b/ui/leafwiki-ui/src/lib/preprocessWikilinks.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi } from 'vitest'
+import { preprocessWikilinks } from './preprocessWikilinks'
+import type { PageNode } from '@/lib/api/pages'
+
+const page = (id: string, path: string, title: string): PageNode => ({
+  id,
+  title,
+  slug: path.split('/').pop() ?? path,
+  path,
+  version: '1',
+  kind: 'page',
+  children: null,
+})
+
+const noMatch = () => []
+const singleMatch = (p: PageNode) => () => [p]
+const multiMatch = (pages: PageNode[]) => () => pages
+
+describe('preprocessWikilinks', () => {
+  describe('single match', () => {
+    it('replaces [[Title]] with a resolved markdown link', () => {
+      const docs = page('1', 'docs/intro', 'Intro')
+      const result = preprocessWikilinks('See [[Intro]] here.', singleMatch(docs))
+      expect(result).toBe('See [Intro](/docs/intro) here.')
+    })
+
+    it('uses the alias as display text for [[Title|Alias]]', () => {
+      const docs = page('1', 'docs/intro', 'Intro')
+      const result = preprocessWikilinks('[[Intro|our intro]]', singleMatch(docs))
+      expect(result).toBe('[our intro](/docs/intro)')
+    })
+
+    it('trims whitespace from target and alias', () => {
+      const docs = page('1', 'docs/intro', 'Intro')
+      const result = preprocessWikilinks('[[ Intro | our intro ]]', singleMatch(docs))
+      expect(result).toBe('[our intro](/docs/intro)')
+    })
+  })
+
+  describe('no match', () => {
+    it('emits wikilink-notfound: scheme when no page has that title', () => {
+      const result = preprocessWikilinks('[[Missing Page]]', noMatch)
+      expect(result).toBe('[Missing Page](wikilink-notfound:Missing%20Page)')
+    })
+
+    it('percent-encodes spaces and special characters in the notfound scheme', () => {
+      const result = preprocessWikilinks('[[Project Plan]]', noMatch)
+      expect(result).toBe('[Project Plan](wikilink-notfound:Project%20Plan)')
+    })
+  })
+
+  describe('multiple matches', () => {
+    it('emits wikilink-ambiguous: scheme when multiple pages match', () => {
+      const matches = multiMatch([
+        page('1', 'a/notes', 'Notes'),
+        page('2', 'b/notes', 'Notes'),
+      ])
+      const result = preprocessWikilinks('[[Notes]]', matches)
+      expect(result).toBe('[Notes](wikilink-ambiguous:Notes)')
+    })
+
+    it('encodes the title in the ambiguous scheme', () => {
+      const matches = multiMatch([
+        page('1', 'a/my-notes', 'My Notes'),
+        page('2', 'b/my-notes', 'My Notes'),
+      ])
+      const result = preprocessWikilinks('[[My Notes]]', matches)
+      expect(result).toBe('[My Notes](wikilink-ambiguous:My%20Notes)')
+    })
+  })
+
+  describe('path hints ([[Folder/Title]])', () => {
+    it('converts a slash-containing target to a direct path link', () => {
+      const result = preprocessWikilinks('[[docs/intro]]', noMatch)
+      expect(result).toBe('[docs/intro](/docs/intro)')
+    })
+
+    it('uses the alias as display text for path hints', () => {
+      const result = preprocessWikilinks('[[docs/intro|Introduction]]', noMatch)
+      expect(result).toBe('[Introduction](/docs/intro)')
+    })
+  })
+
+  describe('code block protection', () => {
+    it('does not convert [[Title]] inside fenced code blocks', () => {
+      const content = '```\nSee [[Intro]] for details\n```'
+      const result = preprocessWikilinks(content, singleMatch(page('1', 'intro', 'Intro')))
+      expect(result).toBe(content)
+    })
+
+    it('does not convert [[Title]] inside inline code', () => {
+      const content = 'Use `[[Title]]` syntax.'
+      const result = preprocessWikilinks(content, singleMatch(page('1', 'title', 'Title')))
+      expect(result).toBe(content)
+    })
+
+    it('converts [[Title]] outside code blocks but leaves code intact', () => {
+      const intro = page('1', 'docs/intro', 'Intro')
+      const content = 'See [[Intro]].\n\n```\n[[Intro]] example\n```'
+      const result = preprocessWikilinks(content, singleMatch(intro))
+      expect(result).toBe('See [Intro](/docs/intro).\n\n```\n[[Intro]] example\n```')
+    })
+
+    it('handles multiple code spans and wiki-links interleaved', () => {
+      const intro = page('1', 'docs/intro', 'Intro')
+      const content = '`code1` [[Intro]] `code2`'
+      const result = preprocessWikilinks(content, singleMatch(intro))
+      expect(result).toBe('`code1` [Intro](/docs/intro) `code2`')
+    })
+  })
+
+  describe('caching', () => {
+    it('calls getPagesByTitle only once for repeated occurrences of the same title', () => {
+      const intro = page('1', 'docs/intro', 'Intro')
+      const getPagesByTitle = vi.fn().mockReturnValue([intro])
+      preprocessWikilinks('[[Intro]] and [[Intro]] again', getPagesByTitle)
+      expect(getPagesByTitle).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls getPagesByTitle separately for case-variant titles', () => {
+      const getPagesByTitle = vi.fn().mockReturnValue([])
+      preprocessWikilinks('[[Notes]] and [[notes]]', getPagesByTitle)
+      // cache key is lowercased, so both resolve from the same cache entry
+      expect(getPagesByTitle).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('returns empty string unchanged', () => {
+      expect(preprocessWikilinks('', noMatch)).toBe('')
+    })
+
+    it('returns content without wiki-links unchanged', () => {
+      const content = 'Normal [link](/page) and text.'
+      expect(preprocessWikilinks(content, noMatch)).toBe(content)
+    })
+
+    it('handles multiple different wiki-links in one pass', () => {
+      const pageA = page('1', 'a', 'Alpha')
+      const pageB = page('2', 'b', 'Beta')
+      const lookup = (title: string) => {
+        if (title === 'Alpha') return [pageA]
+        if (title === 'Beta') return [pageB]
+        return []
+      }
+      const result = preprocessWikilinks('[[Alpha]] and [[Beta]]', lookup)
+      expect(result).toBe('[Alpha](/a) and [Beta](/b)')
+    })
+  })
+})

--- a/ui/leafwiki-ui/src/lib/preprocessWikilinks.test.ts
+++ b/ui/leafwiki-ui/src/lib/preprocessWikilinks.test.ts
@@ -20,19 +20,28 @@ describe('preprocessWikilinks', () => {
   describe('single match', () => {
     it('replaces [[Title]] with a resolved markdown link', () => {
       const docs = page('1', 'docs/intro', 'Intro')
-      const result = preprocessWikilinks('See [[Intro]] here.', singleMatch(docs))
+      const result = preprocessWikilinks(
+        'See [[Intro]] here.',
+        singleMatch(docs),
+      )
       expect(result).toBe('See [Intro](/docs/intro) here.')
     })
 
     it('uses the alias as display text for [[Title|Alias]]', () => {
       const docs = page('1', 'docs/intro', 'Intro')
-      const result = preprocessWikilinks('[[Intro|our intro]]', singleMatch(docs))
+      const result = preprocessWikilinks(
+        '[[Intro|our intro]]',
+        singleMatch(docs),
+      )
       expect(result).toBe('[our intro](/docs/intro)')
     })
 
     it('trims whitespace from target and alias', () => {
       const docs = page('1', 'docs/intro', 'Intro')
-      const result = preprocessWikilinks('[[ Intro | our intro ]]', singleMatch(docs))
+      const result = preprocessWikilinks(
+        '[[ Intro | our intro ]]',
+        singleMatch(docs),
+      )
       expect(result).toBe('[our intro](/docs/intro)')
     })
   })
@@ -84,13 +93,19 @@ describe('preprocessWikilinks', () => {
   describe('code block protection', () => {
     it('does not convert [[Title]] inside fenced code blocks', () => {
       const content = '```\nSee [[Intro]] for details\n```'
-      const result = preprocessWikilinks(content, singleMatch(page('1', 'intro', 'Intro')))
+      const result = preprocessWikilinks(
+        content,
+        singleMatch(page('1', 'intro', 'Intro')),
+      )
       expect(result).toBe(content)
     })
 
     it('does not convert [[Title]] inside inline code', () => {
       const content = 'Use `[[Title]]` syntax.'
-      const result = preprocessWikilinks(content, singleMatch(page('1', 'title', 'Title')))
+      const result = preprocessWikilinks(
+        content,
+        singleMatch(page('1', 'title', 'Title')),
+      )
       expect(result).toBe(content)
     })
 
@@ -98,7 +113,9 @@ describe('preprocessWikilinks', () => {
       const intro = page('1', 'docs/intro', 'Intro')
       const content = 'See [[Intro]].\n\n```\n[[Intro]] example\n```'
       const result = preprocessWikilinks(content, singleMatch(intro))
-      expect(result).toBe('See [Intro](/docs/intro).\n\n```\n[[Intro]] example\n```')
+      expect(result).toBe(
+        'See [Intro](/docs/intro).\n\n```\n[[Intro]] example\n```',
+      )
     })
 
     it('handles multiple code spans and wiki-links interleaved', () => {

--- a/ui/leafwiki-ui/src/lib/preprocessWikilinks.ts
+++ b/ui/leafwiki-ui/src/lib/preprocessWikilinks.ts
@@ -2,9 +2,18 @@ import { PageNode } from '@/lib/api/pages'
 
 const WIKILINK_RE = /\[\[([^\]|#\n]+?)(?:\|([^\]\n]+?))?\]\]/g
 
+// Matches fenced code blocks (``` ... ```) and inline code spans (`...`).
+// These are extracted before wiki-link processing so [[...]] inside code is
+// never converted to a link.
+const FENCED_CODE_RE = /```[\s\S]*?```/g
+const INLINE_CODE_RE = /`[^`\n]+`/g
+const PLACEHOLDER_RE = /\x00WLPH(\d+)\x00/g
+
 /**
  * Replaces [[Title]] wiki-link syntax with standard Markdown links before the
  * content is passed to the Markdown renderer.
+ *
+ * Code blocks and inline code spans are preserved unchanged.
  *
  * Resolution rules:
  *  - [[Folder/Title]]         → [Folder/Title](/Folder/Title)  (treated as a path hint)
@@ -17,24 +26,42 @@ export function preprocessWikilinks(
   content: string,
   getPagesByTitle: (title: string) => PageNode[],
 ): string {
-  return content.replace(WIKILINK_RE, (_raw, target: string, alias?: string) => {
-    const trimmedTarget = target.trim()
-    const displayText = alias ? alias.trim() : trimmedTarget
+  const placeholders: string[] = []
 
-    if (trimmedTarget.includes('/')) {
-      return `[${displayText}](/${trimmedTarget})`
-    }
+  const makePlaceholder = (m: string) => {
+    placeholders.push(m)
+    return `\x00WLPH${placeholders.length - 1}\x00`
+  }
 
-    const matches = getPagesByTitle(trimmedTarget)
+  // Protect code blocks and inline code from wiki-link substitution.
+  const stripped = content
+    .replace(FENCED_CODE_RE, makePlaceholder)
+    .replace(INLINE_CODE_RE, makePlaceholder)
 
-    if (matches.length === 1) {
-      return `[${displayText}](/${matches[0].path})`
-    }
+  const processed = stripped.replace(
+    WIKILINK_RE,
+    (_raw, target: string, alias?: string) => {
+      const trimmedTarget = target.trim()
+      const displayText = alias ? alias.trim() : trimmedTarget
 
-    if (matches.length === 0) {
-      return `[${displayText}](wikilink-notfound:${encodeURIComponent(trimmedTarget)})`
-    }
+      if (trimmedTarget.includes('/')) {
+        return `[${displayText}](/${trimmedTarget})`
+      }
 
-    return `[${displayText}](wikilink-ambiguous:${encodeURIComponent(trimmedTarget)})`
-  })
+      const matches = getPagesByTitle(trimmedTarget)
+
+      if (matches.length === 1) {
+        return `[${displayText}](/${matches[0].path})`
+      }
+
+      if (matches.length === 0) {
+        return `[${displayText}](wikilink-notfound:${encodeURIComponent(trimmedTarget)})`
+      }
+
+      return `[${displayText}](wikilink-ambiguous:${encodeURIComponent(trimmedTarget)})`
+    },
+  )
+
+  // Restore the original code spans.
+  return processed.replace(PLACEHOLDER_RE, (_, i) => placeholders[+i])
 }

--- a/ui/leafwiki-ui/src/lib/preprocessWikilinks.ts
+++ b/ui/leafwiki-ui/src/lib/preprocessWikilinks.ts
@@ -2,18 +2,18 @@ import { PageNode } from '@/lib/api/pages'
 
 const WIKILINK_RE = /\[\[([^\]|#\n]+?)(?:\|([^\]\n]+?))?\]\]/g
 
-// Matches fenced code blocks (``` ... ```) and inline code spans (`...`).
-// These are extracted before wiki-link processing so [[...]] inside code is
-// never converted to a link.
-const FENCED_CODE_RE = /```[\s\S]*?```/g
-const INLINE_CODE_RE = /`[^`\n]+`/g
-const PLACEHOLDER_RE = /\x00WLPH(\d+)\x00/g
+// Splits content into alternating [text, code, text, code, ...] segments.
+// The capture group keeps the code spans in the result array at odd indices.
+const CODE_SPLIT_RE = /(```[\s\S]*?```|`[^`\n]+`)/g
 
 /**
  * Replaces [[Title]] wiki-link syntax with standard Markdown links before the
  * content is passed to the Markdown renderer.
  *
- * Code blocks and inline code spans are preserved unchanged.
+ * Code blocks and inline code spans are preserved unchanged because only
+ * the even-indexed segments (plain text) are processed by the wiki-link regex.
+ * Repeated [[Title]] occurrences within a single call are resolved only once
+ * (cached) to avoid O(numLinks × numPages) scans.
  *
  * Resolution rules:
  *  - [[Folder/Title]]         → [Folder/Title](/Folder/Title)  (treated as a path hint)
@@ -26,21 +26,16 @@ export function preprocessWikilinks(
   content: string,
   getPagesByTitle: (title: string) => PageNode[],
 ): string {
-  const placeholders: string[] = []
+  const cache = new Map<string, PageNode[]>()
 
-  const makePlaceholder = (m: string) => {
-    placeholders.push(m)
-    return `\x00WLPH${placeholders.length - 1}\x00`
+  const getMatches = (title: string): PageNode[] => {
+    const key = title.toLowerCase()
+    if (!cache.has(key)) cache.set(key, getPagesByTitle(title))
+    return cache.get(key)!
   }
 
-  // Protect code blocks and inline code from wiki-link substitution.
-  const stripped = content
-    .replace(FENCED_CODE_RE, makePlaceholder)
-    .replace(INLINE_CODE_RE, makePlaceholder)
-
-  const processed = stripped.replace(
-    WIKILINK_RE,
-    (_raw, target: string, alias?: string) => {
+  const replaceWikilinks = (text: string): string =>
+    text.replace(WIKILINK_RE, (_raw, target: string, alias?: string) => {
       const trimmedTarget = target.trim()
       const displayText = alias ? alias.trim() : trimmedTarget
 
@@ -48,7 +43,7 @@ export function preprocessWikilinks(
         return `[${displayText}](/${trimmedTarget})`
       }
 
-      const matches = getPagesByTitle(trimmedTarget)
+      const matches = getMatches(trimmedTarget)
 
       if (matches.length === 1) {
         return `[${displayText}](/${matches[0].path})`
@@ -59,9 +54,12 @@ export function preprocessWikilinks(
       }
 
       return `[${displayText}](wikilink-ambiguous:${encodeURIComponent(trimmedTarget)})`
-    },
-  )
+    })
 
-  // Restore the original code spans.
-  return processed.replace(PLACEHOLDER_RE, (_, i) => placeholders[+i])
+  // Split preserves code spans at odd indices; only even indices (plain text)
+  // are processed for wiki-links.
+  return content
+    .split(CODE_SPLIT_RE)
+    .map((segment, i) => (i % 2 === 0 ? replaceWikilinks(segment) : segment))
+    .join('')
 }

--- a/ui/leafwiki-ui/src/lib/preprocessWikilinks.ts
+++ b/ui/leafwiki-ui/src/lib/preprocessWikilinks.ts
@@ -1,0 +1,40 @@
+import { PageNode } from '@/lib/api/pages'
+
+const WIKILINK_RE = /\[\[([^\]|#\n]+?)(?:\|([^\]\n]+?))?\]\]/g
+
+/**
+ * Replaces [[Title]] wiki-link syntax with standard Markdown links before the
+ * content is passed to the Markdown renderer.
+ *
+ * Resolution rules:
+ *  - [[Folder/Title]]         → [Folder/Title](/Folder/Title)  (treated as a path hint)
+ *  - [[Title]]                → [Title](/path)                 (single match in tree)
+ *  - [[Title|Alias]]          → [Alias](/path)                 (with custom display text)
+ *  - no match                 → uses wikilink-notfound: scheme (rendered red)
+ *  - multiple matches         → uses wikilink-ambiguous: scheme (opens disambiguation)
+ */
+export function preprocessWikilinks(
+  content: string,
+  getPagesByTitle: (title: string) => PageNode[],
+): string {
+  return content.replace(WIKILINK_RE, (_raw, target: string, alias?: string) => {
+    const trimmedTarget = target.trim()
+    const displayText = alias ? alias.trim() : trimmedTarget
+
+    if (trimmedTarget.includes('/')) {
+      return `[${displayText}](/${trimmedTarget})`
+    }
+
+    const matches = getPagesByTitle(trimmedTarget)
+
+    if (matches.length === 1) {
+      return `[${displayText}](/${matches[0].path})`
+    }
+
+    if (matches.length === 0) {
+      return `[${displayText}](wikilink-notfound:${encodeURIComponent(trimmedTarget)})`
+    }
+
+    return `[${displayText}](wikilink-ambiguous:${encodeURIComponent(trimmedTarget)})`
+  })
+}

--- a/ui/leafwiki-ui/src/lib/registries/index.tsx
+++ b/ui/leafwiki-ui/src/lib/registries/index.tsx
@@ -1,6 +1,7 @@
 // register sidebar panel items
 import { UnsavedChangesDialog } from '@/components/UnsavedChangesDialog'
 import { AssetManagerDialog } from '@/features/assets/AssetManagerDialog'
+import { WikiLinkDisambiguationDialog } from '@/features/wikilinks/WikiLinkDisambiguationDialog'
 import { LinkInsertDialog } from '@/features/editor/LinkInsertDialog'
 import { ImagePreviewDialog } from '@/features/imagepreview/ImagePreviewDialog'
 import { RestoreRevisionDialog } from '@/features/history/RestoreRevisionDialog'
@@ -77,6 +78,7 @@ export const DIALOG_PAGE_PERMALINK = 'page-permalink'
 export const DIALOG_RESTORE_REVISION_CONFIRMATION =
   'restore-revision-confirmation'
 export const DIALOG_LINK_INSERT = 'link-insert'
+export const DIALOG_WIKILINK_DISAMBIGUATION = 'wikilink-disambiguation'
 
 dialogRegistry.register({
   type: DIALOG_ADD_PAGE,
@@ -295,6 +297,18 @@ dialogRegistry.register({
       <RestoreRevisionDialog
         key={`${DIALOG_RESTORE_REVISION_CONFIRMATION}-${typedProps.revision.id}`}
         {...typedProps}
+      />
+    )
+  },
+})
+
+dialogRegistry.register({
+  type: DIALOG_WIKILINK_DISAMBIGUATION,
+  render: (props) => {
+    return (
+      <WikiLinkDisambiguationDialog
+        key={DIALOG_WIKILINK_DISAMBIGUATION}
+        {...(props as React.ComponentProps<typeof WikiLinkDisambiguationDialog>)}
       />
     )
   },

--- a/ui/leafwiki-ui/src/lib/registries/index.tsx
+++ b/ui/leafwiki-ui/src/lib/registries/index.tsx
@@ -308,7 +308,9 @@ dialogRegistry.register({
     return (
       <WikiLinkDisambiguationDialog
         key={DIALOG_WIKILINK_DISAMBIGUATION}
-        {...(props as React.ComponentProps<typeof WikiLinkDisambiguationDialog>)}
+        {...(props as React.ComponentProps<
+          typeof WikiLinkDisambiguationDialog
+        >)}
       />
     )
   },

--- a/ui/leafwiki-ui/src/stores/tree.test.ts
+++ b/ui/leafwiki-ui/src/stores/tree.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useTreeStore } from './tree'
+import type { PageNode } from '@/lib/api/pages'
+
+const makeNode = (
+  id: string,
+  title: string,
+  path: string,
+): PageNode => ({
+  id,
+  title,
+  slug: path.split('/').pop() ?? path,
+  path,
+  version: '1',
+  kind: 'page',
+  children: null,
+})
+
+describe('useTreeStore — getPagesByTitle', () => {
+  beforeEach(() => {
+    useTreeStore.setState({
+      byId: {},
+      byPath: {},
+      tree: null,
+      flatPages: [],
+    })
+  })
+
+  const load = (nodes: PageNode[]) => {
+    const byId: Record<string, PageNode> = {}
+    const byPath: Record<string, PageNode> = {}
+    for (const n of nodes) {
+      byId[n.id] = n
+      byPath[n.path] = n
+    }
+    useTreeStore.setState({ byId, byPath })
+  }
+
+  it('returns a matching page case-insensitively', () => {
+    load([makeNode('1', 'Getting Started', 'docs/getting-started')])
+    const { getPagesByTitle } = useTreeStore.getState()
+    expect(getPagesByTitle('Getting Started')).toHaveLength(1)
+    expect(getPagesByTitle('getting started')).toHaveLength(1)
+    expect(getPagesByTitle('GETTING STARTED')).toHaveLength(1)
+  })
+
+  it('returns all pages that share a title', () => {
+    load([
+      makeNode('1', 'Notes', 'team/notes'),
+      makeNode('2', 'Notes', 'personal/notes'),
+    ])
+    const { getPagesByTitle } = useTreeStore.getState()
+    expect(getPagesByTitle('Notes')).toHaveLength(2)
+  })
+
+  it('returns an empty array when no page matches', () => {
+    load([makeNode('1', 'Intro', 'intro')])
+    const { getPagesByTitle } = useTreeStore.getState()
+    expect(getPagesByTitle('Nonexistent')).toHaveLength(0)
+  })
+
+  it('returns an empty array when the tree is empty', () => {
+    const { getPagesByTitle } = useTreeStore.getState()
+    expect(getPagesByTitle('Anything')).toHaveLength(0)
+  })
+})

--- a/ui/leafwiki-ui/src/stores/tree.test.ts
+++ b/ui/leafwiki-ui/src/stores/tree.test.ts
@@ -2,11 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { useTreeStore } from './tree'
 import type { PageNode } from '@/lib/api/pages'
 
-const makeNode = (
-  id: string,
-  title: string,
-  path: string,
-): PageNode => ({
+const makeNode = (id: string, title: string, path: string): PageNode => ({
   id,
   title,
   slug: path.split('/').pop() ?? path,

--- a/ui/leafwiki-ui/src/stores/tree.ts
+++ b/ui/leafwiki-ui/src/stores/tree.ts
@@ -62,6 +62,7 @@ type TreeStore = {
   isNodeOpen: (id: string) => boolean
   getPageById: (id: string) => PageNode | null
   getPageByPath: (path: string) => PageNode | null
+  getPagesByTitle: (title: string) => PageNode[]
   getPathById: (id: string) => string | null
   getAncestors: (id: string) => string[]
   openAncestorsForPath: (path: string) => void
@@ -133,6 +134,12 @@ export const useTreeStore = create<TreeStore>()(
 
       getPageByPath: (path: string) => get().byPath?.[path] ?? null,
       getPageById: (id: string) => get().byId?.[id] ?? null,
+      getPagesByTitle: (title: string) => {
+        const lower = title.toLowerCase()
+        return Object.values(get().byId ?? {}).filter(
+          (n) => n.title.toLowerCase() === lower,
+        )
+      },
       getPathById: (id: string) => get().byId?.[id]?.path ?? null,
 
       getAncestors: (id: string) => {

--- a/ui/leafwiki-ui/src/test-setup.ts
+++ b/ui/leafwiki-ui/src/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/ui/leafwiki-ui/tsconfig.app.json
+++ b/ui/leafwiki-ui/tsconfig.app.json
@@ -5,6 +5,7 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["vitest/globals", "@testing-library/jest-dom"],
     "module": "ESNext",
     "skipLibCheck": true,
 
@@ -29,5 +30,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": []
 }

--- a/ui/leafwiki-ui/vitest.config.ts
+++ b/ui/leafwiki-ui/vitest.config.ts
@@ -1,0 +1,24 @@
+import react from '@vitejs/plugin-react'
+import path from 'path'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test-setup.ts'],
+    include: ['src/**/*.test.{ts,tsx}'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['src/**/*.test.{ts,tsx}', 'src/test-setup.ts', 'src/main.tsx'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+})


### PR DESCRIPTION
Preprocesses [[Title]] and [[Title|Alias]] syntax before markdown rendering. Single title matches resolve directly to the target page. Missing pages show as red broken links with a create-page prompt. Ambiguous titles (N>1 matches) show a disambiguation dialog so the user can pick the intended page. [[Folder/Title]] is treated as a direct path hint.