### PR TITLE
fix(wikilinks): ambiguous links use brand color instead of warning orange

### DIFF
--- a/ui/leafwiki-ui/src/features/preview/MarkdownLink.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownLink.tsx
@@ -62,7 +62,7 @@ export function MarkdownLink({
       <Button
         variant="link"
         onClick={() => openDialog(DIALOG_WIKILINK_DISAMBIGUATION, { title })}
-        className="text-warning hover:text-warning/80 m-0 p-0 text-base no-underline hover:no-underline"
+        className="text-brand hover:text-brand-dark m-0 p-0 text-base no-underline hover:no-underline"
       >
         {children}
       </Button>


### PR DESCRIPTION
There is no reason to mark an ambiguous link as a warning — it is a valid link that simply needs disambiguation. Using the same green as resolved links makes the visual hierarchy consistent.