### PR TITLE
fix(wikilinks): handle ambiguous links

### DIFF
--- a/e2e/tests/wikilinks.spec.ts
+++ b/e2e/tests/wikilinks.spec.ts
@@ -192,4 +192,37 @@ test.describe('WikiLink autocomplete', () => {
     await expect(page.locator('article > h1')).toHaveText(missingTitle);
     await expect(page.locator('article a', { hasText: missingTitle })).toBeVisible();
   });
+
+  test('ambiguous-wikilink-opens-disambiguation-dialog', async ({ page }) => {
+    const stamp = Date.now();
+    const duplicateTitle = `Ambiguous WikiLink Target ${stamp}`;
+    const firstSlug = `wikilink-ambiguous-first-${stamp}`;
+    const secondSlug = `wikilink-ambiguous-second-${stamp}`;
+    const editorSlug = `wikilink-ambiguous-editor-${stamp}`;
+
+    await createPage(page, { title: duplicateTitle, slug: firstSlug });
+    await createPage(page, { title: duplicateTitle, slug: secondSlug });
+    await createPage(page, {
+      title: `WikiLink Ambiguous Editor ${stamp}`,
+      slug: editorSlug,
+      content: `[[${duplicateTitle}]]`,
+    });
+
+    const viewPage = new ViewPage(page);
+    await viewPage.goto(`/${editorSlug}`);
+
+    const ambiguousLinkButton = page.getByRole('button', { name: duplicateTitle });
+    await expect(ambiguousLinkButton).toBeVisible();
+    await ambiguousLinkButton.click();
+
+    const dialog = page.getByTestId('wikilink-disambiguation-dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText(`/${firstSlug}`)).toBeVisible();
+    await expect(dialog.getByText(`/${secondSlug}`)).toBeVisible();
+
+    await dialog.getByText(`/${firstSlug}`).click();
+
+    await expect(page).toHaveURL(new RegExp(`/${firstSlug}$`));
+    await expect(page.locator('article > h1')).toHaveText(duplicateTitle);
+  });
 });

--- a/internal/links/helpers.go
+++ b/internal/links/helpers.go
@@ -341,7 +341,7 @@ func toOutgoingLinkResult(tree *tree.TreeService, outgoings []Outgoing) *Outgoin
 func toOutgoingResultItem(tree *tree.TreeService, outgoing Outgoing) OutgoingResultItem {
 	displayPath := outgoing.ToPath
 	if IsWikilinkSentinel(outgoing.ToPath) {
-		displayPath = "[[" + WikilinkTitleFromSentinel(outgoing.ToPath) + "]]"
+		displayPath = WikilinkTitleFromSentinel(outgoing.ToPath)
 	}
 	item := OutgoingResultItem{
 		ToPageID:   outgoing.ToPageID,

--- a/internal/links/link_service_test.go
+++ b/internal/links/link_service_test.go
@@ -574,6 +574,36 @@ func TestToOutgoingResult_MapsOutgoingToResultItems(t *testing.T) {
 
 }
 
+func TestToOutgoingResult_WikilinkSentinelDisplaysPlainTitle(t *testing.T) {
+	ts, page1ID, _ := setupTreeForLinksTest(t)
+
+	outgoings := []Outgoing{{
+		FromPageID: page1ID,
+		ToPath:     wikilinkSentinel("Kafka"),
+		Broken:     true,
+		FromTitle:  "Page 1",
+	}}
+
+	result := toOutgoingLinkResult(ts, outgoings)
+	if result == nil {
+		t.Fatalf("expected non-nil result")
+	}
+	if result.Count != 1 {
+		t.Fatalf("expected 1 outgoing, got %d", result.Count)
+	}
+
+	item := result.Outgoings[0]
+	if item.ToPath != "Kafka" {
+		t.Errorf("ToPath = %q, want %q", item.ToPath, "Kafka")
+	}
+	if item.ToPath == "[[Kafka]]" {
+		t.Errorf("ToPath = %q, should not include wiki-link brackets", item.ToPath)
+	}
+	if !item.Broken {
+		t.Errorf("Broken = %v, want %v", item.Broken, true)
+	}
+}
+
 func TestLinkService_LateCreatedTarget_BecomesResolvedAfterReindex(t *testing.T) {
 	svc, ts, _ := setupLinkService(t)
 

--- a/ui/leafwiki-ui/src/features/wikilinks/WikiLinkDisambiguationDialog.tsx
+++ b/ui/leafwiki-ui/src/features/wikilinks/WikiLinkDisambiguationDialog.tsx
@@ -12,6 +12,7 @@ import { DIALOG_WIKILINK_DISAMBIGUATION } from '@/lib/registries'
 import { useDialogsStore } from '@/stores/dialogs'
 import { useTreeStore } from '@/stores/tree'
 import { File, FolderTree } from 'lucide-react'
+import { useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 type WikiLinkDisambiguationDialogProps = {
@@ -26,10 +27,16 @@ export function WikiLinkDisambiguationDialog({
   const isOpen = useDialogsStore(
     (s) => s.dialogType === DIALOG_WIKILINK_DISAMBIGUATION,
   )
-  const matches: PageNode[] = useTreeStore((s) =>
-    title ? s.getPagesByTitle(title) : [],
-  )
+  const byId = useTreeStore((s) => s.byId)
   const openAncestorsForPath = useTreeStore((s) => s.openAncestorsForPath)
+  const matches: PageNode[] = useMemo(() => {
+    if (!title) return []
+
+    const lower = title.toLowerCase()
+    return Object.values(byId ?? {}).filter(
+      (page) => page.title.toLowerCase() === lower,
+    )
+  }, [byId, title])
 
   const handleSelect = (path: string) => {
     openAncestorsForPath(path)
@@ -44,7 +51,10 @@ export function WikiLinkDisambiguationDialog({
         if (!open) queueMicrotask(() => closeDialog())
       }}
     >
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent
+        className="sm:max-w-lg"
+        data-testid="wikilink-disambiguation-dialog"
+      >
         <DialogHeader>
           <DialogTitle>
             {i18next.t('wikiLinkDisambiguation.title', { ns: 'editor' })}
@@ -65,6 +75,7 @@ export function WikiLinkDisambiguationDialog({
                 <button
                   type="button"
                   onClick={() => handleSelect(page.path)}
+                  data-testid={`wikilink-disambiguation-option-${page.id}`}
                   className="hover:bg-accent flex w-full items-start gap-3 rounded-md px-3 py-2 text-left"
                 >
                   <Icon className="mt-0.5 h-4 w-4 shrink-0" />


### PR DESCRIPTION
Stabilize the wikilink disambiguation dialog to avoid the React update loop and add coverage for ambiguous wikilink flows.

Adjust broken wikilink display output so ambiguous title sentinels render without wiki brackets in link status results.