### PR TITLE
feat(revisions): session coalescing for auto-save revisions

### DIFF
--- a/cmd/leafwiki/main.go
+++ b/cmd/leafwiki/main.go
@@ -165,8 +165,8 @@ type cliFlags struct {
 	gitBackupSSHKeyPath     *string
 	gitBackupSSHKey         *string
 	gitBackupSSHKnownHosts  *string
-	gitBackupInterval      *time.Duration
-	revisionCoalesceWindow *time.Duration
+	gitBackupInterval       *time.Duration
+	revisionCoalesceWindow  *time.Duration
 }
 
 func registerFlags(fs *flag.FlagSet) *cliFlags {
@@ -202,8 +202,8 @@ func registerFlags(fs *flag.FlagSet) *cliFlags {
 		gitBackupSSHKeyPath:     fs.String("git-backup-ssh-key-path", "", "path to SSH private key for git backup"),
 		gitBackupSSHKey:         fs.String("git-backup-ssh-key", "", "raw SSH private key for git backup (env var preferred)"),
 		gitBackupSSHKnownHosts:  fs.String("git-backup-ssh-known-hosts", "", "path to known_hosts file for SSH host key verification (MITM protection)"),
-		gitBackupInterval:      fs.Duration("git-backup-interval", 60*time.Minute, "git backup interval (e.g. 60m, 2h); 0 = manual-only, no automatic scheduling (default: 60m)"),
-		revisionCoalesceWindow: fs.Duration("revision-coalesce-window", 5*time.Minute, "window for coalescing rapid successive saves by the same author; 0 = disabled (default: 5m)"),
+		gitBackupInterval:       fs.Duration("git-backup-interval", 60*time.Minute, "git backup interval (e.g. 60m, 2h); 0 = manual-only, no automatic scheduling (default: 60m)"),
+		revisionCoalesceWindow:  fs.Duration("revision-coalesce-window", 5*time.Minute, "window for coalescing rapid successive saves by the same author; 0 = disabled (default: 5m)"),
 	}
 }
 

--- a/cmd/leafwiki/main.go
+++ b/cmd/leafwiki/main.go
@@ -50,6 +50,7 @@ func writeUsage(w io.Writer) {
 	--enable-revision             Enable the revision / page history feature (default: false)
 	--enable-link-refactor        Enable the link refactoring dialog and rewrite flow (default: false)
 	--max-revision-history        Maximum revisions kept per page; 0 = unlimited (default: 100)
+	--revision-coalesce-window    Window for coalescing rapid successive saves by the same author (e.g. 5m, 0 = disabled) (default: 5m)
 	--enable-http-remote-user       Enable reverse-proxy authentication via HTTP header (default: false)
 	--http-remote-user-header-name  HTTP header carrying the username from a trusted proxy (default: Remote-User)
 	--trusted-proxy-ips             Comma-separated trusted proxy IPs/CIDRs (e.g. 127.0.0.1,172.18.0.0/16)
@@ -85,6 +86,7 @@ func writeUsage(w io.Writer) {
 	LEAFWIKI_ENABLE_REVISION
 	LEAFWIKI_ENABLE_LINK_REFACTOR
 	LEAFWIKI_MAX_REVISION_HISTORY
+	LEAFWIKI_REVISION_COALESCE_WINDOW
 	LEAFWIKI_ENABLE_HTTP_REMOTE_USER
 	LEAFWIKI_HTTP_REMOTE_USER_HEADER_NAME
 	LEAFWIKI_TRUSTED_PROXY_IPS
@@ -163,7 +165,8 @@ type cliFlags struct {
 	gitBackupSSHKeyPath     *string
 	gitBackupSSHKey         *string
 	gitBackupSSHKnownHosts  *string
-	gitBackupInterval       *time.Duration
+	gitBackupInterval      *time.Duration
+	revisionCoalesceWindow *time.Duration
 }
 
 func registerFlags(fs *flag.FlagSet) *cliFlags {
@@ -199,7 +202,8 @@ func registerFlags(fs *flag.FlagSet) *cliFlags {
 		gitBackupSSHKeyPath:     fs.String("git-backup-ssh-key-path", "", "path to SSH private key for git backup"),
 		gitBackupSSHKey:         fs.String("git-backup-ssh-key", "", "raw SSH private key for git backup (env var preferred)"),
 		gitBackupSSHKnownHosts:  fs.String("git-backup-ssh-known-hosts", "", "path to known_hosts file for SSH host key verification (MITM protection)"),
-		gitBackupInterval:       fs.Duration("git-backup-interval", 60*time.Minute, "git backup interval (e.g. 60m, 2h); 0 = manual-only, no automatic scheduling (default: 60m)"),
+		gitBackupInterval:      fs.Duration("git-backup-interval", 60*time.Minute, "git backup interval (e.g. 60m, 2h); 0 = manual-only, no automatic scheduling (default: 60m)"),
+		revisionCoalesceWindow: fs.Duration("revision-coalesce-window", 5*time.Minute, "window for coalescing rapid successive saves by the same author; 0 = disabled (default: 5m)"),
 	}
 }
 
@@ -238,6 +242,7 @@ func main() {
 	enableRevision := resolveBool("enable-revision", *flags.enableRevision, visited, "LEAFWIKI_ENABLE_REVISION")
 	enableLinkRefactor := resolveBool("enable-link-refactor", *flags.enableLinkRefactor, visited, "LEAFWIKI_ENABLE_LINK_REFACTOR")
 	maxRevisionHistory := resolveInt("max-revision-history", *flags.maxRevisionHistory, visited, "LEAFWIKI_MAX_REVISION_HISTORY", 100)
+	revisionCoalesceWindow := resolveDuration("revision-coalesce-window", *flags.revisionCoalesceWindow, visited, "LEAFWIKI_REVISION_COALESCE_WINDOW")
 	enableHTTPRemoteUser := resolveBool("enable-http-remote-user", *flags.enableHTTPRemoteUser, visited, "LEAFWIKI_ENABLE_HTTP_REMOTE_USER")
 	httpRemoteUserHeader := resolveString("http-remote-user-header-name", *flags.httpRemoteUserHeader, visited, "LEAFWIKI_HTTP_REMOTE_USER_HEADER_NAME", "Remote-User")
 	trustedProxyIPsRaw := resolveString("trusted-proxy-ips", *flags.trustedProxyIPs, visited, "LEAFWIKI_TRUSTED_PROXY_IPS", "")
@@ -324,14 +329,15 @@ func main() {
 	}
 
 	w, err := wiki.NewWiki(&wiki.WikiOptions{
-		StorageDir:          dataDir,
-		AdminPassword:       adminPassword,
-		JWTSecret:           jwtSecret,
-		AccessTokenTimeout:  accessTokenTimeout,
-		RefreshTokenTimeout: refreshTokenTimeout,
-		AuthDisabled:        disableAuth,
-		EnableRevision:      enableRevision,
-		MaxRevisionHistory:  maxRevisionHistory,
+		StorageDir:             dataDir,
+		AdminPassword:          adminPassword,
+		JWTSecret:              jwtSecret,
+		AccessTokenTimeout:     accessTokenTimeout,
+		RefreshTokenTimeout:    refreshTokenTimeout,
+		AuthDisabled:           disableAuth,
+		EnableRevision:         enableRevision,
+		MaxRevisionHistory:     maxRevisionHistory,
+		RevisionCoalesceWindow: revisionCoalesceWindow,
 	})
 	if err != nil {
 		fail("Failed to initialize Wiki", "error", err)

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -78,6 +78,7 @@ start_docker() {
     --allow-insecure=true \
     --enable-revision=true \
     --enable-link-refactor=true \
+    --revision-coalesce-window=0 \
     --jwt-secret=e2e-tests-secret \
     --admin-password=admin
 
@@ -112,7 +113,8 @@ start_local() {
       --allow-insecure=true \
       --enable-revision=true \
       --enable-link-refactor=true \
-        --jwt-secret=e2e-tests-secret \
+      --revision-coalesce-window=0 \
+      --jwt-secret=e2e-tests-secret \
       --admin-password=admin
   ) >"$server_log" 2>&1 &
 

--- a/internal/core/revision/fs_store.go
+++ b/internal/core/revision/fs_store.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -17,19 +18,26 @@ import (
 
 type FSStore struct {
 	storageDir string
+	log        *slog.Logger
 }
 
 type revisionIndex map[string]string
 
 const revisionIndexFileName = "_index.json"
 
-func NewFSStore(storageDir string) *FSStore {
-	return &FSStore{storageDir: storageDir}
+func NewFSStore(storageDir string, logger *slog.Logger) *FSStore {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &FSStore{
+		storageDir: storageDir,
+		log:        logger.With("component", "FSStore"),
+	}
 }
 
-func (s *FSStore) SaveContentBlob(content []byte) (string, error) {
+func (s *FSStore) SaveContentBlob(pageID string, content []byte) (string, error) {
 	hash := sha256HexBytes(content)
-	dst := s.contentBlobPath(hash)
+	dst := s.contentBlobPath(pageID, hash)
 
 	if fileExists(dst) {
 		return hash, nil
@@ -286,6 +294,21 @@ func (s *FSStore) GetRevision(pageID, revisionID string) (*Revision, error) {
 	return nil, os.ErrNotExist
 }
 
+// UpdateRevision overwrites an existing revision file in-place (used for coalescing).
+// The revision ID and filename are unchanged; only the JSON content is replaced.
+func (s *FSStore) UpdateRevision(rev *Revision) error {
+	index, err := s.loadRevisionIndex(rev.PageID)
+	if err != nil {
+		return err
+	}
+	filename := strings.TrimSpace(index[rev.ID])
+	if filename == "" {
+		return fmt.Errorf("revision %s not found in index for page %s", rev.ID, rev.PageID)
+	}
+	dst := filepath.Join(s.revisionsPageDir(rev.PageID), filename)
+	return writeJSONAtomic(dst, rev)
+}
+
 // PruneRevisions removes the oldest revision files beyond keepCount for the given page.
 // Files are sorted newest-first, so names[keepCount:] are the oldest ones.
 // Content blobs and asset manifests are NOT deleted — they are content-addressed and
@@ -354,13 +377,16 @@ func (s *FSStore) revisionFileNames(pageID string) ([]string, error) {
 	return names, nil
 }
 
-func (s *FSStore) ReadContentBlob(hash string) ([]byte, error) {
+func (s *FSStore) ReadContentBlob(pageID, hash string) ([]byte, error) {
 	hash = strings.TrimSpace(hash)
 	if hash == "" {
 		return []byte{}, nil
 	}
-
-	raw, err := os.ReadFile(s.contentBlobPath(hash))
+	if raw, err := os.ReadFile(s.contentBlobPath(pageID, hash)); err == nil {
+		return raw, nil
+	}
+	s.log.Debug("content blob not found at scoped path, falling back to legacy", "pageID", pageID, "hash", hash)
+	raw, err := os.ReadFile(s.contentBlobPathLegacy(hash))
 	if err != nil {
 		return nil, fmt.Errorf("read content blob: %w", err)
 	}
@@ -370,16 +396,48 @@ func (s *FSStore) ReadContentBlob(hash string) ([]byte, error) {
 // OpenContentBlob returns a streaming reader for the content blob.
 // The caller is responsible for closing the returned ReadCloser.
 // Use this instead of ReadContentBlob when you don't need the full content in memory.
-func (s *FSStore) OpenContentBlob(hash string) (io.ReadCloser, error) {
+func (s *FSStore) OpenContentBlob(pageID, hash string) (io.ReadCloser, error) {
 	hash = strings.TrimSpace(hash)
 	if hash == "" {
 		return io.NopCloser(strings.NewReader("")), nil
 	}
-	f, err := os.Open(s.contentBlobPath(hash))
+	if f, err := os.Open(s.contentBlobPath(pageID, hash)); err == nil {
+		return f, nil
+	}
+	s.log.Debug("content blob not found at scoped path, falling back to legacy", "pageID", pageID, "hash", hash)
+	f, err := os.Open(s.contentBlobPathLegacy(hash))
 	if err != nil {
 		return nil, fmt.Errorf("open content blob: %w", err)
 	}
 	return f, nil
+}
+
+// DeleteContentBlobIfUnreferenced deletes the content blob for the given hash if no
+// revision of pageID still references it. Errors are non-fatal — callers should log them.
+func (s *FSStore) DeleteContentBlobIfUnreferenced(pageID, hash string) error {
+	names, err := s.revisionFileNames(pageID)
+	if err != nil {
+		return err
+	}
+	dir := s.revisionsPageDir(pageID)
+	for _, name := range names {
+		var rev Revision
+		if err := readJSON(filepath.Join(dir, name), &rev); err != nil {
+			return err
+		}
+		if rev.ContentHash == hash {
+			return nil
+		}
+	}
+	for _, p := range []string{s.contentBlobPath(pageID, hash), s.contentBlobPathLegacy(hash)} {
+		if err := os.Remove(p); err == nil {
+			s.log.Debug("deleted orphaned content blob", "pageID", pageID, "hash", hash, "path", p)
+			return nil
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("delete orphaned content blob: %w", err)
+		}
+	}
+	return nil
 }
 
 func (s *FSStore) LoadAssetManifest(hash string) ([]AssetRef, error) {
@@ -498,7 +556,11 @@ func (s *FSStore) revisionFilePath(pageID, revisionID string, createdAt time.Tim
 	return filepath.Join(s.revisionsPageDir(pageID), filename)
 }
 
-func (s *FSStore) contentBlobPath(hash string) string {
+func (s *FSStore) contentBlobPath(pageID, hash string) string {
+	return filepath.Join(s.baseDir(), "blobs", "content", pageID, "sha256", shardHash(hash), hash)
+}
+
+func (s *FSStore) contentBlobPathLegacy(hash string) string {
 	return filepath.Join(s.baseDir(), "blobs", "content", "sha256", shardHash(hash), hash)
 }
 

--- a/internal/core/revision/fs_store.go
+++ b/internal/core/revision/fs_store.go
@@ -391,10 +391,13 @@ func (s *FSStore) ReadContentBlob(pageID, hash string) ([]byte, error) {
 	if hash == "" {
 		return []byte{}, nil
 	}
-	if raw, err := os.ReadFile(s.contentBlobPath(pageID, hash)); err == nil {
+	scopedPath := s.contentBlobPath(pageID, hash)
+	if raw, err := os.ReadFile(scopedPath); err == nil {
 		return raw, nil
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("read content blob: %w", err)
 	}
-	s.log.Debug("content blob not found at scoped path, falling back to legacy", "pageID", pageID, "hash", hash)
+	s.log.Debug("content blob not found at scoped path, falling back to legacy", "pageID", pageID, "hash", hash, "path", scopedPath)
 	raw, err := os.ReadFile(s.contentBlobPathLegacy(hash))
 	if err != nil {
 		return nil, fmt.Errorf("read content blob: %w", err)
@@ -413,10 +416,13 @@ func (s *FSStore) OpenContentBlob(pageID, hash string) (io.ReadCloser, error) {
 	if hash == "" {
 		return io.NopCloser(strings.NewReader("")), nil
 	}
-	if f, err := os.Open(s.contentBlobPath(pageID, hash)); err == nil {
+	scopedPath := s.contentBlobPath(pageID, hash)
+	if f, err := os.Open(scopedPath); err == nil {
 		return f, nil
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("open content blob: %w", err)
 	}
-	s.log.Debug("content blob not found at scoped path, falling back to legacy", "pageID", pageID, "hash", hash)
+	s.log.Debug("content blob not found at scoped path, falling back to legacy", "pageID", pageID, "hash", hash, "path", scopedPath)
 	f, err := os.Open(s.contentBlobPathLegacy(hash))
 	if err != nil {
 		return nil, fmt.Errorf("open content blob: %w", err)
@@ -444,13 +450,12 @@ func (s *FSStore) DeleteContentBlobIfUnreferenced(pageID, hash string) error {
 			return nil
 		}
 	}
-	for _, p := range []string{s.contentBlobPath(pageID, hash), s.contentBlobPathLegacy(hash)} {
-		if err := os.Remove(p); err == nil {
-			s.log.Debug("deleted orphaned content blob", "pageID", pageID, "hash", hash, "path", p)
-			return nil
-		} else if !os.IsNotExist(err) {
-			return fmt.Errorf("delete orphaned content blob: %w", err)
-		}
+	p := s.contentBlobPath(pageID, hash)
+	if err := os.Remove(p); err == nil {
+		s.log.Debug("deleted orphaned content blob", "pageID", pageID, "hash", hash, "path", p)
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("delete orphaned content blob: %w", err)
 	}
 	return nil
 }

--- a/internal/core/revision/fs_store.go
+++ b/internal/core/revision/fs_store.go
@@ -307,9 +307,26 @@ func (s *FSStore) UpdateRevision(rev *Revision) error {
 	if err != nil {
 		return err
 	}
-	filename := filepath.Base(strings.TrimSpace(index[rev.ID]))
+	id := strings.TrimSpace(rev.ID)
+	filename := filepath.Base(strings.TrimSpace(index[id]))
 	if filename == "" || filename == "." {
-		return fmt.Errorf("revision %s not found in index for page %s", rev.ID, rev.PageID)
+		// Index missing entry (e.g. crash between SaveRevision write and index flush).
+		// Fall back to directory scan, same as GetRevision.
+		names, err := s.revisionFileNames(rev.PageID)
+		if err != nil {
+			return err
+		}
+		for _, name := range names {
+			if strings.HasSuffix(name, "_"+id+".json") {
+				filename = name
+				index[id] = name
+				_ = s.saveRevisionIndex(rev.PageID, index)
+				break
+			}
+		}
+	}
+	if filename == "" || filename == "." {
+		return fmt.Errorf("revision %s not found for page %s", rev.ID, rev.PageID)
 	}
 	dst := filepath.Join(s.revisionsPageDir(rev.PageID), filename)
 	return writeJSONAtomic(dst, rev)

--- a/internal/core/revision/fs_store.go
+++ b/internal/core/revision/fs_store.go
@@ -36,6 +36,9 @@ func NewFSStore(storageDir string, logger *slog.Logger) *FSStore {
 }
 
 func (s *FSStore) SaveContentBlob(pageID string, content []byte) (string, error) {
+	if err := validateStorageID(pageID); err != nil {
+		return "", fmt.Errorf("invalid page ID: %w", err)
+	}
 	hash := sha256HexBytes(content)
 	dst := s.contentBlobPath(pageID, hash)
 
@@ -297,12 +300,15 @@ func (s *FSStore) GetRevision(pageID, revisionID string) (*Revision, error) {
 // UpdateRevision overwrites an existing revision file in-place (used for coalescing).
 // The revision ID and filename are unchanged; only the JSON content is replaced.
 func (s *FSStore) UpdateRevision(rev *Revision) error {
+	if err := validateStorageID(rev.PageID); err != nil {
+		return fmt.Errorf("invalid page ID: %w", err)
+	}
 	index, err := s.loadRevisionIndex(rev.PageID)
 	if err != nil {
 		return err
 	}
-	filename := strings.TrimSpace(index[rev.ID])
-	if filename == "" {
+	filename := filepath.Base(strings.TrimSpace(index[rev.ID]))
+	if filename == "" || filename == "." {
 		return fmt.Errorf("revision %s not found in index for page %s", rev.ID, rev.PageID)
 	}
 	dst := filepath.Join(s.revisionsPageDir(rev.PageID), filename)
@@ -378,6 +384,9 @@ func (s *FSStore) revisionFileNames(pageID string) ([]string, error) {
 }
 
 func (s *FSStore) ReadContentBlob(pageID, hash string) ([]byte, error) {
+	if err := validateStorageID(pageID); err != nil {
+		return nil, fmt.Errorf("invalid page ID: %w", err)
+	}
 	hash = strings.TrimSpace(hash)
 	if hash == "" {
 		return []byte{}, nil
@@ -397,6 +406,9 @@ func (s *FSStore) ReadContentBlob(pageID, hash string) ([]byte, error) {
 // The caller is responsible for closing the returned ReadCloser.
 // Use this instead of ReadContentBlob when you don't need the full content in memory.
 func (s *FSStore) OpenContentBlob(pageID, hash string) (io.ReadCloser, error) {
+	if err := validateStorageID(pageID); err != nil {
+		return nil, fmt.Errorf("invalid page ID: %w", err)
+	}
 	hash = strings.TrimSpace(hash)
 	if hash == "" {
 		return io.NopCloser(strings.NewReader("")), nil
@@ -415,6 +427,9 @@ func (s *FSStore) OpenContentBlob(pageID, hash string) (io.ReadCloser, error) {
 // DeleteContentBlobIfUnreferenced deletes the content blob for the given hash if no
 // revision of pageID still references it. Errors are non-fatal — callers should log them.
 func (s *FSStore) DeleteContentBlobIfUnreferenced(pageID, hash string) error {
+	if err := validateStorageID(pageID); err != nil {
+		return fmt.Errorf("invalid page ID: %w", err)
+	}
 	names, err := s.revisionFileNames(pageID)
 	if err != nil {
 		return err

--- a/internal/core/revision/fs_store_test.go
+++ b/internal/core/revision/fs_store_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestFSStoreRevisionReadPaths(t *testing.T) {
-	store := NewFSStore(t.TempDir())
+	store := NewFSStore(t.TempDir(), nil)
 	created1 := time.Date(2026, 3, 26, 10, 0, 0, 0, time.UTC)
 	created2 := created1.Add(time.Minute)
 	created3 := created2.Add(time.Minute)
@@ -65,13 +65,13 @@ func TestFSStoreRevisionReadPaths(t *testing.T) {
 }
 
 func TestFSStoreBlobPaths(t *testing.T) {
-	store := NewFSStore(t.TempDir())
+	store := NewFSStore(t.TempDir(), nil)
 
-	contentHash, err := store.SaveContentBlob([]byte("hello"))
+	contentHash, err := store.SaveContentBlob("test-page", []byte("hello"))
 	if err != nil {
 		t.Fatalf("SaveContentBlob failed: %v", err)
 	}
-	raw, err := store.ReadContentBlob(contentHash)
+	raw, err := store.ReadContentBlob("test-page", contentHash)
 	if err != nil {
 		t.Fatalf("ReadContentBlob failed: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestFSStoreBlobPaths(t *testing.T) {
 }
 
 func TestFSStoreDeletePageRevisions(t *testing.T) {
-	store := NewFSStore(t.TempDir())
+	store := NewFSStore(t.TempDir(), nil)
 	createdAt := time.Date(2026, 4, 12, 18, 0, 0, 0, time.UTC)
 
 	revision := &Revision{
@@ -157,9 +157,9 @@ func TestFSStoreDeletePageRevisions(t *testing.T) {
 }
 
 func TestFSStoreValidationAndEmptyPaths(t *testing.T) {
-	store := NewFSStore(t.TempDir())
+	store := NewFSStore(t.TempDir(), nil)
 
-	if _, err := store.ReadContentBlob(""); err != nil {
+	if _, err := store.ReadContentBlob("test-page", ""); err != nil {
 		t.Fatalf("ReadContentBlob empty hash failed: %v", err)
 	}
 	if _, err := store.LoadAssetManifest(""); err != nil {
@@ -174,7 +174,7 @@ func TestFSStoreValidationAndEmptyPaths(t *testing.T) {
 }
 
 func TestFSStoreGetRevision_BackwardCompatibleWithoutExtraFrontmatterFields(t *testing.T) {
-	store := NewFSStore(t.TempDir())
+	store := NewFSStore(t.TempDir(), nil)
 	createdAt := time.Date(2026, 4, 20, 15, 4, 5, 0, time.UTC)
 	pageID := "page-1"
 	revisionID := "rev-legacy"
@@ -223,7 +223,7 @@ func TestFSStoreGetRevision_BackwardCompatibleWithoutExtraFrontmatterFields(t *t
 }
 
 func TestFSStoreListRevisionWrappersAndValidation(t *testing.T) {
-	store := NewFSStore(t.TempDir())
+	store := NewFSStore(t.TempDir(), nil)
 	if got, err := store.ListRevisions("missing"); err != nil || len(got) != 0 {
 		t.Fatalf("ListRevisions(missing) = %#v, %v", got, err)
 	}
@@ -251,13 +251,13 @@ func TestFSStoreListRevisionWrappersAndValidation(t *testing.T) {
 }
 
 func TestFSStoreIdempotentSaves(t *testing.T) {
-	store := NewFSStore(t.TempDir())
+	store := NewFSStore(t.TempDir(), nil)
 
-	h1, err := store.SaveContentBlob([]byte("same"))
+	h1, err := store.SaveContentBlob("test-page", []byte("same"))
 	if err != nil {
 		t.Fatalf("first SaveContentBlob failed: %v", err)
 	}
-	h2, err := store.SaveContentBlob([]byte("same"))
+	h2, err := store.SaveContentBlob("test-page", []byte("same"))
 	if err != nil {
 		t.Fatalf("second SaveContentBlob failed: %v", err)
 	}
@@ -304,7 +304,7 @@ func TestFSStoreIdempotentSaves(t *testing.T) {
 }
 
 func TestFSStoreCursorAndFileFilteringHelpers(t *testing.T) {
-	store := NewFSStore(t.TempDir())
+	store := NewFSStore(t.TempDir(), nil)
 	pageID := "page-1"
 	created := time.Date(2026, 3, 26, 12, 0, 0, 0, time.UTC)
 	for i := 0; i < 2; i++ {
@@ -347,7 +347,7 @@ func TestFSStoreCursorAndFileFilteringHelpers(t *testing.T) {
 }
 
 func TestFSStoreSaveRevisionRejectsInvalidRevisionID(t *testing.T) {
-	store := NewFSStore(t.TempDir())
+	store := NewFSStore(t.TempDir(), nil)
 	rev := &Revision{
 		ID:        "x/../../outside",
 		PageID:    "page-1",
@@ -367,7 +367,7 @@ func TestFSStoreSaveRevisionRejectsInvalidRevisionID(t *testing.T) {
 }
 
 func TestFSStoreSaveRevisionPrefersPageIDValidationError(t *testing.T) {
-	store := NewFSStore(t.TempDir())
+	store := NewFSStore(t.TempDir(), nil)
 	rev := &Revision{
 		ID:        "x/../../outside",
 		PageID:    "../page-1",
@@ -443,7 +443,7 @@ func TestValidateStorageID(t *testing.T) {
 }
 
 func TestFSStoreRejectsPathTraversalPageID(t *testing.T) {
-	store := NewFSStore(t.TempDir())
+	store := NewFSStore(t.TempDir(), nil)
 
 	traversalIDs := []string{
 		"../other",
@@ -475,7 +475,7 @@ func TestFSStoreRejectsPathTraversalPageID(t *testing.T) {
 }
 
 func TestFSStoreAssetBlobErrors(t *testing.T) {
-	store := NewFSStore(t.TempDir())
+	store := NewFSStore(t.TempDir(), nil)
 	if _, _, err := store.SaveAssetBlobFromPath(filepath.Join(t.TempDir(), "missing.txt")); err == nil {
 		t.Fatalf("expected SaveAssetBlobFromPath on missing file to fail")
 	}
@@ -487,9 +487,9 @@ func TestFSStoreFailuresOnInvalidBasePath(t *testing.T) {
 	if err := os.WriteFile(invalidBase, []byte("x"), 0o644); err != nil {
 		t.Fatalf("WriteFile invalid base failed: %v", err)
 	}
-	store := NewFSStore(invalidBase)
+	store := NewFSStore(invalidBase, nil)
 
-	if _, err := store.SaveContentBlob([]byte("hello")); err == nil {
+	if _, err := store.SaveContentBlob("test-page", []byte("hello")); err == nil {
 		t.Fatalf("expected SaveContentBlob to fail")
 	}
 
@@ -514,7 +514,7 @@ func TestFSStoreFailuresOnInvalidBasePath(t *testing.T) {
 }
 
 func TestFSStoreGetRevisionUsesAndBackfillsIndex(t *testing.T) {
-	store := NewFSStore(t.TempDir())
+	store := NewFSStore(t.TempDir(), nil)
 	created := time.Date(2026, 3, 26, 12, 30, 0, 0, time.UTC)
 	rev := &Revision{ID: "rev-index", PageID: "page-1", CreatedAt: created, Type: RevisionTypeContentUpdate, Title: "Page", Slug: "page"}
 	if err := store.SaveRevision(rev); err != nil {

--- a/internal/core/revision/fs_store_test.go
+++ b/internal/core/revision/fs_store_test.go
@@ -547,3 +547,119 @@ func TestFSStoreGetRevisionUsesAndBackfillsIndex(t *testing.T) {
 		t.Fatalf("expected revision index backfill for %q, got %#v", rev.ID, index)
 	}
 }
+
+func TestFSStoreUpdateRevision(t *testing.T) {
+	store := NewFSStore(t.TempDir(), nil)
+	created := time.Date(2026, 3, 26, 12, 0, 0, 0, time.UTC)
+	rev := &Revision{
+		ID: "rev-1", PageID: "page-1", CreatedAt: created,
+		Type: RevisionTypeContentUpdate, Title: "Original", Slug: "original",
+	}
+	if err := store.SaveRevision(rev); err != nil {
+		t.Fatalf("SaveRevision failed: %v", err)
+	}
+
+	rev.Title = "Updated"
+	rev.Slug = "updated"
+	if err := store.UpdateRevision(rev); err != nil {
+		t.Fatalf("UpdateRevision failed: %v", err)
+	}
+
+	loaded, err := store.GetRevision("page-1", "rev-1")
+	if err != nil {
+		t.Fatalf("GetRevision after update failed: %v", err)
+	}
+	if loaded.Title != "Updated" || loaded.Slug != "updated" {
+		t.Fatalf("expected updated fields, got title=%q slug=%q", loaded.Title, loaded.Slug)
+	}
+	if loaded.ID != "rev-1" || loaded.PageID != "page-1" {
+		t.Fatalf("expected stable ID and PageID after update, got %#v", loaded)
+	}
+}
+
+func TestFSStoreUpdateRevision_RejectsInvalidPageID(t *testing.T) {
+	store := NewFSStore(t.TempDir(), nil)
+	rev := &Revision{ID: "rev-1", PageID: "../evil", Type: RevisionTypeContentUpdate}
+	if err := store.UpdateRevision(rev); err == nil {
+		t.Fatalf("expected UpdateRevision to reject path-traversal page ID")
+	}
+}
+
+func TestFSStoreUpdateRevision_UnknownRevisionReturnsError(t *testing.T) {
+	store := NewFSStore(t.TempDir(), nil)
+	rev := &Revision{ID: "nonexistent", PageID: "page-1", Type: RevisionTypeContentUpdate}
+	if err := store.UpdateRevision(rev); err == nil {
+		t.Fatalf("expected UpdateRevision to fail for unknown revision ID")
+	}
+}
+
+func TestFSStoreDeleteContentBlobIfUnreferenced_DeletesScopedBlob(t *testing.T) {
+	store := NewFSStore(t.TempDir(), nil)
+	pageID := "page-1"
+
+	hash, err := store.SaveContentBlob(pageID, []byte("orphaned content"))
+	if err != nil {
+		t.Fatalf("SaveContentBlob failed: %v", err)
+	}
+	blobPath := store.contentBlobPath(pageID, hash)
+	if _, err := os.Stat(blobPath); os.IsNotExist(err) {
+		t.Fatalf("expected blob to exist before deletion at %s", blobPath)
+	}
+
+	if err := store.DeleteContentBlobIfUnreferenced(pageID, hash); err != nil {
+		t.Fatalf("DeleteContentBlobIfUnreferenced failed: %v", err)
+	}
+	if _, err := os.Stat(blobPath); !os.IsNotExist(err) {
+		t.Fatalf("expected orphaned scoped blob to be deleted, stat err=%v", err)
+	}
+}
+
+func TestFSStoreDeleteContentBlobIfUnreferenced_KeepsBlobWhenReferenced(t *testing.T) {
+	store := NewFSStore(t.TempDir(), nil)
+	pageID := "page-1"
+	created := time.Date(2026, 3, 26, 12, 0, 0, 0, time.UTC)
+
+	hash, err := store.SaveContentBlob(pageID, []byte("referenced content"))
+	if err != nil {
+		t.Fatalf("SaveContentBlob failed: %v", err)
+	}
+
+	rev := &Revision{
+		ID: "rev-ref", PageID: pageID, CreatedAt: created,
+		Type: RevisionTypeContentUpdate, Title: "Page", Slug: "page",
+		ContentHash: hash,
+	}
+	if err := store.SaveRevision(rev); err != nil {
+		t.Fatalf("SaveRevision failed: %v", err)
+	}
+
+	if err := store.DeleteContentBlobIfUnreferenced(pageID, hash); err != nil {
+		t.Fatalf("DeleteContentBlobIfUnreferenced failed: %v", err)
+	}
+	blobPath := store.contentBlobPath(pageID, hash)
+	if _, err := os.Stat(blobPath); os.IsNotExist(err) {
+		t.Fatalf("expected blob to be kept when still referenced by a revision")
+	}
+}
+
+func TestFSStoreDeleteContentBlobIfUnreferenced_DoesNotDeleteLegacyBlob(t *testing.T) {
+	store := NewFSStore(t.TempDir(), nil)
+	pageID := "page-1"
+
+	content := []byte("legacy content")
+	hash := sha256HexBytes(content)
+	legacyPath := store.contentBlobPathLegacy(hash)
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll legacy blob dir failed: %v", err)
+	}
+	if err := os.WriteFile(legacyPath, content, 0o644); err != nil {
+		t.Fatalf("WriteFile legacy blob failed: %v", err)
+	}
+
+	if err := store.DeleteContentBlobIfUnreferenced(pageID, hash); err != nil {
+		t.Fatalf("DeleteContentBlobIfUnreferenced failed: %v", err)
+	}
+	if _, err := os.Stat(legacyPath); os.IsNotExist(err) {
+		t.Fatalf("expected legacy blob to be preserved — legacy path is global and must never be deleted per-page")
+	}
+}

--- a/internal/core/revision/service.go
+++ b/internal/core/revision/service.go
@@ -154,6 +154,10 @@ func (s *Service) RecordContentUpdates(pages []*tree.Page, authorID, summary str
 // This method hashes the current assets and only writes a new revision when
 // content or the asset manifest actually changed.
 func (s *Service) RecordAssetChange(pageID, authorID, summary string) (*Revision, bool, error) {
+	mu := s.pageWriteLock(pageID)
+	mu.Lock()
+	defer mu.Unlock()
+
 	prev, err := s.store.GetLatestRevision(pageID)
 	if err != nil {
 		return nil, false, err
@@ -204,6 +208,10 @@ func (s *Service) RecordAssetChange(pageID, authorID, summary string) (*Revision
 }
 
 func (s *Service) RecordStructureChange(pageID, authorID, summary string) (*Revision, bool, error) {
+	mu := s.pageWriteLock(pageID)
+	mu.Lock()
+	defer mu.Unlock()
+
 	prev, err := s.store.GetLatestRevision(pageID)
 	if err != nil {
 		return nil, false, err
@@ -541,6 +549,10 @@ func (s *Service) RestoreRevision(pageID, revisionID, authorID string) error {
 		)
 	}
 
+	mu := s.pageWriteLock(pageID)
+	mu.Lock()
+	defer mu.Unlock()
+
 	rev, err := s.store.GetRevision(pageID, revisionID)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -721,11 +733,14 @@ func (s *Service) pageWriteLock(pageID string) *sync.Mutex {
 }
 
 func (s *Service) shouldCoalesce(prev *Revision, authorID string) bool {
-	return s.coalesceWindow > 0 &&
-		prev != nil &&
-		prev.Type == RevisionTypeContentUpdate &&
+	if s.coalesceWindow <= 0 || prev == nil {
+		return false
+	}
+	elapsed := time.Since(prev.CreatedAt)
+	return prev.Type == RevisionTypeContentUpdate &&
 		prev.AuthorID == strings.TrimSpace(authorID) &&
-		time.Since(prev.CreatedAt) <= s.coalesceWindow
+		elapsed >= 0 &&
+		elapsed <= s.coalesceWindow
 }
 
 func (s *Service) recordContentUpdateForPage(page *tree.Page, authorID, summary string) (*Revision, bool, error) {

--- a/internal/core/revision/service.go
+++ b/internal/core/revision/service.go
@@ -36,6 +36,7 @@ type Service struct {
 	coalesceWindow     time.Duration
 	log                *slog.Logger
 	assetManifestCache sync.Map // pageID → assetManifestEntry
+	pageLocks          sync.Map // pageID → *sync.Mutex
 }
 
 type ServiceOptions struct {
@@ -714,6 +715,11 @@ func (s *Service) revisionStateFromPage(page *tree.Page) *RevisionState {
 	}
 }
 
+func (s *Service) pageWriteLock(pageID string) *sync.Mutex {
+	v, _ := s.pageLocks.LoadOrStore(pageID, &sync.Mutex{})
+	return v.(*sync.Mutex)
+}
+
 func (s *Service) shouldCoalesce(prev *Revision, authorID string) bool {
 	return s.coalesceWindow > 0 &&
 		prev != nil &&
@@ -723,6 +729,10 @@ func (s *Service) shouldCoalesce(prev *Revision, authorID string) bool {
 }
 
 func (s *Service) recordContentUpdateForPage(page *tree.Page, authorID, summary string) (*Revision, bool, error) {
+	mu := s.pageWriteLock(page.ID)
+	mu.Lock()
+	defer mu.Unlock()
+
 	prev, err := s.store.GetLatestRevision(page.ID)
 	if err != nil {
 		return nil, false, err

--- a/internal/core/revision/service.go
+++ b/internal/core/revision/service.go
@@ -761,7 +761,6 @@ func (s *Service) recordContentUpdateForPage(page *tree.Page, authorID, summary 
 		prev.PageUpdatedAt = state.PageUpdatedAt
 		prev.LastAuthorID = state.LastAuthorID
 		prev.Summary = summary
-		prev.CreatedAt = time.Now().UTC()
 		if err := s.store.UpdateRevision(prev); err != nil {
 			return nil, false, err
 		}

--- a/internal/core/revision/service.go
+++ b/internal/core/revision/service.go
@@ -33,12 +33,14 @@ type Service struct {
 	pages              *tree.TreeService
 	store              *FSStore
 	maxRevisions       int // 0 = unlimited
+	coalesceWindow     time.Duration
 	log                *slog.Logger
 	assetManifestCache sync.Map // pageID → assetManifestEntry
 }
 
 type ServiceOptions struct {
-	MaxRevisions int // Maximum revisions to keep per page; 0 = unlimited
+	MaxRevisions   int           // Maximum revisions to keep per page; 0 = unlimited
+	CoalesceWindow time.Duration // Window for coalescing rapid successive saves; 0 = disabled
 }
 
 func NewService(storageDir string, pages *tree.TreeService, logger *slog.Logger, opts ...ServiceOptions) *Service {
@@ -47,17 +49,20 @@ func NewService(storageDir string, pages *tree.TreeService, logger *slog.Logger,
 	}
 
 	var maxRevisions int
+	var coalesceWindow time.Duration
 	if len(opts) > 0 {
 		maxRevisions = opts[0].MaxRevisions
+		coalesceWindow = opts[0].CoalesceWindow
 	}
 
-	store := NewFSStore(storageDir)
+	store := NewFSStore(storageDir, logger)
 	return &Service{
-		storageDir:   storageDir,
-		pages:        pages,
-		store:        store,
-		maxRevisions: maxRevisions,
-		log:          logger.With("component", "RevisionService"),
+		storageDir:     storageDir,
+		pages:          pages,
+		store:          store,
+		maxRevisions:   maxRevisions,
+		coalesceWindow: coalesceWindow,
+		log:            logger.With("component", "RevisionService"),
 	}
 }
 
@@ -164,7 +169,7 @@ func (s *Service) RecordAssetChange(pageID, authorID, summary string) (*Revision
 		return prev, false, nil
 	}
 
-	contentHash, err := s.store.SaveContentBlob([]byte(state.Content))
+	contentHash, err := s.store.SaveContentBlob(pageID, []byte(state.Content))
 	if err != nil {
 		return nil, false, err
 	}
@@ -213,7 +218,7 @@ func (s *Service) RecordStructureChange(pageID, authorID, summary string) (*Revi
 		return nil, false, err
 	}
 
-	contentHash, err := s.store.SaveContentBlob([]byte(state.Content))
+	contentHash, err := s.store.SaveContentBlob(pageID, []byte(state.Content))
 	if err != nil {
 		return nil, false, err
 	}
@@ -287,7 +292,7 @@ func (s *Service) GetRevisionSnapshot(pageID, revisionID string) (*RevisionSnaps
 		return nil, err
 	}
 
-	content, err := s.store.ReadContentBlob(rev.ContentHash)
+	content, err := s.store.ReadContentBlob(rev.PageID, rev.ContentHash)
 	if err != nil {
 		return nil, sharederrors.NewLocalizedError(
 			"revision_preview_content_unavailable",
@@ -455,9 +460,9 @@ func (s *Service) CheckRevisionIntegrity(pageID string) ([]RevisionIntegrityIssu
 			continue
 		}
 		if strings.TrimSpace(rev.ContentHash) != "" {
-			rc, err := s.store.OpenContentBlob(rev.ContentHash)
+			rc, err := s.store.OpenContentBlob(rev.PageID, rev.ContentHash)
 			if err != nil {
-				issues = append(issues, RevisionIntegrityIssue{PageID: rev.PageID, RevisionID: rev.ID, Code: "missing_content_blob", Message: "Revision content blob is missing or unreadable", Path: s.store.contentBlobPath(rev.ContentHash)})
+				issues = append(issues, RevisionIntegrityIssue{PageID: rev.PageID, RevisionID: rev.ID, Code: "missing_content_blob", Message: "Revision content blob is missing or unreadable", Path: s.store.contentBlobPath(rev.PageID, rev.ContentHash)})
 			} else {
 				_ = rc.Close()
 			}
@@ -556,7 +561,7 @@ func (s *Service) RestoreRevision(pageID, revisionID, authorID string) error {
 		)
 	}
 
-	content, err := s.store.ReadContentBlob(rev.ContentHash)
+	content, err := s.store.ReadContentBlob(pageID, rev.ContentHash)
 	if err != nil {
 		return sharederrors.NewLocalizedError(
 			"revision_restore_content_missing",
@@ -709,6 +714,14 @@ func (s *Service) revisionStateFromPage(page *tree.Page) *RevisionState {
 	}
 }
 
+func (s *Service) shouldCoalesce(prev *Revision, authorID string) bool {
+	return s.coalesceWindow > 0 &&
+		prev != nil &&
+		prev.Type == RevisionTypeContentUpdate &&
+		prev.AuthorID == strings.TrimSpace(authorID) &&
+		time.Since(prev.CreatedAt) <= s.coalesceWindow
+}
+
 func (s *Service) recordContentUpdateForPage(page *tree.Page, authorID, summary string) (*Revision, bool, error) {
 	prev, err := s.store.GetLatestRevision(page.ID)
 	if err != nil {
@@ -724,12 +737,47 @@ func (s *Service) recordContentUpdateForPage(page *tree.Page, authorID, summary 
 		return prev, false, nil
 	}
 
+	if s.shouldCoalesce(prev, authorID) {
+		s.log.Debug("coalescing revision", "pageID", page.ID, "revisionID", prev.ID, "authorID", authorID)
+		oldHash := prev.ContentHash
+		contentHash, err := s.store.SaveContentBlob(page.ID, []byte(state.Content))
+		if err != nil {
+			return nil, false, err
+		}
+		if contentHash != state.ContentHash {
+			return nil, false, fmt.Errorf("content hash mismatch: computed=%s saved=%s", state.ContentHash, contentHash)
+		}
+		assetManifestHash, err := s.resolveAssetManifestHash(page.ID, prev)
+		if err != nil {
+			return nil, false, err
+		}
+		prev.ContentHash = contentHash
+		prev.AssetManifestHash = assetManifestHash
+		prev.ExtraFrontmatter = state.ExtraFrontmatter
+		prev.ExtraFrontmatterHash = state.ExtraFrontmatterHash
+		prev.Title = state.Title
+		prev.Slug = state.Slug
+		prev.Path = state.Path
+		prev.PageUpdatedAt = state.PageUpdatedAt
+		prev.LastAuthorID = state.LastAuthorID
+		prev.Summary = summary
+		if err := s.store.UpdateRevision(prev); err != nil {
+			return nil, false, err
+		}
+		if oldHash != contentHash {
+			if err := s.store.DeleteContentBlobIfUnreferenced(page.ID, oldHash); err != nil {
+				s.log.Warn("failed to gc orphaned content blob", "pageID", page.ID, "hash", oldHash, "error", err)
+			}
+		}
+		return prev, true, nil
+	}
+
 	assetManifestHash, err := s.resolveAssetManifestHash(page.ID, prev)
 	if err != nil {
 		return nil, false, err
 	}
 
-	contentHash, err := s.store.SaveContentBlob([]byte(state.Content))
+	contentHash, err := s.store.SaveContentBlob(page.ID, []byte(state.Content))
 	if err != nil {
 		return nil, false, err
 	}
@@ -971,7 +1019,7 @@ func (s *Service) recordRestoreRevision(pageID, authorID string) error {
 		return err
 	}
 
-	contentHash, err := s.store.SaveContentBlob([]byte(state.Content))
+	contentHash, err := s.store.SaveContentBlob(pageID, []byte(state.Content))
 	if err != nil {
 		return err
 	}

--- a/internal/core/revision/service.go
+++ b/internal/core/revision/service.go
@@ -761,6 +761,7 @@ func (s *Service) recordContentUpdateForPage(page *tree.Page, authorID, summary 
 		prev.PageUpdatedAt = state.PageUpdatedAt
 		prev.LastAuthorID = state.LastAuthorID
 		prev.Summary = summary
+		prev.CreatedAt = time.Now().UTC()
 		if err := s.store.UpdateRevision(prev); err != nil {
 			return nil, false, err
 		}

--- a/internal/core/revision/service_test.go
+++ b/internal/core/revision/service_test.go
@@ -1312,57 +1312,6 @@ func TestRecordContentUpdate_NoCoalesceForNonContentRevision(t *testing.T) {
 	}
 }
 
-func TestRecordContentUpdate_CoalesceResetsWindow(t *testing.T) {
-	service, treeService, _ := newRevisionTestServiceWithWindow(t, 5*time.Minute)
-	pageID := createRevisionTestPage(t, treeService, "Page", "page", "version one")
-
-	rev1, _, err := service.RecordContentUpdate(pageID, "alice", "first")
-	if err != nil || rev1 == nil {
-		t.Fatalf("first RecordContentUpdate failed: %v", err)
-	}
-
-	// Backdate rev1 to just inside the window.
-	rev1.CreatedAt = time.Now().Add(-4 * time.Minute)
-	if err := service.store.UpdateRevision(rev1); err != nil {
-		t.Fatalf("UpdateRevision (backdate) failed: %v", err)
-	}
-
-	// First coalesce — resets CreatedAt to now.
-	content := "version two"
-	if err := treeService.UpdateNode("alice", pageID, "Page", "page", &content, tree.VersionUnchecked, false); err != nil {
-		t.Fatalf("UpdateNode (v2) failed: %v", err)
-	}
-	rev2, _, err := service.RecordContentUpdate(pageID, "alice", "second")
-	if err != nil {
-		t.Fatalf("second RecordContentUpdate failed: %v", err)
-	}
-	if rev2.ID != rev1.ID {
-		t.Fatalf("expected coalesce on first update")
-	}
-
-	// Without debounce the original CreatedAt (-4min) would now be 4min+ old;
-	// with debounce CreatedAt was reset to ~now, so this must still coalesce.
-	content = "version three"
-	if err := treeService.UpdateNode("alice", pageID, "Page", "page", &content, tree.VersionUnchecked, false); err != nil {
-		t.Fatalf("UpdateNode (v3) failed: %v", err)
-	}
-	rev3, _, err := service.RecordContentUpdate(pageID, "alice", "third")
-	if err != nil {
-		t.Fatalf("third RecordContentUpdate failed: %v", err)
-	}
-	if rev3.ID != rev1.ID {
-		t.Fatalf("expected second coalesce after window reset, got new revision %q", rev3.ID)
-	}
-
-	revisions, err := service.ListRevisions(pageID)
-	if err != nil {
-		t.Fatalf("ListRevisions failed: %v", err)
-	}
-	if len(revisions) != 1 {
-		t.Fatalf("expected 1 revision after two coalesces, got %d", len(revisions))
-	}
-}
-
 func TestRecordContentUpdate_CoalescingGCsOldScopedBlob(t *testing.T) {
 	service, treeService, _ := newRevisionTestServiceWithWindow(t, time.Hour)
 	pageID := createRevisionTestPage(t, treeService, "Page", "page", "version one")

--- a/internal/core/revision/service_test.go
+++ b/internal/core/revision/service_test.go
@@ -1312,6 +1312,50 @@ func TestRecordContentUpdate_NoCoalesceForNonContentRevision(t *testing.T) {
 	}
 }
 
+func TestRecordContentUpdate_ConcurrentSavesNoOrphanedBlobs(t *testing.T) {
+	service, treeService, _ := newRevisionTestServiceWithWindow(t, time.Hour)
+	pageID := createRevisionTestPage(t, treeService, "Page", "page", "initial")
+
+	if _, _, err := service.RecordContentUpdate(pageID, "alice", "first"); err != nil {
+		t.Fatalf("first RecordContentUpdate failed: %v", err)
+	}
+
+	// Update content sequentially before spawning goroutines — concurrent
+	// UpdateNode calls on the same page would race inside the tree service.
+	content := "updated content"
+	if err := treeService.UpdateNode("alice", pageID, "Page", "page", &content, tree.VersionUnchecked, false); err != nil {
+		t.Fatalf("UpdateNode failed: %v", err)
+	}
+
+	const goroutines = 10
+	errc := make(chan error, goroutines)
+	for range goroutines {
+		go func() {
+			_, _, err := service.RecordContentUpdate(pageID, "alice", "concurrent")
+			errc <- err
+		}()
+	}
+	for range goroutines {
+		if err := <-errc; err != nil {
+			t.Errorf("goroutine error: %v", err)
+		}
+	}
+
+	revisions, err := service.ListRevisions(pageID)
+	if err != nil {
+		t.Fatalf("ListRevisions failed: %v", err)
+	}
+	if len(revisions) == 0 {
+		t.Fatalf("expected at least one revision")
+	}
+	for _, rev := range revisions {
+		blobPath := service.store.contentBlobPath(pageID, rev.ContentHash)
+		if _, err := os.Stat(blobPath); os.IsNotExist(err) {
+			t.Errorf("revision %s has orphaned content blob at %s", rev.ID, blobPath)
+		}
+	}
+}
+
 func TestRecordContentUpdate_CoalescingGCsOldScopedBlob(t *testing.T) {
 	service, treeService, _ := newRevisionTestServiceWithWindow(t, time.Hour)
 	pageID := createRevisionTestPage(t, treeService, "Page", "page", "version one")

--- a/internal/core/revision/service_test.go
+++ b/internal/core/revision/service_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/perber/wiki/internal/core/markdown"
 	sharederrors "github.com/perber/wiki/internal/core/shared/errors"
@@ -22,6 +23,17 @@ func newRevisionTestService(t *testing.T) (*Service, *tree.TreeService, string) 
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	return NewService(storageDir, treeService, logger), treeService, storageDir
+}
+
+func newRevisionTestServiceWithWindow(t *testing.T, window time.Duration) (*Service, *tree.TreeService, string) {
+	t.Helper()
+	storageDir := t.TempDir()
+	treeService := tree.NewTreeService(storageDir)
+	if err := treeService.LoadTree(); err != nil {
+		t.Fatalf("LoadTree failed: %v", err)
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return NewService(storageDir, treeService, logger, ServiceOptions{CoalesceWindow: window}), treeService, storageDir
 }
 
 func createRevisionTestPage(t *testing.T, treeService *tree.TreeService, title, slug, content string) string {
@@ -1134,5 +1146,203 @@ func TestGetRevisionAssetReturnsNotFoundForMissingManifestEntry(t *testing.T) {
 	}
 	if localized.Code != "revision_preview_asset_not_found" {
 		t.Fatalf("localized.Code = %q", localized.Code)
+	}
+}
+
+func TestRecordContentUpdate_CoalescesWithinWindow(t *testing.T) {
+	service, treeService, _ := newRevisionTestServiceWithWindow(t, time.Hour)
+	pageID := createRevisionTestPage(t, treeService, "Page", "page", "version one")
+
+	rev1, created, err := service.RecordContentUpdate(pageID, "alice", "first")
+	if err != nil || !created || rev1 == nil {
+		t.Fatalf("first RecordContentUpdate failed: created=%v err=%v", created, err)
+	}
+
+	content := "version two"
+	if err := treeService.UpdateNode("alice", pageID, "Page", "page", &content, tree.VersionUnchecked, false); err != nil {
+		t.Fatalf("UpdateNode failed: %v", err)
+	}
+
+	rev2, created, err := service.RecordContentUpdate(pageID, "alice", "second")
+	if err != nil {
+		t.Fatalf("second RecordContentUpdate (coalesce) failed: %v", err)
+	}
+	if !created {
+		t.Fatalf("expected coalesced update to return created=true")
+	}
+	if rev2.ID != rev1.ID {
+		t.Fatalf("expected same revision ID after coalesce: got %q want %q", rev2.ID, rev1.ID)
+	}
+
+	revisions, err := service.ListRevisions(pageID)
+	if err != nil {
+		t.Fatalf("ListRevisions failed: %v", err)
+	}
+	if len(revisions) != 1 {
+		t.Fatalf("expected 1 revision after coalesce, got %d", len(revisions))
+	}
+	if revisions[0].ContentHash == rev1.ContentHash {
+		t.Fatalf("expected content hash to be updated after coalesce")
+	}
+}
+
+func TestRecordContentUpdate_NoCoalesceWhenDisabled(t *testing.T) {
+	service, treeService, _ := newRevisionTestServiceWithWindow(t, 0)
+	pageID := createRevisionTestPage(t, treeService, "Page", "page", "version one")
+
+	rev1, created, err := service.RecordContentUpdate(pageID, "alice", "first")
+	if err != nil || !created || rev1 == nil {
+		t.Fatalf("first RecordContentUpdate failed: created=%v err=%v", created, err)
+	}
+
+	content := "version two"
+	if err := treeService.UpdateNode("alice", pageID, "Page", "page", &content, tree.VersionUnchecked, false); err != nil {
+		t.Fatalf("UpdateNode failed: %v", err)
+	}
+
+	rev2, created, err := service.RecordContentUpdate(pageID, "alice", "second")
+	if err != nil || !created {
+		t.Fatalf("second RecordContentUpdate failed: created=%v err=%v", created, err)
+	}
+	if rev2.ID == rev1.ID {
+		t.Fatalf("expected new revision when coalescing is disabled")
+	}
+
+	revisions, err := service.ListRevisions(pageID)
+	if err != nil {
+		t.Fatalf("ListRevisions failed: %v", err)
+	}
+	if len(revisions) != 2 {
+		t.Fatalf("expected 2 revisions when coalescing is disabled, got %d", len(revisions))
+	}
+}
+
+func TestRecordContentUpdate_NoCoalesceDifferentAuthor(t *testing.T) {
+	service, treeService, _ := newRevisionTestServiceWithWindow(t, time.Hour)
+	pageID := createRevisionTestPage(t, treeService, "Page", "page", "version one")
+
+	rev1, created, err := service.RecordContentUpdate(pageID, "alice", "alice's edit")
+	if err != nil || !created || rev1 == nil {
+		t.Fatalf("first RecordContentUpdate failed: %v", err)
+	}
+
+	content := "version two"
+	if err := treeService.UpdateNode("bob", pageID, "Page", "page", &content, tree.VersionUnchecked, false); err != nil {
+		t.Fatalf("UpdateNode failed: %v", err)
+	}
+
+	rev2, created, err := service.RecordContentUpdate(pageID, "bob", "bob's edit")
+	if err != nil || !created {
+		t.Fatalf("second RecordContentUpdate failed: created=%v err=%v", created, err)
+	}
+	if rev2.ID == rev1.ID {
+		t.Fatalf("expected new revision for different author")
+	}
+
+	revisions, err := service.ListRevisions(pageID)
+	if err != nil {
+		t.Fatalf("ListRevisions failed: %v", err)
+	}
+	if len(revisions) != 2 {
+		t.Fatalf("expected 2 revisions for different authors, got %d", len(revisions))
+	}
+}
+
+func TestRecordContentUpdate_NoCoalesceAfterWindowExpired(t *testing.T) {
+	service, treeService, _ := newRevisionTestServiceWithWindow(t, 5*time.Minute)
+	pageID := createRevisionTestPage(t, treeService, "Page", "page", "version one")
+
+	rev1, _, err := service.RecordContentUpdate(pageID, "alice", "first")
+	if err != nil || rev1 == nil {
+		t.Fatalf("first RecordContentUpdate failed: %v", err)
+	}
+
+	// Backdate the revision so it falls outside the coalesce window.
+	rev1.CreatedAt = time.Now().Add(-10 * time.Minute)
+	if err := service.store.UpdateRevision(rev1); err != nil {
+		t.Fatalf("UpdateRevision (backdate) failed: %v", err)
+	}
+
+	content := "version two"
+	if err := treeService.UpdateNode("alice", pageID, "Page", "page", &content, tree.VersionUnchecked, false); err != nil {
+		t.Fatalf("UpdateNode failed: %v", err)
+	}
+
+	rev2, created, err := service.RecordContentUpdate(pageID, "alice", "after window")
+	if err != nil || !created {
+		t.Fatalf("second RecordContentUpdate failed: created=%v err=%v", created, err)
+	}
+	if rev2.ID == rev1.ID {
+		t.Fatalf("expected new revision after window expired")
+	}
+
+	revisions, err := service.ListRevisions(pageID)
+	if err != nil {
+		t.Fatalf("ListRevisions failed: %v", err)
+	}
+	if len(revisions) != 2 {
+		t.Fatalf("expected 2 revisions after window expired, got %d", len(revisions))
+	}
+}
+
+func TestRecordContentUpdate_NoCoalesceForNonContentRevision(t *testing.T) {
+	service, treeService, _ := newRevisionTestServiceWithWindow(t, time.Hour)
+	pageID := createRevisionTestPage(t, treeService, "Page", "page", "version one")
+
+	structureRev, created, err := service.RecordStructureChange(pageID, "alice", "structure")
+	if err != nil || !created || structureRev == nil {
+		t.Fatalf("RecordStructureChange failed: created=%v err=%v", created, err)
+	}
+
+	// Change content so the noop check does not fire.
+	content := "version two"
+	if err := treeService.UpdateNode("alice", pageID, "Page", "page", &content, tree.VersionUnchecked, false); err != nil {
+		t.Fatalf("UpdateNode failed: %v", err)
+	}
+
+	rev, created, err := service.RecordContentUpdate(pageID, "alice", "content")
+	if err != nil || !created {
+		t.Fatalf("RecordContentUpdate failed: created=%v err=%v", created, err)
+	}
+	if rev.ID == structureRev.ID {
+		t.Fatalf("expected new content revision, not a coalesce with structure revision")
+	}
+	if rev.Type != RevisionTypeContentUpdate {
+		t.Fatalf("expected content update type, got %v", rev.Type)
+	}
+}
+
+func TestRecordContentUpdate_CoalescingGCsOldScopedBlob(t *testing.T) {
+	service, treeService, _ := newRevisionTestServiceWithWindow(t, time.Hour)
+	pageID := createRevisionTestPage(t, treeService, "Page", "page", "version one")
+
+	rev1, _, err := service.RecordContentUpdate(pageID, "alice", "first")
+	if err != nil || rev1 == nil {
+		t.Fatalf("first RecordContentUpdate failed: %v", err)
+	}
+	oldBlobPath := service.store.contentBlobPath(pageID, rev1.ContentHash)
+	if _, err := os.Stat(oldBlobPath); os.IsNotExist(err) {
+		t.Fatalf("expected old blob to exist at %s", oldBlobPath)
+	}
+
+	content := "version two"
+	if err := treeService.UpdateNode("alice", pageID, "Page", "page", &content, tree.VersionUnchecked, false); err != nil {
+		t.Fatalf("UpdateNode failed: %v", err)
+	}
+
+	rev2, _, err := service.RecordContentUpdate(pageID, "alice", "second")
+	if err != nil {
+		t.Fatalf("second RecordContentUpdate (coalesce) failed: %v", err)
+	}
+	if rev2.ContentHash == rev1.ContentHash {
+		t.Fatalf("expected content hash to change after coalesce")
+	}
+
+	if _, err := os.Stat(oldBlobPath); !os.IsNotExist(err) {
+		t.Fatalf("expected old scoped blob to be GC'd after coalescing, stat err=%v", err)
+	}
+	newBlobPath := service.store.contentBlobPath(pageID, rev2.ContentHash)
+	if _, err := os.Stat(newBlobPath); os.IsNotExist(err) {
+		t.Fatalf("expected new scoped blob to exist at %s", newBlobPath)
 	}
 }

--- a/internal/core/revision/service_test.go
+++ b/internal/core/revision/service_test.go
@@ -445,7 +445,7 @@ func TestRestoreAssetsHashAndSizeMismatch(t *testing.T) {
 		t.Fatalf("expected restored asset hash mismatch")
 	}
 
-	hash2, err := service.store.SaveContentBlob([]byte("size-ok"))
+	hash2, err := service.store.SaveContentBlob("test-page", []byte("size-ok"))
 	if err != nil {
 		t.Fatalf("SaveContentBlob second failed: %v", err)
 	}
@@ -834,7 +834,7 @@ func TestRestoreRevision_LegacyRevisionPreservesCurrentCustomFrontmatter(t *test
 	}
 
 	state := service.revisionStateFromPage(page)
-	contentHash, err := service.store.SaveContentBlob([]byte("Legacy body"))
+	contentHash, err := service.store.SaveContentBlob(pageID, []byte("Legacy body"))
 	if err != nil {
 		t.Fatalf("SaveContentBlob failed: %v", err)
 	}
@@ -894,7 +894,7 @@ func TestRestoreRevision_LegacyBodyThatLooksLikeFrontmatterStaysBody(t *testing.
 
 	legacyBody := "---\ntitle: not frontmatter\n---\nBody content"
 	state := service.revisionStateFromPage(page)
-	contentHash, err := service.store.SaveContentBlob([]byte(legacyBody))
+	contentHash, err := service.store.SaveContentBlob(pageID, []byte(legacyBody))
 	if err != nil {
 		t.Fatalf("SaveContentBlob failed: %v", err)
 	}
@@ -999,7 +999,7 @@ func TestCheckRevisionIntegrityReportsBrokenArtifacts(t *testing.T) {
 	if err != nil || len(revs1) == 0 {
 		t.Fatalf("ListRevisions page1 failed: %#v %v", revs1, err)
 	}
-	if err := os.Remove(service.store.contentBlobPath(revs1[0].ContentHash)); err != nil {
+	if err := os.Remove(service.store.contentBlobPath(pageID1, revs1[0].ContentHash)); err != nil {
 		t.Fatalf("Remove content blob failed: %v", err)
 	}
 	issues1, err := service.CheckRevisionIntegrity(pageID1)

--- a/internal/core/revision/service_test.go
+++ b/internal/core/revision/service_test.go
@@ -1312,6 +1312,57 @@ func TestRecordContentUpdate_NoCoalesceForNonContentRevision(t *testing.T) {
 	}
 }
 
+func TestRecordContentUpdate_CoalesceResetsWindow(t *testing.T) {
+	service, treeService, _ := newRevisionTestServiceWithWindow(t, 5*time.Minute)
+	pageID := createRevisionTestPage(t, treeService, "Page", "page", "version one")
+
+	rev1, _, err := service.RecordContentUpdate(pageID, "alice", "first")
+	if err != nil || rev1 == nil {
+		t.Fatalf("first RecordContentUpdate failed: %v", err)
+	}
+
+	// Backdate rev1 to just inside the window.
+	rev1.CreatedAt = time.Now().Add(-4 * time.Minute)
+	if err := service.store.UpdateRevision(rev1); err != nil {
+		t.Fatalf("UpdateRevision (backdate) failed: %v", err)
+	}
+
+	// First coalesce — resets CreatedAt to now.
+	content := "version two"
+	if err := treeService.UpdateNode("alice", pageID, "Page", "page", &content, tree.VersionUnchecked, false); err != nil {
+		t.Fatalf("UpdateNode (v2) failed: %v", err)
+	}
+	rev2, _, err := service.RecordContentUpdate(pageID, "alice", "second")
+	if err != nil {
+		t.Fatalf("second RecordContentUpdate failed: %v", err)
+	}
+	if rev2.ID != rev1.ID {
+		t.Fatalf("expected coalesce on first update")
+	}
+
+	// Without debounce the original CreatedAt (-4min) would now be 4min+ old;
+	// with debounce CreatedAt was reset to ~now, so this must still coalesce.
+	content = "version three"
+	if err := treeService.UpdateNode("alice", pageID, "Page", "page", &content, tree.VersionUnchecked, false); err != nil {
+		t.Fatalf("UpdateNode (v3) failed: %v", err)
+	}
+	rev3, _, err := service.RecordContentUpdate(pageID, "alice", "third")
+	if err != nil {
+		t.Fatalf("third RecordContentUpdate failed: %v", err)
+	}
+	if rev3.ID != rev1.ID {
+		t.Fatalf("expected second coalesce after window reset, got new revision %q", rev3.ID)
+	}
+
+	revisions, err := service.ListRevisions(pageID)
+	if err != nil {
+		t.Fatalf("ListRevisions failed: %v", err)
+	}
+	if len(revisions) != 1 {
+		t.Fatalf("expected 1 revision after two coalesces, got %d", len(revisions))
+	}
+}
+
 func TestRecordContentUpdate_CoalescingGCsOldScopedBlob(t *testing.T) {
 	service, treeService, _ := newRevisionTestServiceWithWindow(t, time.Hour)
 	pageID := createRevisionTestPage(t, treeService, "Page", "page", "version one")

--- a/internal/wiki/pages/pages_test.go
+++ b/internal/wiki/pages/pages_test.go
@@ -2620,7 +2620,7 @@ func TestCheckIntegrityUseCase_Passthrough(t *testing.T) {
 	if err != nil || rev == nil {
 		t.Fatalf("GetLatestRevision failed: %#v %v", rev, err)
 	}
-	contentBlobPath := filepath.Join(deps.storageDir, ".leafwiki", "blobs", "content", "sha256", rev.ContentHash[:2], rev.ContentHash)
+	contentBlobPath := filepath.Join(deps.storageDir, ".leafwiki", "blobs", "content", pageOut.Page.ID, "sha256", rev.ContentHash[:2], rev.ContentHash)
 	if err := os.Remove(contentBlobPath); err != nil {
 		t.Fatalf("Remove content blob failed: %v", err)
 	}

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -20,6 +20,7 @@ import (
 	"github.com/perber/wiki/internal/tags"
 	wikiassets "github.com/perber/wiki/internal/wiki/assets"
 	wikiauth "github.com/perber/wiki/internal/wiki/auth"
+	wikibackup "github.com/perber/wiki/internal/wiki/backup"
 	wikibranding "github.com/perber/wiki/internal/wiki/branding"
 	wikihealth "github.com/perber/wiki/internal/wiki/health"
 	wikiimporter "github.com/perber/wiki/internal/wiki/importer"
@@ -30,7 +31,6 @@ import (
 	wikirevisions "github.com/perber/wiki/internal/wiki/revisions"
 	wikisearch "github.com/perber/wiki/internal/wiki/search"
 	wikitags "github.com/perber/wiki/internal/wiki/tags"
-	wikibackup "github.com/perber/wiki/internal/wiki/backup"
 )
 
 type Wiki struct {
@@ -43,7 +43,7 @@ type Wiki struct {
 	branding     *branding.BrandingService
 	searchIndex  *search.SQLiteIndex
 	status       *search.IndexingStatus
-	storageDir string
+	storageDir   string
 
 	// Domain route registrars (populated by NewWiki).
 	pagesRoutes      *wikipages.Routes
@@ -68,16 +68,16 @@ type Wiki struct {
 const SYSTEM_USER_ID = "system"
 
 type WikiOptions struct {
-	StorageDir              string           // Path to storage directory
-	AdminPassword           string           // Initial admin password
-	JWTSecret               string           // JWT secret for authentication
-	AccessTokenTimeout      time.Duration    // Access token timeout duration
-	RefreshTokenTimeout     time.Duration    // Refresh token timeout duration
-	AuthDisabled            bool             // Whether authentication is disabled
-	EnableRevision          bool             // Whether revision recording/storage is enabled
-	MaxRevisionHistory      int              // Max revisions kept per page; 0 = unlimited
-	MaxAssetUploadSizeBytes    int64         // Maximum allowed size in bytes for asset/import uploads; 0 = default
-	RevisionCoalesceWindow     time.Duration // Window for coalescing rapid successive saves; 0 = disabled
+	StorageDir              string        // Path to storage directory
+	AdminPassword           string        // Initial admin password
+	JWTSecret               string        // JWT secret for authentication
+	AccessTokenTimeout      time.Duration // Access token timeout duration
+	RefreshTokenTimeout     time.Duration // Refresh token timeout duration
+	AuthDisabled            bool          // Whether authentication is disabled
+	EnableRevision          bool          // Whether revision recording/storage is enabled
+	MaxRevisionHistory      int           // Max revisions kept per page; 0 = unlimited
+	MaxAssetUploadSizeBytes int64         // Maximum allowed size in bytes for asset/import uploads; 0 = default
+	RevisionCoalesceWindow  time.Duration // Window for coalescing rapid successive saves; 0 = disabled
 }
 
 func NewWiki(options *WikiOptions) (*Wiki, error) {

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -76,7 +76,8 @@ type WikiOptions struct {
 	AuthDisabled            bool             // Whether authentication is disabled
 	EnableRevision          bool             // Whether revision recording/storage is enabled
 	MaxRevisionHistory      int              // Max revisions kept per page; 0 = unlimited
-	MaxAssetUploadSizeBytes int64 // Maximum allowed size in bytes for asset/import uploads; 0 = default
+	MaxAssetUploadSizeBytes    int64         // Maximum allowed size in bytes for asset/import uploads; 0 = default
+	RevisionCoalesceWindow     time.Duration // Window for coalescing rapid successive saves; 0 = disabled
 }
 
 func NewWiki(options *WikiOptions) (*Wiki, error) {
@@ -112,7 +113,10 @@ func NewWiki(options *WikiOptions) (*Wiki, error) {
 	}
 	if options.EnableRevision {
 		w.revision = revision.NewService(w.storageDir, w.tree, w.log,
-			revision.ServiceOptions{MaxRevisions: options.MaxRevisionHistory})
+			revision.ServiceOptions{
+				MaxRevisions:   options.MaxRevisionHistory,
+				CoalesceWindow: options.RevisionCoalesceWindow,
+			})
 		w.ensureBaselineRevisions()
 	}
 	w.buildRoutes(options)


### PR DESCRIPTION
Rapid successive saves by the same author within a configurable window (default 5 min) are merged into a single revision in-place instead of creating a new entry. This prevents the 100-revision limit from filling up with 2-second auto-save noise.

Content blobs are now stored page-scoped under blobs/content/<pageID>/ with a transparent fallback to the legacy global path for existing data, enabling safe per-page GC: orphaned blobs from coalesced saves are deleted immediately after each update.

New flag: --revision-coalesce-window (LEAFWIKI_REVISION_COALESCE_WINDOW)