### PR TITLE
fix(refactor): extend link refactoring to handle [[Title]] wiki-link syntax

### DIFF
--- a/internal/links/link_refactor.go
+++ b/internal/links/link_refactor.go
@@ -76,7 +76,9 @@ func (e *MarkdownRefactorEngine) RewriteWikiLinks(content string, rules []Rewrit
 	for _, rule := range rules {
 		if rule.OldTitle != "" && rule.OldTitle != rule.NewTitle {
 			rewrites = append(rewrites, wikiRewrite{
-				re:        regexp.MustCompile(`(?i)\[\[` + regexp.QuoteMeta(rule.OldTitle) + `(\|[^\]\n]*)?\]\]`),
+				// \s* inside [[...]] mirrors the TrimSpace done by the extractor,
+				// so [[ Project Plan ]] is rewritten just like [[Project Plan]].
+				re:        regexp.MustCompile(`(?i)\[\[\s*` + regexp.QuoteMeta(rule.OldTitle) + `\s*(\|[^\]\n]*)?\]\]`),
 				newTarget: rule.NewTitle,
 			})
 		}
@@ -84,7 +86,7 @@ func (e *MarkdownRefactorEngine) RewriteWikiLinks(content string, rules []Rewrit
 		newHint := strings.TrimPrefix(normalizeWikiPath(rule.NewPath), "/")
 		if oldHint != "" && oldHint != newHint {
 			rewrites = append(rewrites, wikiRewrite{
-				re:        regexp.MustCompile(`\[\[` + regexp.QuoteMeta(oldHint) + `(\|[^\]\n]*)?\]\]`),
+				re:        regexp.MustCompile(`\[\[\s*` + regexp.QuoteMeta(oldHint) + `\s*(\|[^\]\n]*)?\]\]`),
 				newTarget: newHint,
 			})
 		}
@@ -130,22 +132,36 @@ func (e *MarkdownRefactorEngine) RewriteWikiLinks(content string, rules []Rewrit
 
 // FindWikiLinksForPath returns the wiki-link texts (e.g. "[[Project Plan]]")
 // found in content that reference the given path via title or path hint.
-// Used by the refactor preview to show wiki-links in the affected-pages list.
-func FindWikiLinksForPath(content, oldPath, pageTitle string) []string {
+// Only occurrences outside fenced code blocks and inline code are reported,
+// matching the same exclusion logic used by RewriteWikiLinks so preview and
+// apply agree on which links would actually be rewritten.
+func (e *MarkdownRefactorEngine) FindWikiLinksForPath(content, oldPath, pageTitle string) []string {
 	if content == "" {
 		return nil
 	}
+
+	_, excludedRanges := e.collectCandidatesAndExcludedRanges(content)
+
+	match := func(re *regexp.Regexp) bool {
+		for _, m := range re.FindAllStringIndex(content, -1) {
+			if !isExcludedOffset(m[0], excludedRanges) {
+				return true
+			}
+		}
+		return false
+	}
+
 	var found []string
 	oldHint := strings.TrimPrefix(normalizeWikiPath(oldPath), "/")
 	if oldHint != "" {
-		re := regexp.MustCompile(`\[\[` + regexp.QuoteMeta(oldHint) + `(?:\|[^\]\n]*)?\]\]`)
-		if re.MatchString(content) {
+		re := regexp.MustCompile(`\[\[\s*` + regexp.QuoteMeta(oldHint) + `\s*(?:\|[^\]\n]*)?\]\]`)
+		if match(re) {
 			found = append(found, "[["+oldHint+"]]")
 		}
 	}
 	if pageTitle != "" {
-		re := regexp.MustCompile(`(?i)\[\[` + regexp.QuoteMeta(pageTitle) + `(?:\|[^\]\n]*)?\]\]`)
-		if re.MatchString(content) {
+		re := regexp.MustCompile(`(?i)\[\[\s*` + regexp.QuoteMeta(pageTitle) + `\s*(?:\|[^\]\n]*)?\]\]`)
+		if match(re) {
 			found = append(found, "[["+pageTitle+"]]")
 		}
 	}

--- a/internal/links/link_refactor.go
+++ b/internal/links/link_refactor.go
@@ -2,6 +2,7 @@ package links
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -53,6 +54,102 @@ func (r RewriteResult) Count() int {
 func RewriteMarkdownLinks(content string, currentPath string, rules []RewriteRule) (string, int) {
 	result := NewMarkdownRefactorEngine().Rewrite(content, currentPath, rules)
 	return result.Content, result.Count()
+}
+
+// RewriteWikiLinks rewrites [[Title]] and [[Folder/Path]] wiki-link syntax
+// according to the provided rules, respecting code blocks and inline code.
+//
+// For each rule:
+//   - OldTitle → NewTitle rewrites [[OldTitle]] and [[OldTitle|Alias]]
+//   - OldPath  → NewPath  rewrites [[old/path]] and [[old/path|Alias]] path hints
+func (e *MarkdownRefactorEngine) RewriteWikiLinks(content string, rules []RewriteRule) RewriteResult {
+	if content == "" {
+		return RewriteResult{Content: content}
+	}
+
+	type wikiRewrite struct {
+		re        *regexp.Regexp
+		newTarget string
+	}
+
+	var rewrites []wikiRewrite
+	for _, rule := range rules {
+		if rule.OldTitle != "" && rule.OldTitle != rule.NewTitle {
+			rewrites = append(rewrites, wikiRewrite{
+				re:        regexp.MustCompile(`(?i)\[\[` + regexp.QuoteMeta(rule.OldTitle) + `(\|[^\]\n]*)?\]\]`),
+				newTarget: rule.NewTitle,
+			})
+		}
+		oldHint := strings.TrimPrefix(normalizeWikiPath(rule.OldPath), "/")
+		newHint := strings.TrimPrefix(normalizeWikiPath(rule.NewPath), "/")
+		if oldHint != "" && oldHint != newHint {
+			rewrites = append(rewrites, wikiRewrite{
+				re:        regexp.MustCompile(`\[\[` + regexp.QuoteMeta(oldHint) + `(\|[^\]\n]*)?\]\]`),
+				newTarget: newHint,
+			})
+		}
+	}
+
+	if len(rewrites) == 0 {
+		return RewriteResult{Content: content}
+	}
+
+	_, excludedRanges := e.collectCandidatesAndExcludedRanges(content)
+
+	var replacements []RewriteReplacement
+	for _, rw := range rewrites {
+		for _, m := range rw.re.FindAllStringSubmatchIndex(content, -1) {
+			if isExcludedOffset(m[0], excludedRanges) {
+				continue
+			}
+			var newValue string
+			if m[2] >= 0 {
+				newValue = "[[" + rw.newTarget + content[m[2]:m[3]] + "]]"
+			} else {
+				newValue = "[[" + rw.newTarget + "]]"
+			}
+			replacements = append(replacements, RewriteReplacement{
+				Start: m[0], End: m[1], NewValue: newValue,
+			})
+		}
+	}
+
+	if len(replacements) == 0 {
+		return RewriteResult{Content: content}
+	}
+
+	sort.Slice(replacements, func(i, j int) bool {
+		return replacements[i].Start < replacements[j].Start
+	})
+
+	return RewriteResult{
+		Content:      applyReplacements(content, replacements),
+		Replacements: replacements,
+	}
+}
+
+// FindWikiLinksForPath returns the wiki-link texts (e.g. "[[Project Plan]]")
+// found in content that reference the given path via title or path hint.
+// Used by the refactor preview to show wiki-links in the affected-pages list.
+func FindWikiLinksForPath(content, oldPath, pageTitle string) []string {
+	if content == "" {
+		return nil
+	}
+	var found []string
+	oldHint := strings.TrimPrefix(normalizeWikiPath(oldPath), "/")
+	if oldHint != "" {
+		re := regexp.MustCompile(`\[\[` + regexp.QuoteMeta(oldHint) + `(?:\|[^\]\n]*)?\]\]`)
+		if re.MatchString(content) {
+			found = append(found, "[["+oldHint+"]]")
+		}
+	}
+	if pageTitle != "" {
+		re := regexp.MustCompile(`(?i)\[\[` + regexp.QuoteMeta(pageTitle) + `(?:\|[^\]\n]*)?\]\]`)
+		if re.MatchString(content) {
+			found = append(found, "[["+pageTitle+"]]")
+		}
+	}
+	return found
 }
 
 func (e *MarkdownRefactorEngine) RewriteRelativeLinksForPathChange(content string, oldCurrentPath string, newCurrentPath string, rules []RewriteRule) RewriteResult {

--- a/internal/links/link_refactor_wikilinks_test.go
+++ b/internal/links/link_refactor_wikilinks_test.go
@@ -1,0 +1,147 @@
+package links
+
+import "testing"
+
+// ─── RewriteWikiLinks ────────────────────────────────────────────────────────
+
+func TestRewriteWikiLinks_TitleRename(t *testing.T) {
+	engine := NewMarkdownRefactorEngine()
+	content := "See [[Project Plan]] and [[Project Plan|our plan]] for details."
+
+	result := engine.RewriteWikiLinks(content, []RewriteRule{{
+		OldPath:  "/docs/project-plan",
+		NewPath:  "/docs/project-overview",
+		OldTitle: "Project Plan",
+		NewTitle: "Project Overview",
+	}})
+
+	want := "See [[Project Overview]] and [[Project Overview|our plan]] for details."
+	if result.Content != want {
+		t.Errorf("got %q, want %q", result.Content, want)
+	}
+	if result.Count() != 2 {
+		t.Errorf("expected 2 replacements, got %d", result.Count())
+	}
+}
+
+func TestRewriteWikiLinks_TitleRenameCaseInsensitive(t *testing.T) {
+	engine := NewMarkdownRefactorEngine()
+	content := "See [[project plan]] here."
+
+	result := engine.RewriteWikiLinks(content, []RewriteRule{{
+		OldTitle: "Project Plan",
+		NewTitle: "Project Overview",
+	}})
+
+	want := "See [[Project Overview]] here."
+	if result.Content != want {
+		t.Errorf("got %q, want %q", result.Content, want)
+	}
+}
+
+func TestRewriteWikiLinks_PathHintRewrite(t *testing.T) {
+	engine := NewMarkdownRefactorEngine()
+	content := "See [[docs/intro]] and [[docs/intro|Introduction]]."
+
+	result := engine.RewriteWikiLinks(content, []RewriteRule{{
+		OldPath: "/docs/intro",
+		NewPath: "/guides/intro",
+	}})
+
+	want := "See [[guides/intro]] and [[guides/intro|Introduction]]."
+	if result.Content != want {
+		t.Errorf("got %q, want %q", result.Content, want)
+	}
+	if result.Count() != 2 {
+		t.Errorf("expected 2 replacements, got %d", result.Count())
+	}
+}
+
+func TestRewriteWikiLinks_SkipsCodeBlocks(t *testing.T) {
+	engine := NewMarkdownRefactorEngine()
+	content := "```\n[[Old Title]]\n```\n\n[[Old Title]] outside"
+
+	result := engine.RewriteWikiLinks(content, []RewriteRule{
+		{OldTitle: "Old Title", NewTitle: "New Title"},
+	})
+
+	want := "```\n[[Old Title]]\n```\n\n[[New Title]] outside"
+	if result.Content != want {
+		t.Errorf("got %q, want %q", result.Content, want)
+	}
+	if result.Count() != 1 {
+		t.Errorf("expected 1 replacement (outside code block), got %d", result.Count())
+	}
+}
+
+func TestRewriteWikiLinks_NoMatchReturnsUnchanged(t *testing.T) {
+	engine := NewMarkdownRefactorEngine()
+	content := "See [[Other Page]] here."
+
+	result := engine.RewriteWikiLinks(content, []RewriteRule{
+		{OldTitle: "Project Plan", NewTitle: "Project Overview"},
+	})
+
+	if result.Content != content {
+		t.Errorf("content should be unchanged, got %q", result.Content)
+	}
+	if result.Count() != 0 {
+		t.Errorf("expected 0 replacements, got %d", result.Count())
+	}
+}
+
+func TestRewriteWikiLinks_EmptyRulesNoOp(t *testing.T) {
+	engine := NewMarkdownRefactorEngine()
+	content := "[[Some Page]]"
+	result := engine.RewriteWikiLinks(content, nil)
+	if result.Content != content {
+		t.Errorf("expected unchanged content, got %q", result.Content)
+	}
+}
+
+// ─── FindWikiLinksForPath ────────────────────────────────────────────────────
+
+func TestFindWikiLinksForPath_FindsPathHint(t *testing.T) {
+	content := "See [[docs/intro]] for details."
+	found := FindWikiLinksForPath(content, "/docs/intro", "Intro")
+	if len(found) == 0 {
+		t.Fatal("expected to find path hint [[docs/intro]]")
+	}
+	if found[0] != "[[docs/intro]]" {
+		t.Errorf("got %q, want [[docs/intro]]", found[0])
+	}
+}
+
+func TestFindWikiLinksForPath_FindsTitleLink(t *testing.T) {
+	content := "See [[Project Plan]] for details."
+	found := FindWikiLinksForPath(content, "/docs/project-plan", "Project Plan")
+	if len(found) == 0 {
+		t.Fatal("expected to find title link [[Project Plan]]")
+	}
+	if found[0] != "[[Project Plan]]" {
+		t.Errorf("got %q, want [[Project Plan]]", found[0])
+	}
+}
+
+func TestFindWikiLinksForPath_TitleMatchCaseInsensitive(t *testing.T) {
+	content := "See [[project plan]] for details."
+	found := FindWikiLinksForPath(content, "/docs/project-plan", "Project Plan")
+	if len(found) == 0 {
+		t.Fatal("expected case-insensitive title match")
+	}
+}
+
+func TestFindWikiLinksForPath_EmptyContentReturnsNil(t *testing.T) {
+	found := FindWikiLinksForPath("", "/docs/intro", "Intro")
+	if len(found) != 0 {
+		t.Errorf("expected nil for empty content, got %v", found)
+	}
+}
+
+func TestFindWikiLinksForPath_NoMatchReturnsEmpty(t *testing.T) {
+	content := "No wiki links here, just [regular](/links)."
+	found := FindWikiLinksForPath(content, "/docs/intro", "Intro")
+	if len(found) != 0 {
+		t.Errorf("expected no matches, got %v", found)
+	}
+}

--- a/internal/links/link_refactor_wikilinks_test.go
+++ b/internal/links/link_refactor_wikilinks_test.go
@@ -26,16 +26,20 @@ func TestRewriteWikiLinks_TitleRename(t *testing.T) {
 
 func TestRewriteWikiLinks_TitleRenameCaseInsensitive(t *testing.T) {
 	engine := NewMarkdownRefactorEngine()
-	content := "See [[project plan]] here."
 
-	result := engine.RewriteWikiLinks(content, []RewriteRule{{
-		OldTitle: "Project Plan",
-		NewTitle: "Project Overview",
-	}})
-
-	want := "See [[Project Overview]] here."
-	if result.Content != want {
-		t.Errorf("got %q, want %q", result.Content, want)
+	cases := []struct{ input, want string }{
+		{"See [[project plan]] here.", "See [[Project Overview]] here."},
+		{"See [[ project plan ]] here.", "See [[Project Overview]] here."},
+		{"See [[ Project Plan  ]] here.", "See [[Project Overview]] here."},
+	}
+	for _, tc := range cases {
+		result := engine.RewriteWikiLinks(tc.input, []RewriteRule{{
+			OldTitle: "Project Plan",
+			NewTitle: "Project Overview",
+		}})
+		if result.Content != tc.want {
+			t.Errorf("input %q: got %q, want %q", tc.input, result.Content, tc.want)
+		}
 	}
 }
 
@@ -59,18 +63,18 @@ func TestRewriteWikiLinks_PathHintRewrite(t *testing.T) {
 
 func TestRewriteWikiLinks_SkipsCodeBlocks(t *testing.T) {
 	engine := NewMarkdownRefactorEngine()
-	content := "```\n[[Old Title]]\n```\n\n[[Old Title]] outside"
+	content := "`[[Old Title]]` inline\n\n```\n[[Old Title]]\n```\n\n[[Old Title]] outside"
 
 	result := engine.RewriteWikiLinks(content, []RewriteRule{
 		{OldTitle: "Old Title", NewTitle: "New Title"},
 	})
 
-	want := "```\n[[Old Title]]\n```\n\n[[New Title]] outside"
+	want := "`[[Old Title]]` inline\n\n```\n[[Old Title]]\n```\n\n[[New Title]] outside"
 	if result.Content != want {
 		t.Errorf("got %q, want %q", result.Content, want)
 	}
 	if result.Count() != 1 {
-		t.Errorf("expected 1 replacement (outside code block), got %d", result.Count())
+		t.Errorf("expected 1 replacement (outside code), got %d", result.Count())
 	}
 }
 
@@ -102,8 +106,9 @@ func TestRewriteWikiLinks_EmptyRulesNoOp(t *testing.T) {
 // ─── FindWikiLinksForPath ────────────────────────────────────────────────────
 
 func TestFindWikiLinksForPath_FindsPathHint(t *testing.T) {
+	engine := NewMarkdownRefactorEngine()
 	content := "See [[docs/intro]] for details."
-	found := FindWikiLinksForPath(content, "/docs/intro", "Intro")
+	found := engine.FindWikiLinksForPath(content, "/docs/intro", "Intro")
 	if len(found) == 0 {
 		t.Fatal("expected to find path hint [[docs/intro]]")
 	}
@@ -113,8 +118,9 @@ func TestFindWikiLinksForPath_FindsPathHint(t *testing.T) {
 }
 
 func TestFindWikiLinksForPath_FindsTitleLink(t *testing.T) {
+	engine := NewMarkdownRefactorEngine()
 	content := "See [[Project Plan]] for details."
-	found := FindWikiLinksForPath(content, "/docs/project-plan", "Project Plan")
+	found := engine.FindWikiLinksForPath(content, "/docs/project-plan", "Project Plan")
 	if len(found) == 0 {
 		t.Fatal("expected to find title link [[Project Plan]]")
 	}
@@ -124,23 +130,45 @@ func TestFindWikiLinksForPath_FindsTitleLink(t *testing.T) {
 }
 
 func TestFindWikiLinksForPath_TitleMatchCaseInsensitive(t *testing.T) {
+	engine := NewMarkdownRefactorEngine()
 	content := "See [[project plan]] for details."
-	found := FindWikiLinksForPath(content, "/docs/project-plan", "Project Plan")
+	found := engine.FindWikiLinksForPath(content, "/docs/project-plan", "Project Plan")
 	if len(found) == 0 {
 		t.Fatal("expected case-insensitive title match")
 	}
 }
 
+func TestFindWikiLinksForPath_SkipsCodeBlocks(t *testing.T) {
+	engine := NewMarkdownRefactorEngine()
+	// Fenced code block: no occurrence outside code → nothing reported.
+	fenced := "```\n[[Project Plan]]\n```"
+	if found := engine.FindWikiLinksForPath(fenced, "/docs/project-plan", "Project Plan"); len(found) != 0 {
+		t.Errorf("fenced block: expected no match, got %v", found)
+	}
+	// Inline code: also excluded.
+	inline := "`[[Project Plan]]`"
+	if found := engine.FindWikiLinksForPath(inline, "/docs/project-plan", "Project Plan"); len(found) != 0 {
+		t.Errorf("inline code: expected no match, got %v", found)
+	}
+	// Outside code: should be found.
+	outside := "See [[Project Plan]] here."
+	if found := engine.FindWikiLinksForPath(outside, "/docs/project-plan", "Project Plan"); len(found) == 0 {
+		t.Errorf("outside code: expected match, got none")
+	}
+}
+
 func TestFindWikiLinksForPath_EmptyContentReturnsNil(t *testing.T) {
-	found := FindWikiLinksForPath("", "/docs/intro", "Intro")
+	engine := NewMarkdownRefactorEngine()
+	found := engine.FindWikiLinksForPath("", "/docs/intro", "Intro")
 	if len(found) != 0 {
 		t.Errorf("expected nil for empty content, got %v", found)
 	}
 }
 
 func TestFindWikiLinksForPath_NoMatchReturnsEmpty(t *testing.T) {
+	engine := NewMarkdownRefactorEngine()
 	content := "No wiki links here, just [regular](/links)."
-	found := FindWikiLinksForPath(content, "/docs/intro", "Intro")
+	found := engine.FindWikiLinksForPath(content, "/docs/intro", "Intro")
 	if len(found) != 0 {
 		t.Errorf("expected no matches, got %v", found)
 	}

--- a/internal/links/refactor.go
+++ b/internal/links/refactor.go
@@ -8,6 +8,8 @@ type RefactorLinkMatch struct {
 }
 
 type RewriteRule struct {
-	OldPath string
-	NewPath string
+	OldPath  string
+	NewPath  string
+	OldTitle string // optional: rewrite [[OldTitle]] wiki-links (rename only)
+	NewTitle string
 }

--- a/internal/wiki/pages/refactor.go
+++ b/internal/wiki/pages/refactor.go
@@ -210,7 +210,7 @@ func (uc *PreviewPageRefactorUseCase) getAffectedPages(oldPath string, pageTitle
 		// Replace raw route paths in matchedPaths with their wiki-link syntax
 		// when the page content uses [[Title]] or [[path/hint]] instead of
 		// a standard markdown link.
-		wikiLinks := links.FindWikiLinksForPath(sourcePage.Content, oldPath, pageTitle)
+		wikiLinks := engine.FindWikiLinksForPath(sourcePage.Content, oldPath, pageTitle)
 		for _, wl := range wikiLinks {
 			if !containsString(item.MatchedPaths, wl) {
 				item.MatchedPaths = append(item.MatchedPaths, wl)

--- a/internal/wiki/pages/refactor.go
+++ b/internal/wiki/pages/refactor.go
@@ -94,7 +94,7 @@ func (uc *PreviewPageRefactorUseCase) Execute(_ context.Context, in RefactorPrev
 	}
 
 	excludeIDs := subtreeIDSet(page.PageNode)
-	affectedPages, matchedLinks, err := uc.getAffectedPages(oldPath, excludeIDs)
+	affectedPages, matchedLinks, err := uc.getAffectedPages(oldPath, page.Title, excludeIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +165,7 @@ func (uc *PreviewPageRefactorUseCase) resolveParentPath(parentID string) (string
 	return parent.CalculatePath(), nil
 }
 
-func (uc *PreviewPageRefactorUseCase) getAffectedPages(oldPath string, excludeIDs map[string]struct{}) ([]RefactorAffectedPage, int, error) {
+func (uc *PreviewPageRefactorUseCase) getAffectedPages(oldPath string, pageTitle string, excludeIDs map[string]struct{}) ([]RefactorAffectedPage, int, error) {
 	if uc.links == nil {
 		return nil, 0, nil
 	}
@@ -206,6 +206,19 @@ func (uc *PreviewPageRefactorUseCase) getAffectedPages(oldPath string, excludeID
 		if err != nil {
 			return nil, 0, err
 		}
+
+		// Replace raw route paths in matchedPaths with their wiki-link syntax
+		// when the page content uses [[Title]] or [[path/hint]] instead of
+		// a standard markdown link.
+		wikiLinks := links.FindWikiLinksForPath(sourcePage.Content, oldPath, pageTitle)
+		for _, wl := range wikiLinks {
+			if !containsString(item.MatchedPaths, wl) {
+				item.MatchedPaths = append(item.MatchedPaths, wl)
+			}
+			// Remove the raw route path entry that the wiki-link replaces.
+			item.MatchedPaths = removeString(item.MatchedPaths, oldPath)
+		}
+
 		rules := []links.RewriteRule{{OldPath: oldPath, NewPath: oldPath}}
 		result := engine.Rewrite(sourcePage.Content, sourcePage.CalculatePath(), rules)
 		for _, w := range result.Warnings {
@@ -271,8 +284,12 @@ func (uc *ApplyPageRefactorUseCase) Execute(ctx context.Context, in RefactorAppl
 	}
 
 	if in.RewriteLinks {
-		rules := []links.RewriteRule{{OldPath: plan.oldPath, NewPath: plan.newPath}}
-		if err := uc.rewriteAffectedPages(in.UserID, plan.affectedPageIDs, rules); err != nil {
+		rule := links.RewriteRule{OldPath: plan.oldPath, NewPath: plan.newPath}
+		if in.Kind == RefactorKindRename && in.Title != plan.page.Title {
+			rule.OldTitle = plan.page.Title
+			rule.NewTitle = in.Title
+		}
+		if err := uc.rewriteAffectedPages(in.UserID, plan.affectedPageIDs, []links.RewriteRule{rule}); err != nil {
 			return nil, err
 		}
 	}
@@ -413,12 +430,14 @@ func (uc *ApplyPageRefactorUseCase) rewriteAffectedPages(userID string, affected
 		if !ok {
 			continue
 		}
-		result := engine.Rewrite(page.Content, page.CalculatePath(), rules)
-		if result.Count() == 0 || result.Content == page.Content {
+		mdResult := engine.Rewrite(page.Content, page.CalculatePath(), rules)
+		wikiResult := engine.RewriteWikiLinks(mdResult.Content, rules)
+		newContent := wikiResult.Content
+		if mdResult.Count() == 0 && wikiResult.Count() == 0 || newContent == page.Content {
 			continue
 		}
-		items = append(items, pending{page: page, content: result.Content})
-		bulk = append(bulk, tree.BulkContentUpdate{ID: page.ID, Content: result.Content})
+		items = append(items, pending{page: page, content: newContent})
+		bulk = append(bulk, tree.BulkContentUpdate{ID: page.ID, Content: newContent})
 	}
 
 	if len(bulk) == 0 {
@@ -548,6 +567,16 @@ func containsString(values []string, target string) bool {
 		}
 	}
 	return false
+}
+
+func removeString(values []string, target string) []string {
+	out := values[:0]
+	for _, v := range values {
+		if v != target {
+			out = append(out, v)
+		}
+	}
+	return out
 }
 
 func ensureStrings(values []string) []string {


### PR DESCRIPTION
Preview: FindWikiLinksForPath detects [[Title]] and [[path/hint]] patterns in page content and shows them in the affected-pages list instead of the raw route path, so users see [[Project Plan]] rather than /docs/project-plan.

Apply: RewriteWikiLinks rewrites [[OldTitle]] → [[NewTitle]] on rename and [[old/path]] → [[new/path]] for path hints on rename/move, respecting code blocks and inline code spans. OldTitle/NewTitle added to RewriteRule so the rename case carries title information through to the rewrite step.
