### PR TITLE
refactor(wikilinks): always store [[Title]] links as sentinels

### DIFF
--- a/e2e/tests/wikilinks-refactor.spec.ts
+++ b/e2e/tests/wikilinks-refactor.spec.ts
@@ -1,0 +1,420 @@
+import test, { Page, expect } from '@playwright/test';
+import DeletePageDialog from '../pages/DeletePageDialog';
+import EditPage from '../pages/EditPage';
+import EditPageMetadataDialog from '../pages/EditPageMetadataDialog';
+import LoginPage from '../pages/LoginPage';
+import MovePageDialog from '../pages/MovePageDialog';
+import ViewPage from '../pages/ViewPage';
+
+const user = process.env.E2E_ADMIN_USER || 'admin';
+const password = process.env.E2E_ADMIN_PASSWORD || 'admin';
+
+// ─── API helpers ──────────────────────────────────────────────────────────────
+
+function getCsrfScript(): string {
+  return `
+    const hostMatch =
+      document.cookie.match(/(?:^|;\\s*)__Host-leafwiki_csrf=([^;]+)/) ??
+      document.cookie.match(/(?:^|;\\s*)leafwiki_csrf=([^;]+)/);
+    if (!hostMatch) throw new Error('Missing CSRF token cookie');
+    try { return decodeURIComponent(hostMatch[1]); } catch { return hostMatch[1]; }
+  `;
+}
+
+async function createPage(
+  page: Page,
+  input: { title: string; slug: string; content?: string; parentSlug?: string },
+): Promise<{ id: string; version: string }> {
+  return page.evaluate(
+    async ({ title, slug, content, parentSlug, csrfScript }) => {
+      const csrfToken = new Function(csrfScript)() as string;
+      const headers = { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken };
+
+      let parentId: string | null = null;
+      if (parentSlug) {
+        const r = await fetch(`/api/pages/by-path?path=${encodeURIComponent(parentSlug)}`, {
+          credentials: 'include',
+          headers: { 'X-CSRF-Token': csrfToken },
+        });
+        if (!r.ok) throw new Error(`parent lookup failed: ${r.status}`);
+        parentId = ((await r.json()) as { id: string }).id;
+      }
+
+      const createRes = await fetch('/api/pages', {
+        method: 'POST',
+        credentials: 'include',
+        headers,
+        body: JSON.stringify({ parentId, title, slug, kind: 'page' }),
+      });
+      if (!createRes.ok) throw new Error(`create failed: ${createRes.status}`);
+      const created = (await createRes.json()) as { id: string; version: string };
+
+      if (content !== undefined) {
+        const updateRes = await fetch(`/api/pages/${created.id}`, {
+          method: 'PUT',
+          credentials: 'include',
+          headers,
+          body: JSON.stringify({
+            version: created.version,
+            title,
+            slug,
+            content,
+            tags: [],
+            properties: {},
+          }),
+        });
+        if (!updateRes.ok) throw new Error(`update failed: ${updateRes.status}`);
+        return (await updateRes.json()) as { id: string; version: string };
+      }
+      return created;
+    },
+    { ...input, csrfScript: getCsrfScript() },
+  );
+}
+
+async function refactorPreview(
+  page: Page,
+  pageSlug: string,
+  body: Record<string, unknown>,
+): Promise<{
+  counts: { affectedPages: number; matchedLinks: number };
+  affectedPages: Array<{ fromTitle: string; matchedPaths: string[] }>;
+}> {
+  return page.evaluate(
+    async ({ pageSlug, body, csrfScript }) => {
+      const csrfToken = new Function(csrfScript)() as string;
+      const r = await fetch(`/api/pages/by-path?path=${encodeURIComponent(pageSlug)}`, {
+        credentials: 'include',
+        headers: { 'X-CSRF-Token': csrfToken },
+      });
+      if (!r.ok) throw new Error(`lookup failed: ${r.status}`);
+      const { id } = (await r.json()) as { id: string };
+
+      const pr = await fetch(`/api/pages/${id}/refactor/preview`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
+        body: JSON.stringify(body),
+      });
+      if (!pr.ok) throw new Error(`preview failed: ${pr.status}`);
+      return pr.json();
+    },
+    { pageSlug, body, csrfScript: getCsrfScript() },
+  );
+}
+
+async function applyRefactorRename(
+  page: Page,
+  pageSlug: string,
+  newTitle: string,
+  newSlug: string,
+  rewriteLinks: boolean,
+): Promise<void> {
+  await page.evaluate(
+    async ({ pageSlug, newTitle, newSlug, rewriteLinks, csrfScript }) => {
+      const csrfToken = new Function(csrfScript)() as string;
+      const r = await fetch(`/api/pages/by-path?path=${encodeURIComponent(pageSlug)}`, {
+        credentials: 'include',
+        headers: { 'X-CSRF-Token': csrfToken },
+      });
+      if (!r.ok) throw new Error(`lookup failed: ${r.status}`);
+      const { id, version } = (await r.json()) as { id: string; version: string };
+
+      const ar = await fetch(`/api/pages/${id}/refactor/apply`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
+        body: JSON.stringify({
+          kind: 'rename',
+          version,
+          title: newTitle,
+          slug: newSlug,
+          rewriteLinks,
+        }),
+      });
+      if (!ar.ok) throw new Error(`apply failed: ${ar.status}`);
+    },
+    { pageSlug, newTitle, newSlug, rewriteLinks, csrfScript: getCsrfScript() },
+  );
+}
+
+async function getPageContent(page: Page, slug: string): Promise<string> {
+  return page.evaluate(
+    async ({ slug, csrfScript }) => {
+      const csrfToken = new Function(csrfScript)() as string;
+      const r = await fetch(`/api/pages/by-path?path=${encodeURIComponent(slug)}`, {
+        credentials: 'include',
+        headers: { 'X-CSRF-Token': csrfToken },
+      });
+      if (!r.ok) throw new Error(`lookup failed: ${r.status}`);
+      return ((await r.json()) as { content: string }).content;
+    },
+    { slug, csrfScript: getCsrfScript() },
+  );
+}
+
+/** Polls the refactor preview endpoint until affectedPages reaches the expected count. */
+async function waitForAffectedPages(
+  page: Page,
+  pageSlug: string,
+  previewBody: Record<string, unknown>,
+  expectedCount: number,
+) {
+  await expect
+    .poll(
+      async () => {
+        const preview = await refactorPreview(page, pageSlug, previewBody);
+        return preview.counts.affectedPages;
+      },
+      { timeout: 15000 },
+    )
+    .toBe(expectedCount);
+}
+
+// ─── Suite ────────────────────────────────────────────────────────────────────
+
+test.describe('WikiLink [[Title]] refactoring and link status', () => {
+  test.beforeEach(async ({ page }) => {
+    await new LoginPage(page).goto();
+    await new LoginPage(page).login(user, password);
+    await new ViewPage(page).expectUserLoggedIn();
+  });
+
+  test.afterEach(async ({ page }) => {
+    await new ViewPage(page).logout();
+  });
+
+  // ── Rename: preview and apply via API ─────────────────────────────────────
+
+  test('rename-preview-includes-wikilink-title-as-affected-page', async ({ page }) => {
+    const s = Date.now();
+    const targetTitle = `Rename Target ${s}`;
+    const targetSlug = `rename-target-${s}`;
+    const refTitle = `Rename Ref ${s}`;
+    const refSlug = `rename-ref-${s}`;
+    const newTitle = `Rename Target New ${s}`;
+    const newSlug = `rename-target-new-${s}`;
+
+    await createPage(page, { title: targetTitle, slug: targetSlug });
+    await createPage(page, { title: refTitle, slug: refSlug, content: `[[${targetTitle}]]` });
+
+    const previewBody = { kind: 'rename', title: newTitle, slug: newSlug };
+    await waitForAffectedPages(page, targetSlug, previewBody, 1);
+
+    const preview = await refactorPreview(page, targetSlug, previewBody);
+    expect(preview.counts.affectedPages).toBe(1);
+    expect(preview.affectedPages[0].fromTitle).toBe(refTitle);
+    // The matched path entry must use wiki-link syntax, not a raw route path.
+    expect(preview.affectedPages[0].matchedPaths).toContain(`[[${targetTitle}]]`);
+  });
+
+  test('rename-rewrite-updates-wikilink-title-in-referencing-page', async ({ page }) => {
+    const s = Date.now();
+    const targetTitle = `Rewrite Target ${s}`;
+    const targetSlug = `rewrite-target-${s}`;
+    const newTitle = `Rewrite Target Renamed ${s}`;
+    const newSlug = `rewrite-target-renamed-${s}`;
+    const refSlug = `rewrite-ref-${s}`;
+
+    await createPage(page, { title: targetTitle, slug: targetSlug });
+    await createPage(page, {
+      title: `Rewrite Ref ${s}`,
+      slug: refSlug,
+      content: `[[${targetTitle}]]`,
+    });
+
+    await waitForAffectedPages(
+      page,
+      targetSlug,
+      { kind: 'rename', title: newTitle, slug: newSlug },
+      1,
+    );
+
+    await applyRefactorRename(page, targetSlug, newTitle, newSlug, true);
+
+    const content = await getPageContent(page, refSlug);
+    expect(content).toContain(`[[${newTitle}]]`);
+    expect(content).not.toContain(`[[${targetTitle}]]`);
+  });
+
+  // ── Rename: refactor dialog via UI ────────────────────────────────────────
+
+  test('rename-refactor-dialog-shows-wikilink-page-with-correct-matched-path', async ({ page }) => {
+    const s = Date.now();
+    const targetTitle = `UI Rename Target ${s}`;
+    const targetSlug = `ui-rename-target-${s}`;
+    const newTitle = `UI Rename Target New ${s}`;
+    const newSlug = `ui-rename-target-new-${s}`;
+    const refTitle = `UI Rename Ref ${s}`;
+    const refSlug = `ui-rename-ref-${s}`;
+
+    await createPage(page, { title: targetTitle, slug: targetSlug });
+    await createPage(page, { title: refTitle, slug: refSlug, content: `[[${targetTitle}]]` });
+
+    // Wait for the link index before navigating so the dialog shows correct data.
+    await waitForAffectedPages(
+      page,
+      targetSlug,
+      { kind: 'rename', title: newTitle, slug: newSlug },
+      1,
+    );
+
+    const viewPage = new ViewPage(page);
+    await viewPage.goto(`/${targetSlug}`);
+    await viewPage.clickEditPageButton();
+
+    const editPage = new EditPage(page);
+    await editPage.openMetadataDialog();
+
+    const metaDialog = new EditPageMetadataDialog(page);
+    await metaDialog.fillTitle(newTitle);
+    await metaDialog.fillSlug(newSlug);
+    await metaDialog.submit();
+
+    // Slug changed → refactor preview dialog must appear.
+    const movePageDialog = new MovePageDialog(page);
+    await movePageDialog.expectRefactorDialogVisible();
+    await movePageDialog.expectAffectedPagesCount(1);
+    await movePageDialog.expectAffectedPageTitle(refTitle);
+
+    // The matched-path column must show [[Title]] syntax, not a raw path.
+    await expect(
+      page.locator('[data-testid="page-refactor-dialog-affected-page-matches"]'),
+    ).toContainText(`[[${targetTitle}]]`);
+
+    await movePageDialog.confirmRefactorDialog();
+    await editPage.closeEditor();
+
+    // After rewrite, the ref page content must use the new title.
+    await viewPage.goto(`/${refSlug}`);
+    await expect(page.locator('article')).toContainText(`[[${newTitle}]]`);
+    await expect(page.locator('article')).not.toContainText(`[[${targetTitle}]]`);
+  });
+
+  // ── Move: path-hint wikilink appears in refactor dialog ───────────────────
+
+  test('move-refactor-dialog-shows-path-hint-wikilink-as-affected-page', async ({ page }) => {
+    const s = Date.now();
+    const parentSlug = `move-parent-${s}`;
+    const targetSlug = `move-target-${s}`;
+    const refTitle = `Move Ref ${s}`;
+    const refSlug = `move-ref-${s}`;
+    const fullPath = `${parentSlug}/${targetSlug}`;
+
+    await createPage(page, { title: `Move Parent ${s}`, slug: parentSlug });
+    await createPage(page, { title: `Move Target ${s}`, slug: targetSlug, parentSlug });
+    // Path-hint wikilink: [[parent/child]] resolves via route-path lookup.
+    await createPage(page, { title: refTitle, slug: refSlug, content: `[[${fullPath}]]` });
+
+    await waitForAffectedPages(page, fullPath, { kind: 'move', parentId: null }, 1);
+
+    const preview = await refactorPreview(page, fullPath, { kind: 'move', parentId: null });
+    expect(preview.counts.affectedPages).toBe(1);
+    expect(preview.affectedPages[0].fromTitle).toBe(refTitle);
+    // Path-hint wikilinks should appear with their [[path/hint]] syntax in the preview.
+    const allMatches = preview.affectedPages[0].matchedPaths;
+    expect(allMatches.some((p) => p.includes(targetSlug))).toBe(true);
+  });
+
+  // ── Ambiguous links: not broken ───────────────────────────────────────────
+
+  test('ambiguous-wikilink-not-shown-as-broken-in-link-panel', async ({ page }) => {
+    const s = Date.now();
+    const sharedTitle = `Ambiguous Broken ${s}`;
+    const slug1 = `ambiguous-broken-1-${s}`;
+    const slug2 = `ambiguous-broken-2-${s}`;
+    const sourceSlug = `ambiguous-broken-source-${s}`;
+
+    await createPage(page, { title: sharedTitle, slug: slug1 });
+    await createPage(page, { title: sharedTitle, slug: slug2 });
+    await createPage(page, {
+      title: `Ambiguous Source ${s}`,
+      slug: sourceSlug,
+      content: `[[${sharedTitle}]]`,
+    });
+
+    const viewPage = new ViewPage(page);
+    await viewPage.goto(`/${sourceSlug}`);
+
+    // Wait for backlinks panel to finish loading (no more "Loading…" text).
+    await expect
+      .poll(async () => page.locator('.backlinks__content').textContent(), { timeout: 15000 })
+      .not.toContain('Loading');
+
+    // "Broken links" count must be 0 — ambiguous [[Title]] is not a broken link.
+    const brokenGroupTitle = page
+      .locator('.backlinks__group-title')
+      .filter({ hasText: 'Broken links' });
+    await expect(brokenGroupTitle).toContainText('0');
+
+    // No broken-link items should be visible.
+    await expect(page.locator('.backlinks__item--broken')).toHaveCount(0);
+  });
+
+  // ── Ambiguous links: appear as backlinks for all matching pages ───────────
+
+  test('ambiguous-wikilink-appears-as-backlink-for-both-matching-pages', async ({ page }) => {
+    const s = Date.now();
+    const sharedTitle = `Ambiguous Backlink ${s}`;
+    const slug1 = `ambiguous-bl-1-${s}`;
+    const slug2 = `ambiguous-bl-2-${s}`;
+    const sourceTitle = `Ambiguous BL Source ${s}`;
+    const sourceSlug = `ambiguous-bl-source-${s}`;
+
+    await createPage(page, { title: sharedTitle, slug: slug1 });
+    await createPage(page, { title: sharedTitle, slug: slug2 });
+    await createPage(page, { title: sourceTitle, slug: sourceSlug, content: `[[${sharedTitle}]]` });
+
+    const viewPage = new ViewPage(page);
+
+    for (const slug of [slug1, slug2]) {
+      await viewPage.goto(`/${slug}`);
+
+      // Wait for the "Referenced by" badge to show at least 1 entry.
+      await expect
+        .poll(
+          async () => {
+            const el = page.locator('.backlinks__group-title').filter({ hasText: 'Referenced by' });
+            return el.textContent();
+          },
+          { timeout: 15000 },
+        )
+        .toMatch(/Referenced by\D*[1-9]/);
+
+      // The source page must appear as a backlink.
+      await expect(page.locator('.backlinks__item').filter({ hasText: sourceTitle })).toBeVisible();
+    }
+  });
+
+  // ── Delete dialog: [[Title]] backlinks show warning ───────────────────────
+
+  test('delete-dialog-shows-wikilink-backlink-warning', async ({ page }) => {
+    const s = Date.now();
+    const targetTitle = `Del Wikilink Target ${s}`;
+    const targetSlug = `del-wikilink-target-${s}`;
+    const refTitle = `Del Wikilink Ref ${s}`;
+    const refSlug = `del-wikilink-ref-${s}`;
+
+    await createPage(page, { title: targetTitle, slug: targetSlug });
+    await createPage(page, { title: refTitle, slug: refSlug, content: `[[${targetTitle}]]` });
+
+    // Wait until the link index has registered the [[Title]] backlink
+    // (reuse the rename preview as a proxy for index readiness).
+    await waitForAffectedPages(
+      page,
+      targetSlug,
+      { kind: 'rename', title: `${targetTitle} X`, slug: `${targetSlug}-x` },
+      1,
+    );
+
+    const viewPage = new ViewPage(page);
+    await viewPage.goto(`/${targetSlug}`);
+    await viewPage.clickDeletePageButton();
+
+    const deleteDialog = new DeletePageDialog(page);
+    await deleteDialog.waitForVisible();
+    await deleteDialog.expectBacklinksWarningVisible();
+    await deleteDialog.expectBacklinkTitle(refTitle);
+    await deleteDialog.abortDeletion();
+  });
+});

--- a/e2e/tests/wikilinks-refactor.spec.ts
+++ b/e2e/tests/wikilinks-refactor.spec.ts
@@ -271,6 +271,15 @@ test.describe('WikiLink [[Title]] refactoring and link status', () => {
     await metaDialog.fillSlug(newSlug);
     await metaDialog.submit();
 
+    // Auto-save skips slug changes — trigger a manual save.
+    // Wait until the toolbar reflects the metadata change so the manual save
+    // click actually starts the refactor flow.
+    const saveButton = page.locator('button[data-testid="save-page-button"]');
+    await expect(saveButton).toBeEnabled();
+    // Click the button without awaiting completion: the refactor dialog appears
+    // mid-save and must be confirmed before the save promise resolves.
+    await saveButton.click();
+
     // Slug changed → refactor preview dialog must appear.
     const movePageDialog = new MovePageDialog(page);
     await movePageDialog.expectRefactorDialogVisible();
@@ -283,6 +292,10 @@ test.describe('WikiLink [[Title]] refactoring and link status', () => {
     ).toContainText(`[[${targetTitle}]]`);
 
     await movePageDialog.confirmRefactorDialog();
+
+    // Wait for the save to complete after the dialog is confirmed.
+    await page.getByText('Page saved successfully').last().waitFor({ state: 'visible' });
+
     await editPage.closeEditor();
 
     // After rewrite, the ref page content must use the new title.

--- a/e2e/tests/wikilinks-refactor.spec.ts
+++ b/e2e/tests/wikilinks-refactor.spec.ts
@@ -298,10 +298,10 @@ test.describe('WikiLink [[Title]] refactoring and link status', () => {
 
     await editPage.closeEditor();
 
-    // After rewrite, the ref page content must use the new title.
-    await viewPage.goto(`/${refSlug}`);
-    await expect(page.locator('article')).toContainText(`[[${newTitle}]]`);
-    await expect(page.locator('article')).not.toContainText(`[[${targetTitle}]]`);
+    // After rewrite, the stored ref page content must use the new title.
+    const refContent = await getPageContent(page, refSlug);
+    expect(refContent).toContain(`[[${newTitle}]]`);
+    expect(refContent).not.toContain(`[[${targetTitle}]]`);
   });
 
   // ── Move: path-hint wikilink appears in refactor dialog ───────────────────

--- a/internal/links/helpers.go
+++ b/internal/links/helpers.go
@@ -144,7 +144,7 @@ func resolveWikiLinkTargets(treeService *tree.TreeService, targets []string) []T
 			if len(pages) == 1 {
 				result = append(result, TargetLink{
 					TargetPageID:   pages[0].ID,
-					TargetPagePath: normalizeWikiPath(pages[0].CalculatePath()),
+					TargetPagePath: wikilinkSentinel(target),
 					Broken:         false,
 				})
 				continue
@@ -163,7 +163,7 @@ func resolveWikiLinkTargets(treeService *tree.TreeService, targets []string) []T
 		if len(pages) == 1 {
 			result = append(result, TargetLink{
 				TargetPageID:   pages[0].ID,
-				TargetPagePath: normalizeWikiPath(pages[0].CalculatePath()),
+				TargetPagePath: wikilinkSentinel(target),
 				Broken:         false,
 			})
 		} else {

--- a/internal/links/link_service.go
+++ b/internal/links/link_service.go
@@ -83,6 +83,10 @@ func (b *LinkService) GetRefactorSourcePageIDsForPrefix(oldPrefix string) ([]str
 	return b.store.GetRefactorSourcePageIDsForPrefix(oldPrefix)
 }
 
+func (b *LinkService) GetRefactorSourcePageIDsForWikiLinkTitle(title string) ([]string, error) {
+	return b.store.GetRefactorSourcePageIDsForWikiLinkTitle(title)
+}
+
 func (b *LinkService) UpdateRewrittenLinksAndHealForPages(pages []*tree.Page, rules []RewriteRule) error {
 	outgoingByPageID, err := b.store.GetOutgoingLinksForPages(pageIDsForPages(pages))
 	if err != nil {
@@ -287,10 +291,29 @@ func (b *LinkService) HealLinksForExactPath(page *tree.Page) error {
 }
 
 // HealWikiLinksForPage heals broken [[Title]] sentinel records that target
-// this page's title. Called after page creation or restore so that wiki-links
-// written before the target page existed are automatically resolved.
+// this page's title, but only when exactly one page with that title exists.
+// If the title is shared by multiple pages the link is ambiguous and must
+// remain as a broken sentinel.
 func (b *LinkService) HealWikiLinksForPage(page *tree.Page) error {
+	if len(b.treeService.FindPagesByTitle(page.Title)) != 1 {
+		return nil
+	}
 	return b.store.HealWikiLinksForTitle(page.Title, page.ID)
+}
+
+// HealWikiLinksForTitleIfUnambiguous heals broken [[Title]] sentinels when
+// exactly one page with that title now exists. Called after a page is deleted
+// so that formerly ambiguous wikilinks become resolved if only one candidate
+// remains.
+func (b *LinkService) HealWikiLinksForTitleIfUnambiguous(title string) error {
+	if title == "" {
+		return nil
+	}
+	matches := b.treeService.FindPagesByTitle(title)
+	if len(matches) != 1 {
+		return nil
+	}
+	return b.store.HealWikiLinksForTitle(title, matches[0].ID)
 }
 
 func (b *LinkService) Close() error {

--- a/internal/links/link_service_test.go
+++ b/internal/links/link_service_test.go
@@ -1703,3 +1703,69 @@ func TestLinkService_AmbiguousWikiLinksAreNotBrokenInSourceStatus(t *testing.T) 
 		t.Fatalf("ToPath = %q, want %q", status.Outgoings[0].ToPath, "Kafka")
 	}
 }
+
+// ─── HealWikiLinksForPage ambiguity guard ─────────────────────────────────────
+
+// Gap 3: when N>1 pages share a title, HealWikiLinksForPage must not heal
+// broken [[Title]] sentinels, because the link is still ambiguous.
+func TestLinkService_HealWikiLinksForPage_DoesNotHealWhenAmbiguous(t *testing.T) {
+	svc, ts, _ := setupLinkService(t)
+
+	// Two "Kafka" pages already exist.
+	kafka1IDPtr, err := ts.CreateNode("system", nil, "Kafka", "kafka1", pageNodeKind())
+	if err != nil {
+		t.Fatalf("CreateNode kafka1: %v", err)
+	}
+	kafka2IDPtr, err := ts.CreateNode("system", nil, "Kafka", "kafka2", pageNodeKind())
+	if err != nil {
+		t.Fatalf("CreateNode kafka2: %v", err)
+	}
+	_ = kafka1IDPtr
+
+	// Source page writes [[Kafka]] while two matches exist → sentinel broken=1.
+	sourceIDPtr, err := ts.CreateNode("system", nil, "Source", "source", pageNodeKind())
+	if err != nil {
+		t.Fatalf("CreateNode source: %v", err)
+	}
+	sourcePage, err := ts.GetPage(*sourceIDPtr)
+	if err != nil {
+		t.Fatalf("GetPage source: %v", err)
+	}
+	if err := svc.UpdateLinksForPage(sourcePage, "See [[Kafka]]."); err != nil {
+		t.Fatalf("UpdateLinksForPage: %v", err)
+	}
+
+	out, err := svc.GetOutgoingLinksForPage(*sourceIDPtr)
+	if err != nil {
+		t.Fatalf("GetOutgoingLinksForPage: %v", err)
+	}
+	if out.Count != 1 || !out.Outgoings[0].Broken {
+		t.Fatalf("precondition: expected [[Kafka]] to be a broken sentinel with 2 pages, got %+v", out)
+	}
+
+	// Create a third "Kafka" page and call HealWikiLinksForPage for it.
+	// The sentinel must stay broken because 3 pages share the title.
+	kafka3IDPtr, err := ts.CreateNode("system", nil, "Kafka", "kafka3", pageNodeKind())
+	if err != nil {
+		t.Fatalf("CreateNode kafka3: %v", err)
+	}
+	kafka3, err := ts.GetPage(*kafka3IDPtr)
+	if err != nil {
+		t.Fatalf("GetPage kafka3: %v", err)
+	}
+	_ = kafka2IDPtr
+	if err := svc.HealWikiLinksForPage(kafka3); err != nil {
+		t.Fatalf("HealWikiLinksForPage: %v", err)
+	}
+
+	out, err = svc.GetOutgoingLinksForPage(*sourceIDPtr)
+	if err != nil {
+		t.Fatalf("GetOutgoingLinksForPage after heal attempt: %v", err)
+	}
+	if out.Count != 1 {
+		t.Fatalf("expected 1 outgoing, got %d", out.Count)
+	}
+	if !out.Outgoings[0].Broken {
+		t.Fatalf("[[Kafka]] should remain broken/ambiguous after 3rd Kafka page created, but was healed to %q", out.Outgoings[0].ToPath)
+	}
+}

--- a/internal/links/links_store.go
+++ b/internal/links/links_store.go
@@ -515,6 +515,39 @@ func (s *LinksStore) GetRefactorSourcePageIDsForPrefix(oldPrefix string) ([]stri
 	return pageIDs, nil
 }
 
+func (s *LinksStore) GetRefactorSourcePageIDsForWikiLinkTitle(title string) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	rows, err := s.db.Query(`
+		SELECT DISTINCT from_page_id
+		FROM links
+		WHERE LOWER(to_path) = ?
+	`, strings.ToLower(wikilinkSentinelPrefix+title))
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Default().Error("could not close rows", "error", err)
+		}
+	}()
+
+	var pageIDs []string
+	for rows.Next() {
+		var pageID string
+		if err := rows.Scan(&pageID); err != nil {
+			return nil, err
+		}
+		pageIDs = append(pageIDs, pageID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return pageIDs, nil
+}
+
 func (s *LinksStore) GetBrokenIncomingForPath(toPath string) ([]Backlink, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/wiki/pages/pages_test.go
+++ b/internal/wiki/pages/pages_test.go
@@ -1326,8 +1326,11 @@ func TestApplyPageRefactorUseCase_RenameRewritesTitleBasedWikiLinks(t *testing.T
 	if outgoing.Count != 1 {
 		t.Fatalf("expected 1 outgoing, got %d", outgoing.Count)
 	}
-	if outgoing.Outgoings[0].ToPath != "/target-renamed" {
-		t.Fatalf("ToPath = %q, want %q", outgoing.Outgoings[0].ToPath, "/target-renamed")
+	if outgoing.Outgoings[0].ToPath != "Target Renamed" {
+		t.Fatalf("ToPath = %q, want %q", outgoing.Outgoings[0].ToPath, "Target Renamed")
+	}
+	if outgoing.Outgoings[0].ToPageID != updated.ID {
+		t.Fatalf("ToPageID = %q, want %q", outgoing.Outgoings[0].ToPageID, updated.ID)
 	}
 	if outgoing.Outgoings[0].Broken {
 		t.Fatalf("expected rewritten wikilink to remain valid")
@@ -1561,8 +1564,8 @@ func TestApplyPageRefactorUseCase_Move_LeavesTitleBasedWikiLinksUnchanged(t *tes
 	if outgoing.Outgoings[0].ToPageID != target.Page.ID {
 		t.Fatalf("ToPageID = %q, want %q", outgoing.Outgoings[0].ToPageID, target.Page.ID)
 	}
-	if outgoing.Outgoings[0].ToPath != "/archive/target" {
-		t.Fatalf("ToPath = %q, want %q", outgoing.Outgoings[0].ToPath, "/archive/target")
+	if outgoing.Outgoings[0].ToPath != "Target" {
+		t.Fatalf("ToPath = %q, want %q", outgoing.Outgoings[0].ToPath, "Target")
 	}
 	if outgoing.Outgoings[0].Broken {
 		t.Fatalf("expected title-based wikilink to remain valid after move")
@@ -1856,6 +1859,232 @@ func TestDeletePageUseCase_Recursive_RemovesOutgoingForSubtree_AndBreaksIncoming
 	got := outC.Outgoings[0]
 	if got.ToPath != "/docs/b" || !got.Broken || got.ToPageID != "" {
 		t.Fatalf("unexpected outgoing after recursive delete: %#v", got)
+	}
+}
+
+// Gap 1: deleting one of two same-title pages should heal [[Title]] sentinels
+// that are now unambiguous (exactly one page with that title remains).
+func TestDeletePageUseCase_SingleDelete_HealsSentinelWhenDuplicateTitleRemoved(t *testing.T) {
+	deps := newTestDeps(t)
+	createUC := pages.NewCreatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default())
+	updateUC := pages.NewUpdatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default())
+	deleteUC := pages.NewDeletePageUseCase(deps.tree, deps.revision, deps.assets, deps.orchestrator(), slog.Default())
+
+	// Two pages share the title "Kafka".
+	kafka1, err := createUC.Execute(context.Background(), pages.CreatePageInput{
+		UserID: "system", Title: "Kafka", Slug: "kafka1", Kind: pageKind(),
+	})
+	if err != nil {
+		t.Fatalf("CreatePage kafka1: %v", err)
+	}
+	kafka2, err := createUC.Execute(context.Background(), pages.CreatePageInput{
+		UserID: "system", Title: "Kafka", Slug: "kafka2", Kind: pageKind(),
+	})
+	if err != nil {
+		t.Fatalf("CreatePage kafka2: %v", err)
+	}
+
+	// Source page writes [[Kafka]] while two matches exist → sentinel broken=1.
+	source, err := createUC.Execute(context.Background(), pages.CreatePageInput{
+		UserID: "system", Title: "Source", Slug: "source", Kind: pageKind(),
+	})
+	if err != nil {
+		t.Fatalf("CreatePage source: %v", err)
+	}
+	content := "See [[Kafka]]."
+	if _, err := updateUC.Execute(context.Background(), pages.UpdatePageInput{
+		UserID: "system", ID: source.Page.ID, Version: source.Page.Version(),
+		Title: source.Page.Title, Slug: source.Page.Slug, Content: &content, Kind: pageKind(),
+	}); err != nil {
+		t.Fatalf("UpdatePage source: %v", err)
+	}
+
+	// Precondition: [[Kafka]] is a broken sentinel (ambiguous).
+	out, err := deps.links.GetOutgoingLinksForPage(source.Page.ID)
+	if err != nil {
+		t.Fatalf("GetOutgoingLinksForPage: %v", err)
+	}
+	if out.Count != 1 || !out.Outgoings[0].Broken {
+		t.Fatalf("precondition: expected broken sentinel, got %+v", out)
+	}
+
+	// Delete kafka1 → only kafka2 remains → sentinel should be healed.
+	if err := deleteUC.Execute(context.Background(), pages.DeletePageInput{
+		UserID: "system", ID: kafka1.Page.ID, Version: kafka1.Page.Version(), Recursive: false,
+	}); err != nil {
+		t.Fatalf("DeletePage kafka1: %v", err)
+	}
+
+	out, err = deps.links.GetOutgoingLinksForPage(source.Page.ID)
+	if err != nil {
+		t.Fatalf("GetOutgoingLinksForPage after delete: %v", err)
+	}
+	if out.Count != 1 {
+		t.Fatalf("expected 1 outgoing, got %d", out.Count)
+	}
+	if out.Outgoings[0].Broken {
+		t.Fatalf("[[Kafka]] should be healed to kafka2 after kafka1 deleted, but is still broken")
+	}
+	if out.Outgoings[0].ToPageID != kafka2.Page.ID {
+		t.Fatalf("ToPageID = %q, want kafka2 %q", out.Outgoings[0].ToPageID, kafka2.Page.ID)
+	}
+}
+
+// Gap 1 (recursive): deleting a subtree that contains one of two same-title pages
+// should heal [[Title]] sentinels for titles that are now unambiguous.
+func TestDeletePageUseCase_Recursive_HealsSentinelWhenDuplicateTitleRemoved(t *testing.T) {
+	deps := newTestDeps(t)
+	createUC := pages.NewCreatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default())
+	updateUC := pages.NewUpdatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default())
+	deleteUC := pages.NewDeletePageUseCase(deps.tree, deps.revision, deps.assets, deps.orchestrator(), slog.Default())
+
+	// kafka1 lives inside a section that we will delete recursively.
+	section, err := createUC.Execute(context.Background(), pages.CreatePageInput{
+		UserID: "system", Title: "Section", Slug: "section", Kind: pageKind(),
+	})
+	if err != nil {
+		t.Fatalf("CreatePage section: %v", err)
+	}
+	kafka1, err := createUC.Execute(context.Background(), pages.CreatePageInput{
+		UserID: "system", ParentID: &section.Page.ID, Title: "Kafka", Slug: "kafka1", Kind: pageKind(),
+	})
+	if err != nil {
+		t.Fatalf("CreatePage kafka1: %v", err)
+	}
+	_ = kafka1
+	kafka2, err := createUC.Execute(context.Background(), pages.CreatePageInput{
+		UserID: "system", Title: "Kafka", Slug: "kafka2", Kind: pageKind(),
+	})
+	if err != nil {
+		t.Fatalf("CreatePage kafka2: %v", err)
+	}
+
+	source, err := createUC.Execute(context.Background(), pages.CreatePageInput{
+		UserID: "system", Title: "Source", Slug: "source", Kind: pageKind(),
+	})
+	if err != nil {
+		t.Fatalf("CreatePage source: %v", err)
+	}
+	content := "See [[Kafka]]."
+	if _, err := updateUC.Execute(context.Background(), pages.UpdatePageInput{
+		UserID: "system", ID: source.Page.ID, Version: source.Page.Version(),
+		Title: source.Page.Title, Slug: source.Page.Slug, Content: &content, Kind: pageKind(),
+	}); err != nil {
+		t.Fatalf("UpdatePage source: %v", err)
+	}
+
+	out, err := deps.links.GetOutgoingLinksForPage(source.Page.ID)
+	if err != nil {
+		t.Fatalf("GetOutgoingLinksForPage: %v", err)
+	}
+	if out.Count != 1 || !out.Outgoings[0].Broken {
+		t.Fatalf("precondition: expected broken sentinel, got %+v", out)
+	}
+
+	// Delete the whole section (contains kafka1) → kafka2 remains → sentinel healed.
+	sectionPage, err := deps.tree.GetPage(section.Page.ID)
+	if err != nil {
+		t.Fatalf("GetPage section: %v", err)
+	}
+	if err := deleteUC.Execute(context.Background(), pages.DeletePageInput{
+		UserID: "system", ID: sectionPage.ID, Version: sectionPage.Version(), Recursive: true,
+	}); err != nil {
+		t.Fatalf("DeletePage section (recursive): %v", err)
+	}
+
+	out, err = deps.links.GetOutgoingLinksForPage(source.Page.ID)
+	if err != nil {
+		t.Fatalf("GetOutgoingLinksForPage after recursive delete: %v", err)
+	}
+	if out.Count != 1 {
+		t.Fatalf("expected 1 outgoing, got %d", out.Count)
+	}
+	if out.Outgoings[0].Broken {
+		t.Fatalf("[[Kafka]] should be healed to kafka2 after section deleted, but is still broken")
+	}
+	if out.Outgoings[0].ToPageID != kafka2.Page.ID {
+		t.Fatalf("ToPageID = %q, want kafka2 %q", out.Outgoings[0].ToPageID, kafka2.Page.ID)
+	}
+}
+
+// Gap 1 (recursive, healed sentinel): when a recursive delete removes the only
+// page a [[Title]] sentinel was healed to, the link must be marked broken.
+// MarkLinksBrokenForPrefix misses healed sentinels because their to_path is
+// "wikilink:X", not the route path — MarkIncomingLinksBrokenForPage must also
+// run for each page in the subtree.
+//
+// Critical setup: [[Kafka]] must be written BEFORE the kafka page exists so it
+// is stored as a broken sentinel (to_path="wikilink:Kafka"). Only then does
+// healing via HealWikiLinksForPage produce a healed sentinel (broken=0,
+// to_page_id=kafka1, to_path="wikilink:Kafka").
+func TestDeletePageUseCase_Recursive_MarksHealedWikiLinkSentinelBroken(t *testing.T) {
+	deps := newTestDeps(t)
+	createUC := pages.NewCreatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default())
+	updateUC := pages.NewUpdatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default())
+	deleteUC := pages.NewDeletePageUseCase(deps.tree, deps.revision, deps.assets, deps.orchestrator(), slog.Default())
+
+	// Step 1: source writes [[Kafka]] before any Kafka page exists → broken sentinel.
+	source, err := createUC.Execute(context.Background(), pages.CreatePageInput{
+		UserID: "system", Title: "Source", Slug: "source", Kind: pageKind(),
+	})
+	if err != nil {
+		t.Fatalf("CreatePage source: %v", err)
+	}
+	content := "See [[Kafka]]."
+	if _, err := updateUC.Execute(context.Background(), pages.UpdatePageInput{
+		UserID: "system", ID: source.Page.ID, Version: source.Page.Version(),
+		Title: source.Page.Title, Slug: source.Page.Slug, Content: &content, Kind: pageKind(),
+	}); err != nil {
+		t.Fatalf("UpdatePage source: %v", err)
+	}
+
+	// Step 2: create kafka1 inside a section → HealWikiLinksForPage heals the sentinel
+	// to broken=0, to_page_id=kafka1, to_path="wikilink:Kafka" (not the route path).
+	section, err := createUC.Execute(context.Background(), pages.CreatePageInput{
+		UserID: "system", Title: "Section", Slug: "section", Kind: pageKind(),
+	})
+	if err != nil {
+		t.Fatalf("CreatePage section: %v", err)
+	}
+	_, err = createUC.Execute(context.Background(), pages.CreatePageInput{
+		UserID: "system", ParentID: &section.Page.ID, Title: "Kafka", Slug: "kafka1", Kind: pageKind(),
+	})
+	if err != nil {
+		t.Fatalf("CreatePage kafka1: %v", err)
+	}
+
+	// Precondition: sentinel is healed (broken=0, to_path="wikilink:Kafka").
+	out, err := deps.links.GetOutgoingLinksForPage(source.Page.ID)
+	if err != nil {
+		t.Fatalf("GetOutgoingLinksForPage: %v", err)
+	}
+	if out.Count != 1 || out.Outgoings[0].Broken {
+		t.Fatalf("precondition: expected healed sentinel, got %+v", out)
+	}
+
+	// Step 3: delete the whole section recursively.
+	// MarkLinksBrokenForPrefix('/section') will NOT match to_path="wikilink:Kafka".
+	// Without also calling MarkIncomingLinksBrokenForPage(kafka1.ID) the sentinel
+	// stays broken=0 pointing at the now-deleted kafka1.
+	sectionPage, err := deps.tree.GetPage(section.Page.ID)
+	if err != nil {
+		t.Fatalf("GetPage section: %v", err)
+	}
+	if err := deleteUC.Execute(context.Background(), pages.DeletePageInput{
+		UserID: "system", ID: sectionPage.ID, Version: sectionPage.Version(), Recursive: true,
+	}); err != nil {
+		t.Fatalf("DeletePage section (recursive): %v", err)
+	}
+
+	out, err = deps.links.GetOutgoingLinksForPage(source.Page.ID)
+	if err != nil {
+		t.Fatalf("GetOutgoingLinksForPage after recursive delete: %v", err)
+	}
+	if out.Count != 1 {
+		t.Fatalf("expected 1 outgoing, got %d", out.Count)
+	}
+	if !out.Outgoings[0].Broken {
+		t.Fatalf("[[Kafka]] should be broken after kafka1 recursively deleted, but is still resolved to %q", out.Outgoings[0].ToPageID)
 	}
 }
 

--- a/internal/wiki/pages/refactor.go
+++ b/internal/wiki/pages/refactor.go
@@ -94,7 +94,13 @@ func (uc *PreviewPageRefactorUseCase) Execute(_ context.Context, in RefactorPrev
 	}
 
 	excludeIDs := subtreeIDSet(page.PageNode)
-	affectedPages, matchedLinks, err := uc.getAffectedPages(oldPath, page.Title, excludeIDs)
+	// For renames that change the title, also surface pages that reference the
+	// old title via [[OldTitle]] wiki-link sentinels.
+	sentinelTitle := ""
+	if in.Kind == RefactorKindRename && in.Title != page.Title {
+		sentinelTitle = page.Title
+	}
+	affectedPages, matchedLinks, err := uc.getAffectedPages(oldPath, page.Title, excludeIDs, sentinelTitle)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +171,7 @@ func (uc *PreviewPageRefactorUseCase) resolveParentPath(parentID string) (string
 	return parent.CalculatePath(), nil
 }
 
-func (uc *PreviewPageRefactorUseCase) getAffectedPages(oldPath string, pageTitle string, excludeIDs map[string]struct{}) ([]RefactorAffectedPage, int, error) {
+func (uc *PreviewPageRefactorUseCase) getAffectedPages(oldPath string, pageTitle string, excludeIDs map[string]struct{}, sentinelTitle string) ([]RefactorAffectedPage, int, error) {
 	if uc.links == nil {
 		return nil, 0, nil
 	}
@@ -197,6 +203,39 @@ func (uc *PreviewPageRefactorUseCase) getAffectedPages(oldPath string, pageTitle
 			item.MatchedPaths = append(item.MatchedPaths, match.ToPath)
 		}
 		totalMatches++
+	}
+
+	// For title-changing renames, also include pages that reference the old
+	// title via [[OldTitle]] wiki-link sentinels (not matched by path prefix).
+	if sentinelTitle != "" {
+		sentinelIDs, err := uc.links.GetRefactorSourcePageIDsForWikiLinkTitle(sentinelTitle)
+		if err != nil {
+			return nil, 0, err
+		}
+		wikiLinkSyntax := "[[" + sentinelTitle + "]]"
+		for _, id := range sentinelIDs {
+			if _, excluded := excludeIDs[id]; excluded {
+				continue
+			}
+			if _, already := grouped[id]; already {
+				// Already found via path-prefix query; wiki-link annotation
+				// is handled in the items loop below.
+				continue
+			}
+			fromPath := ""
+			fromTitle := ""
+			if p, err := uc.tree.GetPage(id); err == nil && p != nil {
+				fromPath = p.CalculatePath()
+				fromTitle = p.Title
+			}
+			grouped[id] = &RefactorAffectedPage{
+				FromPageID:   id,
+				FromTitle:    fromTitle,
+				FromPath:     fromPath,
+				MatchedPaths: []string{wikiLinkSyntax},
+			}
+			totalMatches++
+		}
 	}
 
 	engine := links.NewMarkdownRefactorEngine()
@@ -389,6 +428,24 @@ func (uc *ApplyPageRefactorUseCase) buildApplyPlan(in RefactorApplyInput) (*appl
 			continue
 		}
 		plan.affectedPageIDs = append(plan.affectedPageIDs, pageID)
+	}
+
+	// For renames that change the title, also find pages that reference the old
+	// title via a sentinel (wikilink:OldTitle). These are stored as sentinels and
+	// are not found by the prefix-based lookup above.
+	if in.Kind == RefactorKindRename && in.Title != plan.page.Title {
+		sentinelIDs, err := uc.links.GetRefactorSourcePageIDsForWikiLinkTitle(plan.page.Title)
+		if err != nil {
+			return nil, err
+		}
+		for _, id := range sentinelIDs {
+			if _, excluded := excludeIDs[id]; excluded {
+				continue
+			}
+			if !containsString(plan.affectedPageIDs, id) {
+				plan.affectedPageIDs = append(plan.affectedPageIDs, id)
+			}
+		}
 	}
 
 	return plan, nil

--- a/internal/wiki/pages/update_page.go
+++ b/internal/wiki/pages/update_page.go
@@ -93,9 +93,9 @@ func (uc *UpdatePageUseCase) Execute(_ context.Context, in UpdatePageInput) (*Up
 	event := pagesave.PageSaveEvent{
 		Operation:      pagesave.PageOperationUpdate,
 		UserID:         in.UserID,
-		Before:         before,
 		After:          after,
 		OldPath:        oldPath,
+		OldTitle:       oldTitle,
 		ContentChanged: contentChanged,
 		SlugChanged:    slugChanged,
 		TitleChanged:   titleChanged,

--- a/internal/wiki/pages/update_page.go
+++ b/internal/wiki/pages/update_page.go
@@ -93,6 +93,7 @@ func (uc *UpdatePageUseCase) Execute(_ context.Context, in UpdatePageInput) (*Up
 	event := pagesave.PageSaveEvent{
 		Operation:      pagesave.PageOperationUpdate,
 		UserID:         in.UserID,
+		Before:         before,
 		After:          after,
 		OldPath:        oldPath,
 		ContentChanged: contentChanged,

--- a/internal/wiki/pagesave/event.go
+++ b/internal/wiki/pagesave/event.go
@@ -27,9 +27,11 @@ type PageSaveEvent struct {
 	SlugChanged    bool
 	TitleChanged   bool
 
-	// OldPath is the path of Before before the mutation (CalculatePath on a live node
+	// OldPath is the path of the page before the mutation (CalculatePath on a live node
 	// returns the new path after UpdateNode/MoveNode mutates the tree in place).
 	OldPath string
+	// OldTitle is the title before an update/rename; empty for other operations.
+	OldTitle string
 
 	// AffectedPages contains every page touched by the operation (e.g. a moved/deleted subtree).
 	// For single-page operations it holds the one affected page.

--- a/internal/wiki/pagesave/link_effect.go
+++ b/internal/wiki/pagesave/link_effect.go
@@ -40,12 +40,12 @@ func (e *LinkIndexSideEffect) Apply(event PageSaveEvent) {
 			// (wikilink:OldTitle, broken=0) are not reached by the path-prefix
 			// query above. Break them by page ID, then re-heal if another page
 			// now exclusively holds the old title.
-			if event.TitleChanged && event.Before != nil {
-				if err := e.svc.MarkIncomingLinksBrokenForPage(event.Before.ID); err != nil {
-					e.log.Warn("failed to mark incoming links broken for renamed page", "pageID", event.Before.ID, "error", err)
+			if event.TitleChanged && event.After != nil {
+				if err := e.svc.MarkIncomingLinksBrokenForPage(event.After.ID); err != nil {
+					e.log.Warn("failed to mark incoming links broken for renamed page", "pageID", event.After.ID, "error", err)
 				}
-				if err := e.svc.HealWikiLinksForTitleIfUnambiguous(event.Before.Title); err != nil {
-					e.log.Warn("failed to heal wiki links for old title", "title", event.Before.Title, "error", err)
+				if err := e.svc.HealWikiLinksForTitleIfUnambiguous(event.OldTitle); err != nil {
+					e.log.Warn("failed to heal wiki links for old title", "title", event.OldTitle, "error", err)
 				}
 			}
 			for _, p := range event.AffectedPages {

--- a/internal/wiki/pagesave/link_effect.go
+++ b/internal/wiki/pagesave/link_effect.go
@@ -36,6 +36,18 @@ func (e *LinkIndexSideEffect) Apply(event PageSaveEvent) {
 	case PageOperationUpdate:
 		if event.SlugChanged {
 			e.markBrokenForOldPath(event.OldPath)
+			// When the title also changed, healed wikilink sentinels
+			// (wikilink:OldTitle, broken=0) are not reached by the path-prefix
+			// query above. Break them by page ID, then re-heal if another page
+			// now exclusively holds the old title.
+			if event.TitleChanged && event.Before != nil {
+				if err := e.svc.MarkIncomingLinksBrokenForPage(event.Before.ID); err != nil {
+					e.log.Warn("failed to mark incoming links broken for renamed page", "pageID", event.Before.ID, "error", err)
+				}
+				if err := e.svc.HealWikiLinksForTitleIfUnambiguous(event.Before.Title); err != nil {
+					e.log.Warn("failed to heal wiki links for old title", "title", event.Before.Title, "error", err)
+				}
+			}
 			for _, p := range event.AffectedPages {
 				e.updateAndHeal(p)
 			}
@@ -64,8 +76,18 @@ func (e *LinkIndexSideEffect) Apply(event PageSaveEvent) {
 			return
 		}
 		if len(event.AffectedPages) > 1 {
-			// Recursive delete: mark entire subtree prefix as broken.
+			// Recursive delete: mark path-based links broken via prefix …
 			e.markBrokenForOldPath(event.OldPath)
+			// … and by page ID so that healed wikilink sentinels
+			// (to_path="wikilink:X", not the route path) are also marked broken.
+			for _, p := range event.AffectedPages {
+				if p == nil {
+					continue
+				}
+				if err := e.svc.MarkIncomingLinksBrokenForPage(p.ID); err != nil {
+					e.log.Warn("failed to mark incoming links broken", "pageID", p.ID, "error", err)
+				}
+			}
 		} else {
 			// Single-page delete.
 			if err := e.svc.MarkIncomingLinksBrokenForPage(event.Before.ID); err != nil {
@@ -75,6 +97,22 @@ func (e *LinkIndexSideEffect) Apply(event PageSaveEvent) {
 				if err := e.svc.MarkLinksBrokenForPath(event.OldPath); err != nil {
 					e.log.Warn("failed to mark links broken for path", "path", event.OldPath, "error", err)
 				}
+			}
+		}
+		// After deletion the title may now be unambiguous: heal any [[Title]]
+		// sentinels that were waiting for a unique match. Deduplicate by title
+		// to avoid redundant DB round-trips for same-titled pages in a subtree.
+		seenTitles := make(map[string]struct{}, len(event.AffectedPages))
+		for _, p := range event.AffectedPages {
+			if p == nil || p.Title == "" {
+				continue
+			}
+			if _, seen := seenTitles[p.Title]; seen {
+				continue
+			}
+			seenTitles[p.Title] = struct{}{}
+			if err := e.svc.HealWikiLinksForTitleIfUnambiguous(p.Title); err != nil {
+				e.log.Warn("failed to heal wiki links after delete", "title", p.Title, "error", err)
 			}
 		}
 	}

--- a/internal/wiki/pagesave/link_effect_test.go
+++ b/internal/wiki/pagesave/link_effect_test.go
@@ -1,0 +1,119 @@
+package pagesave
+
+import (
+	"testing"
+
+	"github.com/perber/wiki/internal/core/tree"
+	"github.com/perber/wiki/internal/links"
+)
+
+func pageKindPtr() *tree.NodeKind {
+	k := tree.NodeKindPage
+	return &k
+}
+
+func setupLinkEffect(t *testing.T) (*LinkIndexSideEffect, *links.LinkService, *tree.TreeService) {
+	t.Helper()
+	dataDir := t.TempDir()
+	ts := tree.NewTreeService(dataDir)
+	if err := ts.LoadTree(); err != nil {
+		t.Fatalf("LoadTree: %v", err)
+	}
+	store, err := links.NewLinksStore(dataDir)
+	if err != nil {
+		t.Fatalf("NewLinksStore: %v", err)
+	}
+	svc := links.NewLinkService(dataDir, ts, store)
+	return NewLinkIndexSideEffect(svc, nil), svc, ts
+}
+
+// TestLinkIndexSideEffect_Rename_HealsPreexistingBrokenWikilinks verifies that
+// renaming page "Alpha" → "Beta" heals broken [[Alpha]] sentinels that already
+// existed in the store (e.g. from when the title was ambiguous) by re-routing
+// them to the one remaining page still titled "Alpha".
+func TestLinkIndexSideEffect_Rename_HealsPreexistingBrokenWikilinks(t *testing.T) {
+	effect, svc, ts := setupLinkEffect(t)
+
+	// "Alpha" will be renamed; "Keeper" retains the title so [[Alpha]] becomes unambiguous.
+	alphaIDPtr, err := ts.CreateNode("system", nil, "Alpha", "alpha", pageKindPtr())
+	if err != nil {
+		t.Fatalf("CreateNode alpha: %v", err)
+	}
+	alphaID := *alphaIDPtr
+
+	keeperIDPtr, err := ts.CreateNode("system", nil, "Alpha", "keeper", pageKindPtr())
+	if err != nil {
+		t.Fatalf("CreateNode keeper: %v", err)
+	}
+	keeperID := *keeperIDPtr
+
+	linkerIDPtr, err := ts.CreateNode("system", nil, "Linker", "linker", pageKindPtr())
+	if err != nil {
+		t.Fatalf("CreateNode linker: %v", err)
+	}
+	linkerID := *linkerIDPtr
+
+	// Write [[Alpha]] wikilink into "Linker" and index it.
+	// With two pages titled "Alpha" the sentinel is ambiguous → stored broken.
+	linkerPage, err := ts.GetPage(linkerID)
+	if err != nil {
+		t.Fatalf("GetPage linker: %v", err)
+	}
+	content := "See [[Alpha]] for details."
+	if err := ts.UpdateNode("system", linkerPage.ID, linkerPage.Title, linkerPage.Slug, &content, tree.VersionUnchecked, false); err != nil {
+		t.Fatalf("UpdateNode linker: %v", err)
+	}
+	linkerPage, err = ts.GetPage(linkerID)
+	if err != nil {
+		t.Fatalf("GetPage linker (after update): %v", err)
+	}
+	if err := svc.UpdateLinksForPage(linkerPage, linkerPage.Content); err != nil {
+		t.Fatalf("UpdateLinksForPage: %v", err)
+	}
+
+	// Precondition: sentinel must be broken (ambiguous).
+	out, err := svc.GetOutgoingLinksForPage(linkerID)
+	if err != nil {
+		t.Fatalf("GetOutgoingLinksForPage: %v", err)
+	}
+	if out.Count != 1 || !out.Outgoings[0].Broken {
+		t.Fatalf("precondition failed: expected 1 broken [[Alpha]] sentinel, got %+v", out.Outgoings)
+	}
+
+	// Rename "Alpha" → "Beta" in the tree (UpdateNode mutates the live node).
+	if err := ts.UpdateNode("system", alphaID, "Beta", "beta", nil, tree.VersionUnchecked, false); err != nil {
+		t.Fatalf("UpdateNode rename alpha→beta: %v", err)
+	}
+	afterPage, err := ts.GetPage(alphaID)
+	if err != nil {
+		t.Fatalf("GetPage after rename: %v", err)
+	}
+
+	// Apply the link effect with the event that the use case would emit.
+	effect.Apply(PageSaveEvent{
+		Operation:     PageOperationUpdate,
+		UserID:        "system",
+		After:         afterPage,
+		OldPath:       "/alpha",
+		OldTitle:      "Alpha",
+		TitleChanged:  true,
+		SlugChanged:   true,
+		AffectedPages: []*tree.Page{afterPage},
+	})
+
+	// The broken [[Alpha]] sentinel must now be healed to point to "Keeper" —
+	// the only page still titled "Alpha".
+	out2, err := svc.GetOutgoingLinksForPage(linkerID)
+	if err != nil {
+		t.Fatalf("GetOutgoingLinksForPage (after heal): %v", err)
+	}
+	if out2.Count != 1 {
+		t.Fatalf("expected 1 outgoing after heal, got %d: %+v", out2.Count, out2.Outgoings)
+	}
+	if out2.Outgoings[0].Broken {
+		t.Fatalf("expected [[Alpha]] sentinel to be healed, still broken: %+v", out2.Outgoings[0])
+	}
+	if out2.Outgoings[0].ToPageID != keeperID {
+		t.Fatalf("expected sentinel to point to keeper (%q), got %q", keeperID, out2.Outgoings[0].ToPageID)
+	}
+}


### PR DESCRIPTION
[[Title]] wiki-links are now stored as wikilink:Title sentinels regardless of whether the target page already exists. Previously a single unambiguous match was stored as a resolved route path, causing inconsistencies across rename, move, and delete flows.

Key changes:
- helpers.go: single-match title lookups (pure and slash-fallback) now return wikilinkSentinel(target) instead of normalizeWikiPath(path)
- links_store.go: GetRefactorSourcePageIDsForWikiLinkTitle finds source pages via sentinel to_path for use in rename refactoring
- link_service.go: delegates new store method; HealWikiLinksForPage guards against ambiguous titles; adds HealWikiLinksForTitleIfUnambiguous
- refactor.go: buildApplyPlan merges sentinel-based page IDs into affectedPageIDs on title-changing renames; getAffectedPages now also queries sentinel-based pages so the preview matches what apply does
- link_effect.go: on title-changing slug updates, breaks stale wikilink:OldTitle sentinels via MarkIncomingLinksBrokenForPage then re-heals if OldTitle is still unambiguous; post-delete heal loop deduplicates by title to avoid redundant DB round-trips