### PR TITLE
feat(links): hide broken links section for read-only users and i18n b…

### DIFF
--- a/ui/leafwiki-ui/src/features/links/LinkInfo.tsx
+++ b/ui/leafwiki-ui/src/features/links/LinkInfo.tsx
@@ -1,10 +1,15 @@
 import { useConfigStore } from '@/stores/config'
 import { createNavigationVisitState } from '@/lib/navigationVisit'
+import i18next from '@/lib/i18n'
+import { useIsReadOnly } from '@/lib/useIsReadOnly'
 import { Link2Off, Paperclip } from 'lucide-react'
 import { useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { useViewerStore } from '../viewer/viewer'
 import { useLinkStatusStore } from './linkstatus_store'
+
+const t = (key: string, opts?: Record<string, unknown>) =>
+  i18next.t(key, { ...opts, ns: 'viewer' })
 
 export function BacklinkInfo() {
   const pageID = useViewerStore((s) => s.page?.id)
@@ -15,6 +20,7 @@ export function BacklinkInfo() {
   const loading = useLinkStatusStore((s) => s.loading)
   const error = useLinkStatusStore((s) => s.error)
   const status = useLinkStatusStore((s) => s.status)
+  const isReadOnly = useIsReadOnly()
 
   const fetchLinkStatusForPage = useLinkStatusStore(
     (s) => s.fetchLinkStatusForPage,
@@ -39,10 +45,9 @@ export function BacklinkInfo() {
   return (
     <div className="backlinks__pane">
       <div className="backlinks__content">
-        {/* Referenced by */}
         <div className="backlinks__group">
           <div className="backlinks__group-title">
-            Referenced by{' '}
+            {t('backlinks.referencedBy')}{' '}
             <span className="backlinks__badge">{backlinks.length}</span>
           </div>
 
@@ -58,83 +63,84 @@ export function BacklinkInfo() {
               ))}
             </ul>
           ) : loading ? (
-            <p className="backlinks__empty">Loading…</p>
+            <p className="backlinks__empty">{t('backlinks.loading')}</p>
           ) : (
-            <p className="backlinks__empty">No pages reference this page.</p>
+            <p className="backlinks__empty">{t('backlinks.noReferences')}</p>
           )}
         </div>
 
-        {/* Broken links */}
-        <div className="backlinks__group">
-          <div className="backlinks__group-title">
-            Broken links{' '}
-            <span className="backlinks__badge">
-              {brokenIncoming.length + brokenOutgoings.length}
-            </span>
-          </div>
+        {!isReadOnly && (
+          <div className="backlinks__group">
+            <div className="backlinks__group-title">
+              {t('backlinks.brokenLinks')}{' '}
+              <span className="backlinks__badge">
+                {brokenIncoming.length + brokenOutgoings.length}
+              </span>
+            </div>
 
-          {error && !loading ? (
-            <p className="page-viewer__error">Error: {error}</p>
-          ) : null}
+            {error && !loading ? (
+              <p className="page-viewer__error">Error: {error}</p>
+            ) : null}
 
-          {loading ? (
-            <p className="backlinks__empty">Loading…</p>
-          ) : brokenIncoming.length + brokenOutgoings.length === 0 ? (
-            <p className="backlinks__empty">No broken links.</p>
-          ) : (
-            <>
-              {brokenOutgoings.length > 0 && (
-                <>
-                  <div className="backlinks__subgroup-title">
-                    This page links to missing targets
-                  </div>
-                  <ul>
-                    {brokenOutgoings.map((ol) => (
-                      <li
-                        key={ol.to_path}
-                        className="backlinks__item backlinks__item--broken"
-                      >
-                        <span className="backlinks__icon-inline">
-                          <Link2Off size={16} className="backlinks__icon" />
-                        </span>
-                        <span className="ml-1">
-                          {ol.to_page_title ? `${ol.to_page_title} ` : ''}
-                          <span className="text-muted font-mono text-xs">
-                            {ol.to_path}
-                          </span>
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-                </>
-              )}
-
-              {brokenIncoming.length > 0 && (
-                <>
-                  <div className="backlinks__subgroup-title">
-                    Pages linking to an old path
-                  </div>
-                  <ul>
-                    {brokenIncoming.map((bl) => (
-                      <li
-                        key={bl.from_page_id}
-                        className="backlinks__item backlinks__item--broken"
-                      >
-                        <Link
-                          to={bl.from_path}
-                          state={createNavigationVisitState()}
+            {loading ? (
+              <p className="backlinks__empty">{t('backlinks.loading')}</p>
+            ) : brokenIncoming.length + brokenOutgoings.length === 0 ? (
+              <p className="backlinks__empty">{t('backlinks.noBrokenLinks')}</p>
+            ) : (
+              <>
+                {brokenOutgoings.length > 0 && (
+                  <>
+                    <div className="backlinks__subgroup-title">
+                      {t('backlinks.brokenOutgoingsTitle')}
+                    </div>
+                    <ul>
+                      {brokenOutgoings.map((ol) => (
+                        <li
+                          key={ol.to_path}
+                          className="backlinks__item backlinks__item--broken"
                         >
-                          <Link2Off size={16} className="backlinks__icon" />{' '}
-                          {bl.from_title}
-                        </Link>
-                      </li>
-                    ))}
-                  </ul>
-                </>
-              )}
-            </>
-          )}
-        </div>
+                          <span className="backlinks__icon-inline">
+                            <Link2Off size={16} className="backlinks__icon" />
+                          </span>
+                          <span className="ml-1">
+                            {ol.to_page_title ? `${ol.to_page_title} ` : ''}
+                            <span className="text-muted font-mono text-xs">
+                              {ol.to_path}
+                            </span>
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </>
+                )}
+
+                {brokenIncoming.length > 0 && (
+                  <>
+                    <div className="backlinks__subgroup-title">
+                      {t('backlinks.brokenIncomingTitle')}
+                    </div>
+                    <ul>
+                      {brokenIncoming.map((bl) => (
+                        <li
+                          key={bl.from_page_id}
+                          className="backlinks__item backlinks__item--broken"
+                        >
+                          <Link
+                            to={bl.from_path}
+                            state={createNavigationVisitState()}
+                          >
+                            <Link2Off size={16} className="backlinks__icon" />{' '}
+                            {bl.from_title}
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  </>
+                )}
+              </>
+            )}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/ui/leafwiki-ui/src/features/links/LinkInfo.tsx
+++ b/ui/leafwiki-ui/src/features/links/LinkInfo.tsx
@@ -45,6 +45,10 @@ export function BacklinkInfo() {
   return (
     <div className="backlinks__pane">
       <div className="backlinks__content">
+        {error && !loading ? (
+          <p className="page-viewer__error">Error: {error}</p>
+        ) : null}
+
         <div className="backlinks__group">
           <div className="backlinks__group-title">
             {t('backlinks.referencedBy')}{' '}
@@ -69,7 +73,7 @@ export function BacklinkInfo() {
           )}
         </div>
 
-        {!isReadOnly && (
+        {!isReadOnly && !error && (
           <div className="backlinks__group">
             <div className="backlinks__group-title">
               {t('backlinks.brokenLinks')}{' '}
@@ -78,9 +82,6 @@ export function BacklinkInfo() {
               </span>
             </div>
 
-            {error && !loading ? (
-              <p className="page-viewer__error">Error: {error}</p>
-            ) : null}
 
             {loading ? (
               <p className="backlinks__empty">{t('backlinks.loading')}</p>

--- a/ui/leafwiki-ui/src/features/links/LinkInfo.tsx
+++ b/ui/leafwiki-ui/src/features/links/LinkInfo.tsx
@@ -82,7 +82,6 @@ export function BacklinkInfo() {
               </span>
             </div>
 
-
             {loading ? (
               <p className="backlinks__empty">{t('backlinks.loading')}</p>
             ) : brokenIncoming.length + brokenOutgoings.length === 0 ? (

--- a/ui/leafwiki-ui/src/locales/en/viewer.json
+++ b/ui/leafwiki-ui/src/locales/en/viewer.json
@@ -9,5 +9,17 @@
     "emptyDescriptionReadOnly": "The section {{title}} does not contain any pages or sections yet.",
     "addPage": "Add Page",
     "addSection": "Add Section"
+  },
+  "markdownPreview": {
+    "renderError": "This page contains Markdown that could not be rendered safely."
+  },
+  "backlinks": {
+    "referencedBy": "Referenced by",
+    "loading": "Loading…",
+    "noReferences": "No pages reference this page.",
+    "brokenLinks": "Broken links",
+    "noBrokenLinks": "No broken links.",
+    "brokenOutgoingsTitle": "This page links to missing targets",
+    "brokenIncomingTitle": "Pages linking to an old path"
   }
 }


### PR DESCRIPTION
…acklink strings

Broken link info is only actionable for editors; viewers see no benefit from it. Guard the section with useIsReadOnly() and move all hardcoded backlink strings into the viewer locale.