### PR TITLE
fix (ui): Update Go directories

### DIFF
--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -18,7 +18,7 @@ import (
 	"github.com/perber/wiki/internal/http/middleware/security"
 )
 
-//go:embed dist/**
+//go:embed dist
 var frontend embed.FS
 
 // EmbedFrontend is a flag to enable or disable embedding the frontend.


### PR DESCRIPTION
Remove recursive globs since Go's embedded compiler doesn't support it.

This can lead to subdirectories being excluded from the compiled binaries.