### PR TITLE
feat(ui): add shortcuts help dialog

### DIFF
--- a/ui/leafwiki-ui/src/components/BaseDialog.tsx
+++ b/ui/leafwiki-ui/src/components/BaseDialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { createHotkeyDefinition } from '@/lib/shortcuts/shortcutCatalog'
 import { useDialogsStore } from '@/stores/dialogs'
 import { HotKeyDefinition, useHotKeysStore } from '@/stores/hotkeys'
 import { Loader2 } from 'lucide-react'
@@ -90,11 +91,9 @@ export default function BaseDialog({
       return
     }
 
-    const confirmHotkey: HotKeyDefinition = {
-      keyCombo: 'Enter',
-      enabled: true,
-      mode: ['dialog'],
-      action: async () => {
+    const confirmHotkey: HotKeyDefinition = createHotkeyDefinition(
+      'dialog.confirm',
+      async () => {
         if (defaultAction === 'cancel') {
           onClose()
           closeDialog()
@@ -117,16 +116,14 @@ export default function BaseDialog({
           closeDialog()
         }
       },
-    }
-    const cancelHotkey: HotKeyDefinition = {
-      keyCombo: 'Escape',
-      enabled: true,
-      mode: ['dialog'],
-      action: () => {
+    )
+    const cancelHotkey: HotKeyDefinition = createHotkeyDefinition(
+      'dialog.close',
+      () => {
         onClose()
         closeDialog()
       },
-    }
+    )
     registerHotkey(confirmHotkey)
     registerHotkey(cancelHotkey)
 

--- a/ui/leafwiki-ui/src/components/UserToolbar.test.tsx
+++ b/ui/leafwiki-ui/src/components/UserToolbar.test.tsx
@@ -1,0 +1,61 @@
+import { DialogManager } from '@/components/DialogManager'
+import UserToolbar from '@/components/UserToolbar'
+import { useBackupStore } from '@/stores/backup'
+import { useConfigStore } from '@/stores/config'
+import { useDialogsStore } from '@/stores/dialogs'
+import { useSessionStore } from '@/stores/session'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('UserToolbar', () => {
+  beforeEach(() => {
+    vi.stubGlobal('__APP_VERSION__', 'test-version')
+
+    useDialogsStore.setState({
+      dialogType: null,
+      dialogProps: null,
+    })
+    useConfigStore.setState({
+      authDisabled: false,
+      httpRemoteUserEnabled: false,
+      httpRemoteUserLogoutUrl: '',
+    })
+    useBackupStore.setState({ enabled: false })
+    useSessionStore.setState({
+      user: {
+        id: 'user-1',
+        username: 'alice',
+        email: 'alice@example.com',
+        role: 'editor',
+      },
+    })
+  })
+
+  it('opens the shortcuts dialog from the user menu', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <MemoryRouter>
+        <UserToolbar />
+        <DialogManager />
+      </MemoryRouter>,
+    )
+
+    const avatar = screen.getByTestId('user-toolbar-avatar')
+    const trigger = avatar.closest('button')
+
+    expect(trigger).toBeTruthy()
+    await user.click(trigger as HTMLButtonElement)
+
+    const menuItem = await screen.findByText('Keyboard Shortcuts')
+    await user.click(menuItem)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('shortcuts-help-dialog')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Available keyboard shortcuts')).toBeInTheDocument()
+    expect(screen.getByText('Go to page')).toBeInTheDocument()
+  })
+})

--- a/ui/leafwiki-ui/src/components/UserToolbar.test.tsx
+++ b/ui/leafwiki-ui/src/components/UserToolbar.test.tsx
@@ -7,9 +7,13 @@ import { useSessionStore } from '@/stores/session'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('UserToolbar', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   beforeEach(() => {
     vi.stubGlobal('__APP_VERSION__', 'test-version')
 

--- a/ui/leafwiki-ui/src/components/UserToolbar.tsx
+++ b/ui/leafwiki-ui/src/components/UserToolbar.tsx
@@ -7,7 +7,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { DIALOG_CHANGE_OWN_PASSWORD } from '@/lib/registries'
+import i18next from '@/lib/i18n'
+import {
+  DIALOG_CHANGE_OWN_PASSWORD,
+  DIALOG_SHORTCUTS_HELP,
+} from '@/lib/registries'
 import { useBackupStore } from '@/stores/backup'
 import { useConfigStore } from '@/stores/config'
 import { useDialogsStore } from '@/stores/dialogs'
@@ -109,6 +113,12 @@ export default function UserToolbar() {
             Version {__APP_VERSION__}
           </DropdownMenuLabel>
           <DropdownMenuSeparator />
+          <DropdownMenuItem
+            className="cursor-pointer"
+            onClick={() => openDialog(DIALOG_SHORTCUTS_HELP)}
+          >
+            {i18next.t('shortcutsHelp.menuItem', { ns: 'viewer' })}
+          </DropdownMenuItem>
           <DropdownMenuItem
             className="cursor-pointer"
             onClick={() => openDialog(DIALOG_CHANGE_OWN_PASSWORD)}

--- a/ui/leafwiki-ui/src/features/assets/AssetItem.tsx
+++ b/ui/leafwiki-ui/src/features/assets/AssetItem.tsx
@@ -7,6 +7,7 @@ import {
   VIDEO_EXTENSIONS,
 } from '@/lib/config'
 import { withBasePath } from '@/lib/routePath'
+import { createHotkeyDefinition } from '@/lib/shortcuts/shortcutCatalog'
 import { HotKeyDefinition, useHotKeysStore } from '@/stores/hotkeys'
 import { Check, FileText, Link2, Pencil, Play, Trash2, X } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
@@ -132,22 +133,18 @@ export function AssetItem({
   useEffect(() => {
     if (!isEditing) return
 
-    const enterHotkey: HotKeyDefinition = {
-      keyCombo: 'Enter',
-      enabled: true,
-      mode: ['dialog'],
-      action: handleRename,
-    }
+    const enterHotkey: HotKeyDefinition = createHotkeyDefinition(
+      'asset.rename.confirm',
+      handleRename,
+    )
 
-    const escapeHotkey: HotKeyDefinition = {
-      keyCombo: 'Escape',
-      enabled: true,
-      mode: ['dialog'],
-      action: () => {
+    const escapeHotkey: HotKeyDefinition = createHotkeyDefinition(
+      'asset.rename.cancel',
+      () => {
         setEditingFilename(null)
         setNewName(baseName.replace(/\.[^/.]+$/, ''))
       },
-    }
+    )
     registerHotkey(enterHotkey)
     registerHotkey(escapeHotkey)
 

--- a/ui/leafwiki-ui/src/features/assets/AssetManagerDialog.tsx
+++ b/ui/leafwiki-ui/src/features/assets/AssetManagerDialog.tsx
@@ -6,6 +6,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { DIALOG_ASSET_MANAGER } from '@/lib/registries'
+import { createHotkeyDefinition } from '@/lib/shortcuts/shortcutCatalog'
 import { useDialogsStore } from '@/stores/dialogs'
 import { HotKeyDefinition, useHotKeysStore } from '@/stores/hotkeys'
 import { useEffect } from 'react'
@@ -33,16 +34,14 @@ export function AssetManagerDialog(props: AssetManagerDialogProps) {
       isRenamingRef.current = false
     }
 
-    const cancelHotkey: HotKeyDefinition = {
-      keyCombo: 'Escape',
-      enabled: true,
-      mode: ['dialog'],
-      action: () => {
+    const cancelHotkey: HotKeyDefinition = createHotkeyDefinition(
+      'dialog.close',
+      () => {
         if (open) {
           closeDialog()
         }
       },
-    }
+    )
 
     registerHotkey(cancelHotkey)
     return () => {

--- a/ui/leafwiki-ui/src/features/editor/LinkInsertDialog.tsx
+++ b/ui/leafwiki-ui/src/features/editor/LinkInsertDialog.tsx
@@ -11,6 +11,7 @@ import { Label } from '@/components/ui/label'
 import { deferStateUpdate } from '@/lib/deferState'
 import { searchFlatPageSearchItems } from '@/lib/pageSearch'
 import { DIALOG_LINK_INSERT } from '@/lib/registries'
+import { createHotkeyDefinition } from '@/lib/shortcuts/shortcutCatalog'
 import { useDialogsStore } from '@/stores/dialogs'
 import { HotKeyDefinition, useHotKeysStore } from '@/stores/hotkeys'
 import { useTreeStore } from '@/stores/tree'
@@ -91,14 +92,12 @@ export function LinkInsertDialog({
   }
 
   useEffect(() => {
-    const cancelHotkey: HotKeyDefinition = {
-      keyCombo: 'Escape',
-      enabled: true,
-      mode: ['dialog'],
-      action: () => {
+    const cancelHotkey: HotKeyDefinition = createHotkeyDefinition(
+      'dialog.close',
+      () => {
         if (open) closeDialog()
       },
-    }
+    )
     registerHotkey(cancelHotkey)
     return () => unregisterHotkey(cancelHotkey.keyCombo)
   }, [open, closeDialog, registerHotkey, unregisterHotkey])

--- a/ui/leafwiki-ui/src/features/editor/useToolbarActions.tsx
+++ b/ui/leafwiki-ui/src/features/editor/useToolbarActions.tsx
@@ -1,5 +1,9 @@
 // Hook to provide toolbar actions for the page viewer
 
+import {
+  createHotkeyDefinition,
+  getShortcutDisplayLabel,
+} from '@/lib/shortcuts/shortcutCatalog'
 import { useAppMode } from '@/lib/useAppMode'
 import { isHotkeyAllowedOnElement } from '@/lib/hotkeys'
 import { useIsReadOnly } from '@/lib/useIsReadOnly'
@@ -47,6 +51,9 @@ export function useToolbarActions({
   const dirty = usePageEditorStore(isDirtyState)
   const autoSave = useEditorStore((s) => s.autoSave)
   const toggleAutoSave = useEditorStore((s) => s.toggleAutoSave)
+  const isMacOS =
+    typeof navigator !== 'undefined' &&
+    /Mac|iPhone|iPad|iPod/.test(navigator.platform)
 
   // useEffect to set toolbar buttons
   useEffect(() => {
@@ -59,7 +66,7 @@ export function useToolbarActions({
       {
         id: 'close-editor',
         label: 'Close Editor',
-        hotkey: 'Esc',
+        hotkey: getShortcutDisplayLabel('editor.page.close', isMacOS),
         icon: <X size={18} />,
         action: closePage,
         variant: 'destructive',
@@ -68,7 +75,7 @@ export function useToolbarActions({
       {
         id: 'save-page',
         label: 'Save Page',
-        hotkey: 'Ctrl+S',
+        hotkey: getShortcutDisplayLabel('editor.page.save', isMacOS),
         icon: <Save size={18} />,
         variant: 'default',
         disabled: !dirty,
@@ -101,6 +108,7 @@ export function useToolbarActions({
     closePage,
     autoSave,
     toggleAutoSave,
+    isMacOS,
   ])
 
   // Register hotkeys
@@ -126,19 +134,14 @@ export function useToolbarActions({
       )
     }
 
-    const saveHotKey: HotKeyDefinition = {
-      keyCombo: 'Mod+KeyS',
-      enabled: true,
-      mode: ['edit'],
-      action: savePage,
-    }
+    const saveHotKey: HotKeyDefinition = createHotkeyDefinition(
+      'editor.page.save',
+      savePage,
+    )
 
-    const closeHotkey: HotKeyDefinition = {
-      keyCombo: 'Escape',
-      enabled: true,
-      mode: ['edit'],
-      shouldHandle: editorCloseShouldHandle,
-      action: () => {
+    const closeHotkey: HotKeyDefinition = createHotkeyDefinition(
+      'editor.page.close',
+      () => {
         const view = getEditorView?.()
         if (view && completionStatus(view.state) !== null) {
           return
@@ -151,56 +154,43 @@ export function useToolbarActions({
 
         closePage()
       },
-    }
+      { shouldHandle: editorCloseShouldHandle },
+    )
 
-    const boldHotkey: HotKeyDefinition = {
-      keyCombo: 'Mod+KeyB',
-      enabled: true,
-      mode: ['edit'],
-      action: formatBold,
-    }
+    const boldHotkey: HotKeyDefinition = createHotkeyDefinition(
+      'editor.format.bold',
+      formatBold,
+    )
 
-    const italicHotkey: HotKeyDefinition = {
-      keyCombo: 'Mod+KeyI',
-      enabled: true,
-      mode: ['edit'],
-      action: formatItalic,
-    }
+    const italicHotkey: HotKeyDefinition = createHotkeyDefinition(
+      'editor.format.italic',
+      formatItalic,
+    )
 
-    const heading1Hotkey: HotKeyDefinition = {
-      keyCombo: 'Mod+Alt+Digit1',
-      enabled: true,
-      mode: ['edit'],
-      action: () => insertHeading(1),
-    }
+    const heading1Hotkey: HotKeyDefinition = createHotkeyDefinition(
+      'editor.heading.one',
+      () => insertHeading(1),
+    )
 
-    const heading2Hotkey: HotKeyDefinition = {
-      keyCombo: 'Mod+Alt+Digit2',
-      enabled: true,
-      mode: ['edit'],
-      action: () => insertHeading(2),
-    }
+    const heading2Hotkey: HotKeyDefinition = createHotkeyDefinition(
+      'editor.heading.two',
+      () => insertHeading(2),
+    )
 
-    const heading3Hotkey: HotKeyDefinition = {
-      keyCombo: 'Mod+Alt+Digit3',
-      enabled: true,
-      mode: ['edit'],
-      action: () => insertHeading(3),
-    }
+    const heading3Hotkey: HotKeyDefinition = createHotkeyDefinition(
+      'editor.heading.three',
+      () => insertHeading(3),
+    )
 
-    const inlineCodeHotkey: HotKeyDefinition = {
-      keyCombo: 'Mod+Backquote',
-      enabled: true,
-      mode: ['edit'],
-      action: formatInlineCode,
-    }
+    const inlineCodeHotkey: HotKeyDefinition = createHotkeyDefinition(
+      'editor.format.inlineCode',
+      formatInlineCode,
+    )
 
-    const linkHotkey: HotKeyDefinition = {
-      keyCombo: 'Mod+KeyK',
-      enabled: true,
-      mode: ['edit'],
-      action: openLinkDialog,
-    }
+    const linkHotkey: HotKeyDefinition = createHotkeyDefinition(
+      'editor.link.insert',
+      openLinkDialog,
+    )
 
     registerHotkey(saveHotKey)
     registerHotkey(closeHotkey)
@@ -238,5 +228,6 @@ export function useToolbarActions({
     registerHotkey,
     unregisterHotkey,
     dirty,
+    isMacOS,
   ])
 }

--- a/ui/leafwiki-ui/src/features/imagepreview/ImagePreviewDialog.tsx
+++ b/ui/leafwiki-ui/src/features/imagepreview/ImagePreviewDialog.tsx
@@ -5,6 +5,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { DIALOG_IMAGE_PREVIEW } from '@/lib/registries'
+import { createHotkeyDefinition } from '@/lib/shortcuts/shortcutCatalog'
 import { useDialogsStore } from '@/stores/dialogs'
 import { HotKeyDefinition, useHotKeysStore } from '@/stores/hotkeys'
 import { useEffect, useMemo, useState } from 'react'
@@ -25,14 +26,12 @@ export function ImagePreviewDialog({ src, alt }: Props) {
     if (!open) {
       return
     }
-    const cancelHotkey: HotKeyDefinition = {
-      keyCombo: 'Escape',
-      enabled: true,
-      mode: ['dialog'],
-      action: () => {
+    const cancelHotkey: HotKeyDefinition = createHotkeyDefinition(
+      'dialog.close',
+      () => {
         closeDialog()
       },
-    }
+    )
 
     setNatural(null)
     registerHotkey(cancelHotkey)

--- a/ui/leafwiki-ui/src/features/page-switcher/PageQuickSwitcherTrigger.tsx
+++ b/ui/leafwiki-ui/src/features/page-switcher/PageQuickSwitcherTrigger.tsx
@@ -1,15 +1,22 @@
 import { Button } from '@/components/ui/button'
 import { DIALOG_PAGE_QUICK_SWITCHER } from '@/lib/registries'
+import {
+  createHotkeyDefinition,
+  getShortcutDisplayLabel,
+} from '@/lib/shortcuts/shortcutCatalog'
 import { useAppMode } from '@/lib/useAppMode'
 import { useDialogsStore } from '@/stores/dialogs'
-import { HotKeyDefinition, useHotKeysStore } from '@/stores/hotkeys'
+import { useHotKeysStore } from '@/stores/hotkeys'
 import { FileSearch } from 'lucide-react'
 import { useEffect } from 'react'
 
 const isMacOS =
   typeof navigator !== 'undefined' &&
   /Mac|iPhone|iPad|iPod/.test(navigator.platform)
-const quickSwitcherHotkeyLabel = isMacOS ? 'Cmd+Option+P' : 'Ctrl+Alt+P'
+const quickSwitcherHotkeyLabel = getShortcutDisplayLabel(
+  'page.quickSwitcher.open',
+  isMacOS,
+)
 
 export function PageQuickSwitcherTrigger() {
   const appMode = useAppMode()
@@ -18,12 +25,9 @@ export function PageQuickSwitcherTrigger() {
   const unregisterHotkey = useHotKeysStore((state) => state.unregisterHotkey)
 
   useEffect(() => {
-    const hotkey: HotKeyDefinition = {
-      keyCombo: 'Mod+Alt+KeyP',
-      enabled: true,
-      mode: ['view'],
-      action: () => openDialog(DIALOG_PAGE_QUICK_SWITCHER),
-    }
+    const hotkey = createHotkeyDefinition('page.quickSwitcher.open', () =>
+      openDialog(DIALOG_PAGE_QUICK_SWITCHER),
+    )
 
     registerHotkey(hotkey)
     return () => unregisterHotkey(hotkey.keyCombo)

--- a/ui/leafwiki-ui/src/features/page/PageHistoryPage.tsx
+++ b/ui/leafwiki-ui/src/features/page/PageHistoryPage.tsx
@@ -83,7 +83,13 @@ export default function PageHistoryPage() {
       setToolbarButtons([])
       unregisterHotkey(closeHotkey.keyCombo)
     }
-  }, [closeHistory, isMacOS, registerHotkey, setToolbarButtons, unregisterHotkey])
+  }, [
+    closeHistory,
+    isMacOS,
+    registerHotkey,
+    setToolbarButtons,
+    unregisterHotkey,
+  ])
 
   const renderError = () => {
     if (!loading && notFound) {

--- a/ui/leafwiki-ui/src/features/page/PageHistoryPage.tsx
+++ b/ui/leafwiki-ui/src/features/page/PageHistoryPage.tsx
@@ -1,6 +1,10 @@
 import Page404 from '@/components/Page404'
 import { buildViewUrl } from '@/lib/routePath'
 import {
+  createHotkeyDefinition,
+  getShortcutDisplayLabel,
+} from '@/lib/shortcuts/shortcutCatalog'
+import {
   createNavigationVisitState,
   getNavigationVisitKey,
 } from '@/lib/navigationVisit'
@@ -31,6 +35,9 @@ export default function PageHistoryPage() {
   const notFound = useViewerStore((s) => s.notFound)
   const page = useViewerStore((s) => s.page)
   const loadPageData = useViewerStore((s) => s.loadPageData)
+  const isMacOS =
+    typeof navigator !== 'undefined' &&
+    /Mac|iPhone|iPad|iPod/.test(navigator.platform)
 
   usePageHistory(page?.id ?? null)
 
@@ -58,19 +65,17 @@ export default function PageHistoryPage() {
       {
         id: 'close-history',
         label: 'Back to Page',
-        hotkey: 'Esc',
+        hotkey: getShortcutDisplayLabel('history.page.close', isMacOS),
         icon: <ArrowLeft size={18} />,
         action: closeHistory,
         variant: 'outline',
       },
     ])
 
-    const closeHotkey: HotKeyDefinition = {
-      keyCombo: 'Escape',
-      enabled: true,
-      mode: ['history'],
-      action: closeHistory,
-    }
+    const closeHotkey: HotKeyDefinition = createHotkeyDefinition(
+      'history.page.close',
+      closeHistory,
+    )
 
     registerHotkey(closeHotkey)
 
@@ -78,7 +83,7 @@ export default function PageHistoryPage() {
       setToolbarButtons([])
       unregisterHotkey(closeHotkey.keyCombo)
     }
-  }, [closeHistory, registerHotkey, setToolbarButtons, unregisterHotkey])
+  }, [closeHistory, isMacOS, registerHotkey, setToolbarButtons, unregisterHotkey])
 
   const renderError = () => {
     if (!loading && notFound) {

--- a/ui/leafwiki-ui/src/features/shortcuts/ShortcutsDialog.test.tsx
+++ b/ui/leafwiki-ui/src/features/shortcuts/ShortcutsDialog.test.tsx
@@ -1,0 +1,54 @@
+import { DIALOG_SHORTCUTS_HELP } from '@/lib/registries'
+import { useDialogsStore } from '@/stores/dialogs'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ShortcutsDialog } from './ShortcutsDialog'
+
+describe('ShortcutsDialog', () => {
+  beforeEach(() => {
+    useDialogsStore.setState({
+      dialogType: DIALOG_SHORTCUTS_HELP,
+      dialogProps: null,
+    })
+  })
+
+  it('shows only view-mode shortcuts on a normal page route', () => {
+    render(
+      <MemoryRouter initialEntries={['/docs/getting-started']}>
+        <ShortcutsDialog />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('Go to page')).toBeInTheDocument()
+    expect(screen.getByText('Open explorer')).toBeInTheDocument()
+    expect(screen.getByText('Open search')).toBeInTheDocument()
+    expect(screen.queryByText('Save page')).not.toBeInTheDocument()
+    expect(screen.queryByText('Back to page')).not.toBeInTheDocument()
+  })
+
+  it('shows edit-mode shortcuts on an editor route', () => {
+    render(
+      <MemoryRouter initialEntries={['/e/docs/getting-started']}>
+        <ShortcutsDialog />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('Save page')).toBeInTheDocument()
+    expect(screen.getByText('Close editor')).toBeInTheDocument()
+    expect(screen.getByText('Open explorer')).toBeInTheDocument()
+    expect(screen.queryByText('Go to page')).not.toBeInTheDocument()
+  })
+
+  it('renders the current mode label via i18n', () => {
+    render(
+      <MemoryRouter initialEntries={['/history/docs/getting-started']}>
+        <ShortcutsDialog />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('Available in history mode')).toBeInTheDocument()
+    expect(screen.getByText('Back to page')).toBeInTheDocument()
+    expect(screen.queryByText('Save page')).not.toBeInTheDocument()
+  })
+})

--- a/ui/leafwiki-ui/src/features/shortcuts/ShortcutsDialog.tsx
+++ b/ui/leafwiki-ui/src/features/shortcuts/ShortcutsDialog.tsx
@@ -1,0 +1,60 @@
+import BaseDialog from '@/components/BaseDialog'
+import i18next from '@/lib/i18n'
+import { DIALOG_SHORTCUTS_HELP } from '@/lib/registries'
+
+const shortcutRows = [
+  {
+    actionKey: 'shortcutsHelp.items.goToPage.action',
+    keys: ['Cmd+Option+P', 'Ctrl+Alt+P'],
+  },
+  {
+    actionKey: 'shortcutsHelp.items.openExplorer.action',
+    keys: ['Mod+Shift+E'],
+  },
+  {
+    actionKey: 'shortcutsHelp.items.openSearch.action',
+    keys: ['Mod+Shift+F'],
+  },
+  {
+    actionKey: 'shortcutsHelp.items.closeDialog.action',
+    keys: ['Esc'],
+  },
+] as const
+
+export function ShortcutsDialog() {
+  return (
+    <BaseDialog
+      dialogType={DIALOG_SHORTCUTS_HELP}
+      dialogTitle={i18next.t('shortcutsHelp.title', { ns: 'viewer' })}
+      dialogDescription={i18next.t('shortcutsHelp.description', {
+        ns: 'viewer',
+      })}
+      testidPrefix="shortcuts-help-dialog"
+      cancelButton={{
+        label: i18next.t('shortcutsHelp.closeButton', { ns: 'viewer' }),
+        variant: 'outline',
+        autoFocus: true,
+      }}
+      defaultAction="cancel"
+      onClose={() => true}
+      onConfirm={async () => true}
+    >
+      <div className="space-y-3 pt-2" data-testid="shortcuts-help-dialog">
+        <div className="rounded-md border">
+          <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-x-4 gap-y-3 p-4">
+            {shortcutRows.map((row) => (
+              <div key={row.actionKey} className="contents">
+                <span className="text-sm">
+                  {i18next.t(row.actionKey, { ns: 'viewer' })}
+                </span>
+                <span className="text-muted-foreground text-right text-sm font-medium whitespace-nowrap">
+                  {row.keys.join(' / ')}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </BaseDialog>
+  )
+}

--- a/ui/leafwiki-ui/src/features/shortcuts/ShortcutsDialog.tsx
+++ b/ui/leafwiki-ui/src/features/shortcuts/ShortcutsDialog.tsx
@@ -1,27 +1,20 @@
 import BaseDialog from '@/components/BaseDialog'
 import i18next from '@/lib/i18n'
+import {
+  getShortcutDisplayLabel,
+  getVisibleShortcutsForMode,
+} from '@/lib/shortcuts/shortcutCatalog'
+import { useAppMode } from '@/lib/useAppMode'
 import { DIALOG_SHORTCUTS_HELP } from '@/lib/registries'
 
-const shortcutRows = [
-  {
-    actionKey: 'shortcutsHelp.items.goToPage.action',
-    keys: ['Cmd+Option+P', 'Ctrl+Alt+P'],
-  },
-  {
-    actionKey: 'shortcutsHelp.items.openExplorer.action',
-    keys: ['Mod+Shift+E'],
-  },
-  {
-    actionKey: 'shortcutsHelp.items.openSearch.action',
-    keys: ['Mod+Shift+F'],
-  },
-  {
-    actionKey: 'shortcutsHelp.items.closeDialog.action',
-    keys: ['Esc'],
-  },
-] as const
+const isMacOS =
+  typeof navigator !== 'undefined' &&
+  /Mac|iPhone|iPad|iPod/.test(navigator.platform)
 
 export function ShortcutsDialog() {
+  const appMode = useAppMode()
+  const shortcuts = getVisibleShortcutsForMode(appMode)
+
   return (
     <BaseDialog
       dialogType={DIALOG_SHORTCUTS_HELP}
@@ -40,15 +33,21 @@ export function ShortcutsDialog() {
       onConfirm={async () => true}
     >
       <div className="space-y-3 pt-2" data-testid="shortcuts-help-dialog">
+        <p className="text-muted-foreground text-sm font-medium">
+          {i18next.t('shortcutsHelp.currentMode', {
+            ns: 'viewer',
+            mode: i18next.t(`shortcutsHelp.modes.${appMode}`, { ns: 'viewer' }),
+          })}
+        </p>
         <div className="rounded-md border">
           <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-x-4 gap-y-3 p-4">
-            {shortcutRows.map((row) => (
-              <div key={row.actionKey} className="contents">
+            {shortcuts.map((shortcut) => (
+              <div key={shortcut.id} className="contents">
                 <span className="text-sm">
-                  {i18next.t(row.actionKey, { ns: 'viewer' })}
+                  {i18next.t(shortcut.labelKey, { ns: 'viewer' })}
                 </span>
                 <span className="text-muted-foreground text-right text-sm font-medium whitespace-nowrap">
-                  {row.keys.join(' / ')}
+                  {getShortcutDisplayLabel(shortcut.id, isMacOS)}
                 </span>
               </div>
             ))}

--- a/ui/leafwiki-ui/src/features/sidebar/Sidebar.tsx
+++ b/ui/leafwiki-ui/src/features/sidebar/Sidebar.tsx
@@ -1,13 +1,17 @@
 import ScrollableContainer from '@/components/ScrollableContainer'
 import { TooltipWrapper } from '@/components/TooltipWrapper'
 import { panelItemRegistry } from '@/lib/registries'
-import { PanelItem } from '@/lib/registries/panelItemRegistry'
+import { createHotkeyDefinition } from '@/lib/shortcuts/shortcutCatalog'
 import { useAppMode } from '@/lib/useAppMode'
 import { useHotKeysStore } from '@/stores/hotkeys'
 import { useSidebarStore } from '@/stores/sidebar'
 import { JSX, useEffect, useMemo } from 'react'
 
 const registeredItems = panelItemRegistry.getAllItems()
+const sidebarShortcutIds: Partial<Record<string, 'sidebar.explorer.open' | 'sidebar.search.open'>> = {
+  tree: 'sidebar.explorer.open',
+  search: 'sidebar.search.open',
+}
 
 export default function Sidebar() {
   const appMode = useAppMode()
@@ -63,14 +67,10 @@ export default function Sidebar() {
     () =>
       items
         .map((item) => {
-          const hotkey = (item as PanelItem).hotkey as string | undefined
-          if (!hotkey) return null
-          return {
-            keyCombo: hotkey,
-            enabled: true,
-            action: actions.get(item.id)!,
-            mode: item.modes ?? ['view', 'edit', 'history'],
-          }
+          const shortcutId = sidebarShortcutIds[item.id]
+          if (!shortcutId) return null
+
+          return createHotkeyDefinition(shortcutId, actions.get(item.id)!)
         })
         .filter(Boolean) as {
         keyCombo: string

--- a/ui/leafwiki-ui/src/features/sidebar/Sidebar.tsx
+++ b/ui/leafwiki-ui/src/features/sidebar/Sidebar.tsx
@@ -8,7 +8,9 @@ import { useSidebarStore } from '@/stores/sidebar'
 import { JSX, useEffect, useMemo } from 'react'
 
 const registeredItems = panelItemRegistry.getAllItems()
-const sidebarShortcutIds: Partial<Record<string, 'sidebar.explorer.open' | 'sidebar.search.open'>> = {
+const sidebarShortcutIds: Partial<
+  Record<string, 'sidebar.explorer.open' | 'sidebar.search.open'>
+> = {
   tree: 'sidebar.explorer.open',
   search: 'sidebar.search.open',
 }

--- a/ui/leafwiki-ui/src/features/viewer/useToolbarActions.tsx
+++ b/ui/leafwiki-ui/src/features/viewer/useToolbarActions.tsx
@@ -1,6 +1,10 @@
 // Hook to provide toolbar actions for the page viewer
 
 import { NODE_KIND_PAGE, type Page } from '@/lib/api/pages'
+import {
+  createHotkeyDefinition,
+  getShortcutDisplayLabel,
+} from '@/lib/shortcuts/shortcutCatalog'
 import { useAppMode } from '@/lib/useAppMode'
 import { useIsReadOnly } from '@/lib/useIsReadOnly'
 import { useConfigStore } from '@/stores/config'
@@ -35,6 +39,9 @@ export function useToolbarActions({
   const registerHotkey = useHotKeysStore((s) => s.registerHotkey)
   const unregisterHotkey = useHotKeysStore((s) => s.unregisterHotkey)
   const itemLabel = pageKind === NODE_KIND_PAGE ? 'Page' : 'Section'
+  const isMacOS =
+    typeof navigator !== 'undefined' &&
+    /Mac|iPhone|iPad|iPod/.test(navigator.platform)
 
   useEffect(() => {
     if (readOnlyMode || appMode !== 'view') {
@@ -46,14 +53,14 @@ export function useToolbarActions({
       {
         id: 'edit-page',
         label: `Edit ${itemLabel}`,
-        hotkey: 'Ctrl+E',
+        hotkey: getShortcutDisplayLabel('viewer.page.edit', isMacOS),
         icon: <Pencil size={18} />,
         action: editPage,
       },
       {
         id: 'page-permalink',
         label: `Share ${itemLabel}`,
-        hotkey: 'Ctrl+Shift+L',
+        hotkey: getShortcutDisplayLabel('viewer.page.permalink', isMacOS),
         icon: <Link2 size={18} />,
         variant: 'outline',
         action: showPermalink,
@@ -61,14 +68,14 @@ export function useToolbarActions({
       {
         id: 'print-page',
         label: `Print ${itemLabel}`,
-        hotkey: 'Ctrl+P',
+        hotkey: getShortcutDisplayLabel('viewer.page.print', isMacOS),
         icon: <Printer size={18} />,
         action: printPage,
       },
       {
         id: 'copy-page',
         label: `Copy ${itemLabel}`,
-        hotkey: 'Ctrl+Shift+S',
+        hotkey: getShortcutDisplayLabel('viewer.page.copy', isMacOS),
         icon: <Copy size={18} />,
         variant: 'outline',
         action: copyPage,
@@ -76,7 +83,7 @@ export function useToolbarActions({
       {
         id: 'delete-page',
         label: `Delete ${itemLabel}`,
-        hotkey: 'Ctrl+Delete',
+        hotkey: getShortcutDisplayLabel('viewer.page.delete', isMacOS),
         icon: <Trash2 size={18} />,
         variant: 'outline',
         destructive: true,
@@ -89,7 +96,7 @@ export function useToolbarActions({
       toolbarButtons.splice(2, 0, {
         id: 'page-history',
         label: `${itemLabel} History`,
-        hotkey: 'Ctrl+H',
+        hotkey: getShortcutDisplayLabel('viewer.page.history', isMacOS),
         icon: <History size={18} />,
         variant: 'outline',
         action: showHistory,
@@ -98,47 +105,35 @@ export function useToolbarActions({
 
     setButtons(toolbarButtons)
 
-    const copyHotkey: HotKeyDefinition = {
-      keyCombo: 'Mod+Shift+KeyS',
-      enabled: true,
-      mode: ['view'],
-      action: copyPage,
-    }
+    const copyHotkey: HotKeyDefinition = createHotkeyDefinition(
+      'viewer.page.copy',
+      copyPage,
+    )
 
-    const permalinkHotkey: HotKeyDefinition = {
-      keyCombo: 'Mod+Shift+KeyL',
-      enabled: true,
-      mode: ['view'],
-      action: showPermalink,
-    }
+    const permalinkHotkey: HotKeyDefinition = createHotkeyDefinition(
+      'viewer.page.permalink',
+      showPermalink,
+    )
 
-    const editHotkey: HotKeyDefinition = {
-      keyCombo: 'Mod+KeyE',
-      enabled: true,
-      mode: ['view'],
-      action: editPage,
-    }
+    const editHotkey: HotKeyDefinition = createHotkeyDefinition(
+      'viewer.page.edit',
+      editPage,
+    )
 
-    const printHotkey: HotKeyDefinition = {
-      keyCombo: 'Mod+KeyP',
-      enabled: true,
-      mode: ['view'],
-      action: printPage,
-    }
+    const printHotkey: HotKeyDefinition = createHotkeyDefinition(
+      'viewer.page.print',
+      printPage,
+    )
 
-    const historyHotkey: HotKeyDefinition = {
-      keyCombo: 'Mod+KeyH',
-      enabled: true,
-      mode: ['view'],
-      action: showHistory,
-    }
+    const historyHotkey: HotKeyDefinition = createHotkeyDefinition(
+      'viewer.page.history',
+      showHistory,
+    )
 
-    const deleteHotkey: HotKeyDefinition = {
-      keyCombo: 'Mod+Delete',
-      enabled: true,
-      mode: ['view'],
-      action: deletePage,
-    }
+    const deleteHotkey: HotKeyDefinition = createHotkeyDefinition(
+      'viewer.page.delete',
+      deletePage,
+    )
 
     registerHotkey(editHotkey)
     registerHotkey(permalinkHotkey)
@@ -173,5 +168,6 @@ export function useToolbarActions({
     registerHotkey,
     unregisterHotkey,
     itemLabel,
+    isMacOS,
   ])
 }

--- a/ui/leafwiki-ui/src/lib/registries/index.tsx
+++ b/ui/leafwiki-ui/src/lib/registries/index.tsx
@@ -15,6 +15,7 @@ import { MovePageDialog } from '@/features/page/MovePageDialog'
 import PermalinkDialog from '@/features/page/PermalinkDialog'
 import { PageRefactorDialog } from '@/features/page/PageRefactorDialog'
 import { SortPagesDialog } from '@/features/page/SortPagesDialog'
+import { ShortcutsDialog } from '@/features/shortcuts/ShortcutsDialog'
 import Search from '@/features/search/Search'
 import TreeView from '@/features/tree/TreeView'
 import { ChangeOwnPasswordDialog } from '@/features/users/ChangeOwnPasswordDialog'
@@ -79,6 +80,7 @@ export const DIALOG_RESTORE_REVISION_CONFIRMATION =
   'restore-revision-confirmation'
 export const DIALOG_LINK_INSERT = 'link-insert'
 export const DIALOG_WIKILINK_DISAMBIGUATION = 'wikilink-disambiguation'
+export const DIALOG_SHORTCUTS_HELP = 'shortcuts-help'
 
 dialogRegistry.register({
   type: DIALOG_ADD_PAGE,
@@ -247,6 +249,13 @@ dialogRegistry.register({
   type: DIALOG_PAGE_QUICK_SWITCHER,
   render: () => {
     return <PageQuickSwitcherDialog key={DIALOG_PAGE_QUICK_SWITCHER} />
+  },
+})
+
+dialogRegistry.register({
+  type: DIALOG_SHORTCUTS_HELP,
+  render: () => {
+    return <ShortcutsDialog key={DIALOG_SHORTCUTS_HELP} />
   },
 })
 

--- a/ui/leafwiki-ui/src/lib/registries/index.tsx
+++ b/ui/leafwiki-ui/src/lib/registries/index.tsx
@@ -24,6 +24,7 @@ import { DeleteUserDialog } from '@/features/users/DeleteUserDialog'
 import { UserFormDialog } from '@/features/users/UserFormDialog'
 import { DialogRegistry } from '@/lib/registries/dialogRegistry'
 import { PanelItemRegistry } from '@/lib/registries/panelItemRegistry'
+import { getShortcutDefinition } from '@/lib/shortcuts/shortcutCatalog'
 import { FolderTree, Search as SearchIcon } from 'lucide-react'
 
 export const panelItemRegistry = new PanelItemRegistry()
@@ -37,7 +38,7 @@ export const SIDEBAR_SEARCH_PANEL_ID = 'search'
 panelItemRegistry.register({
   id: SIDEBAR_TREE_PANEL_ID,
   label: 'Explorer',
-  hotkey: 'Mod+Shift+KeyE',
+  hotkey: getShortcutDefinition('sidebar.explorer.open').keyCombo,
   modes: ['view', 'edit', 'history', 'settings', 'user-management'],
   icon: () => <FolderTree size={16} />,
   render: () => {
@@ -48,7 +49,7 @@ panelItemRegistry.register({
 panelItemRegistry.register({
   id: SIDEBAR_SEARCH_PANEL_ID,
   label: 'Search',
-  hotkey: 'Mod+Shift+KeyF',
+  hotkey: getShortcutDefinition('sidebar.search.open').keyCombo,
   modes: ['view', 'edit', 'history', 'settings', 'user-management'],
   icon: () => <SearchIcon size={16} />,
   render: (props: unknown) => {

--- a/ui/leafwiki-ui/src/lib/shortcuts/shortcutCatalog.test.ts
+++ b/ui/leafwiki-ui/src/lib/shortcuts/shortcutCatalog.test.ts
@@ -49,13 +49,13 @@ describe('shortcutCatalog', () => {
       'sidebar.search.open',
     ])
 
-    expect(getVisibleShortcutsForMode('history').map((item) => item.id)).toEqual(
-      [
-        'history.page.close',
-        'sidebar.explorer.open',
-        'sidebar.search.open',
-      ],
-    )
+    expect(
+      getVisibleShortcutsForMode('history').map((item) => item.id),
+    ).toEqual([
+      'history.page.close',
+      'sidebar.explorer.open',
+      'sidebar.search.open',
+    ])
   })
 
   it('includes the remaining viewer and editor shortcuts in the catalog', () => {

--- a/ui/leafwiki-ui/src/lib/shortcuts/shortcutCatalog.test.ts
+++ b/ui/leafwiki-ui/src/lib/shortcuts/shortcutCatalog.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createHotkeyDefinition,
+  getShortcutDefinition,
+  getShortcutDisplayLabel,
+  getVisibleShortcutsForMode,
+  shortcutDefinitions,
+} from './shortcutCatalog'
+
+describe('shortcutCatalog', () => {
+  it('defines unique shortcut ids', () => {
+    const ids = shortcutDefinitions.map((definition) => definition.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('returns the registered definition for a known shortcut', () => {
+    expect(getShortcutDefinition('page.quickSwitcher.open')).toMatchObject({
+      id: 'page.quickSwitcher.open',
+      keyCombo: 'Mod+Alt+KeyP',
+      modes: ['view'],
+      labelKey: 'shortcutsHelp.items.goToPage.action',
+    })
+  })
+
+  it('filters visible shortcuts by the current mode', () => {
+    expect(getVisibleShortcutsForMode('view').map((item) => item.id)).toEqual([
+      'viewer.page.copy',
+      'viewer.page.delete',
+      'viewer.page.edit',
+      'page.quickSwitcher.open',
+      'viewer.page.history',
+      'viewer.page.print',
+      'viewer.page.permalink',
+      'sidebar.explorer.open',
+      'sidebar.search.open',
+    ])
+
+    expect(getVisibleShortcutsForMode('edit').map((item) => item.id)).toEqual([
+      'editor.page.close',
+      'editor.format.bold',
+      'editor.format.inlineCode',
+      'editor.format.italic',
+      'editor.heading.one',
+      'editor.heading.three',
+      'editor.heading.two',
+      'editor.link.insert',
+      'editor.page.save',
+      'sidebar.explorer.open',
+      'sidebar.search.open',
+    ])
+
+    expect(getVisibleShortcutsForMode('history').map((item) => item.id)).toEqual(
+      [
+        'history.page.close',
+        'sidebar.explorer.open',
+        'sidebar.search.open',
+      ],
+    )
+  })
+
+  it('includes the remaining viewer and editor shortcuts in the catalog', () => {
+    expect(getShortcutDefinition('viewer.page.edit').keyCombo).toBe('Mod+KeyE')
+    expect(getShortcutDefinition('viewer.page.history').keyCombo).toBe(
+      'Mod+KeyH',
+    )
+    expect(getShortcutDefinition('editor.format.bold').keyCombo).toBe(
+      'Mod+KeyB',
+    )
+    expect(getShortcutDefinition('editor.link.insert').keyCombo).toBe(
+      'Mod+KeyK',
+    )
+  })
+
+  it('returns platform-specific display labels', () => {
+    expect(getShortcutDisplayLabel('page.quickSwitcher.open', false)).toBe(
+      'Ctrl+Alt+P',
+    )
+    expect(getShortcutDisplayLabel('page.quickSwitcher.open', true)).toBe(
+      'Cmd+Option+P',
+    )
+    expect(getShortcutDisplayLabel('sidebar.explorer.open', false)).toBe(
+      'Ctrl+Shift+E',
+    )
+    expect(getShortcutDisplayLabel('viewer.page.delete', false)).toBe(
+      'Ctrl+Delete',
+    )
+    expect(getShortcutDisplayLabel('editor.heading.one', true)).toBe(
+      'Cmd+Option+1',
+    )
+  })
+
+  it('creates a hotkey definition with the catalog combo and modes', () => {
+    const hotkey = createHotkeyDefinition('history.page.close', () => undefined)
+
+    expect(hotkey).toMatchObject({
+      keyCombo: 'Escape',
+      enabled: true,
+      mode: ['history'],
+    })
+  })
+
+  it('supports generic dialog and asset rename shortcuts', () => {
+    expect(getShortcutDefinition('dialog.close').keyCombo).toBe('Escape')
+    expect(getShortcutDefinition('dialog.confirm').keyCombo).toBe('Enter')
+    expect(getShortcutDefinition('asset.rename.confirm').keyCombo).toBe('Enter')
+    expect(getShortcutDefinition('asset.rename.cancel').keyCombo).toBe('Escape')
+  })
+})

--- a/ui/leafwiki-ui/src/lib/shortcuts/shortcutCatalog.ts
+++ b/ui/leafwiki-ui/src/lib/shortcuts/shortcutCatalog.ts
@@ -1,0 +1,319 @@
+import i18next from '@/lib/i18n'
+import { AppMode } from '@/lib/useAppMode'
+import { HotKeyDefinition } from '@/stores/hotkeys'
+
+export type ShortcutId =
+  | 'dialog.close'
+  | 'dialog.confirm'
+  | 'page.quickSwitcher.open'
+  | 'sidebar.explorer.open'
+  | 'sidebar.search.open'
+  | 'viewer.page.edit'
+  | 'viewer.page.permalink'
+  | 'viewer.page.print'
+  | 'viewer.page.copy'
+  | 'viewer.page.delete'
+  | 'viewer.page.history'
+  | 'editor.page.close'
+  | 'editor.page.save'
+  | 'editor.format.bold'
+  | 'editor.format.italic'
+  | 'editor.heading.one'
+  | 'editor.heading.two'
+  | 'editor.heading.three'
+  | 'editor.format.inlineCode'
+  | 'editor.link.insert'
+  | 'history.page.close'
+  | 'asset.rename.confirm'
+  | 'asset.rename.cancel'
+
+export type ShortcutDefinition = {
+  id: ShortcutId
+  labelKey: string
+  categoryKey: string
+  keyCombo: string
+  defaultDisplayLabel: string
+  macDisplayLabel?: string
+  modes: AppMode[]
+  customizable: boolean
+}
+
+export const shortcutDefinitions: ShortcutDefinition[] = [
+  {
+    id: 'dialog.close',
+    labelKey: 'shortcutsHelp.items.closeDialog.action',
+    categoryKey: 'shortcutsHelp.categories.dialogs',
+    keyCombo: 'Escape',
+    defaultDisplayLabel: 'Esc',
+    modes: ['dialog'],
+    customizable: false,
+  },
+  {
+    id: 'dialog.confirm',
+    labelKey: 'shortcutsHelp.items.confirmDialog.action',
+    categoryKey: 'shortcutsHelp.categories.dialogs',
+    keyCombo: 'Enter',
+    defaultDisplayLabel: 'Enter',
+    modes: ['dialog'],
+    customizable: false,
+  },
+  {
+    id: 'page.quickSwitcher.open',
+    labelKey: 'shortcutsHelp.items.goToPage.action',
+    categoryKey: 'shortcutsHelp.categories.navigation',
+    keyCombo: 'Mod+Alt+KeyP',
+    defaultDisplayLabel: 'Ctrl+Alt+P',
+    macDisplayLabel: 'Cmd+Option+P',
+    modes: ['view'],
+    customizable: true,
+  },
+  {
+    id: 'sidebar.explorer.open',
+    labelKey: 'shortcutsHelp.items.openExplorer.action',
+    categoryKey: 'shortcutsHelp.categories.navigation',
+    keyCombo: 'Mod+Shift+KeyE',
+    defaultDisplayLabel: 'Ctrl+Shift+E',
+    macDisplayLabel: 'Cmd+Shift+E',
+    modes: ['view', 'edit', 'history', 'settings', 'user-management'],
+    customizable: true,
+  },
+  {
+    id: 'sidebar.search.open',
+    labelKey: 'shortcutsHelp.items.openSearch.action',
+    categoryKey: 'shortcutsHelp.categories.navigation',
+    keyCombo: 'Mod+Shift+KeyF',
+    defaultDisplayLabel: 'Ctrl+Shift+F',
+    macDisplayLabel: 'Cmd+Shift+F',
+    modes: ['view', 'edit', 'history', 'settings', 'user-management'],
+    customizable: true,
+  },
+  {
+    id: 'viewer.page.edit',
+    labelKey: 'shortcutsHelp.items.editPage.action',
+    categoryKey: 'shortcutsHelp.categories.viewing',
+    keyCombo: 'Mod+KeyE',
+    defaultDisplayLabel: 'Ctrl+E',
+    macDisplayLabel: 'Cmd+E',
+    modes: ['view'],
+    customizable: true,
+  },
+  {
+    id: 'viewer.page.permalink',
+    labelKey: 'shortcutsHelp.items.sharePage.action',
+    categoryKey: 'shortcutsHelp.categories.viewing',
+    keyCombo: 'Mod+Shift+KeyL',
+    defaultDisplayLabel: 'Ctrl+Shift+L',
+    macDisplayLabel: 'Cmd+Shift+L',
+    modes: ['view'],
+    customizable: true,
+  },
+  {
+    id: 'viewer.page.print',
+    labelKey: 'shortcutsHelp.items.printPage.action',
+    categoryKey: 'shortcutsHelp.categories.viewing',
+    keyCombo: 'Mod+KeyP',
+    defaultDisplayLabel: 'Ctrl+P',
+    macDisplayLabel: 'Cmd+P',
+    modes: ['view'],
+    customizable: true,
+  },
+  {
+    id: 'viewer.page.copy',
+    labelKey: 'shortcutsHelp.items.copyPage.action',
+    categoryKey: 'shortcutsHelp.categories.viewing',
+    keyCombo: 'Mod+Shift+KeyS',
+    defaultDisplayLabel: 'Ctrl+Shift+S',
+    macDisplayLabel: 'Cmd+Shift+S',
+    modes: ['view'],
+    customizable: true,
+  },
+  {
+    id: 'viewer.page.delete',
+    labelKey: 'shortcutsHelp.items.deletePage.action',
+    categoryKey: 'shortcutsHelp.categories.viewing',
+    keyCombo: 'Mod+Delete',
+    defaultDisplayLabel: 'Ctrl+Delete',
+    macDisplayLabel: 'Cmd+Delete',
+    modes: ['view'],
+    customizable: true,
+  },
+  {
+    id: 'viewer.page.history',
+    labelKey: 'shortcutsHelp.items.pageHistory.action',
+    categoryKey: 'shortcutsHelp.categories.viewing',
+    keyCombo: 'Mod+KeyH',
+    defaultDisplayLabel: 'Ctrl+H',
+    macDisplayLabel: 'Cmd+H',
+    modes: ['view'],
+    customizable: true,
+  },
+  {
+    id: 'editor.page.close',
+    labelKey: 'shortcutsHelp.items.closeEditor.action',
+    categoryKey: 'shortcutsHelp.categories.editing',
+    keyCombo: 'Escape',
+    defaultDisplayLabel: 'Esc',
+    modes: ['edit'],
+    customizable: false,
+  },
+  {
+    id: 'editor.page.save',
+    labelKey: 'shortcutsHelp.items.savePage.action',
+    categoryKey: 'shortcutsHelp.categories.editing',
+    keyCombo: 'Mod+KeyS',
+    defaultDisplayLabel: 'Ctrl+S',
+    macDisplayLabel: 'Cmd+S',
+    modes: ['edit'],
+    customizable: true,
+  },
+  {
+    id: 'editor.format.bold',
+    labelKey: 'shortcutsHelp.items.formatBold.action',
+    categoryKey: 'shortcutsHelp.categories.editing',
+    keyCombo: 'Mod+KeyB',
+    defaultDisplayLabel: 'Ctrl+B',
+    macDisplayLabel: 'Cmd+B',
+    modes: ['edit'],
+    customizable: true,
+  },
+  {
+    id: 'editor.format.italic',
+    labelKey: 'shortcutsHelp.items.formatItalic.action',
+    categoryKey: 'shortcutsHelp.categories.editing',
+    keyCombo: 'Mod+KeyI',
+    defaultDisplayLabel: 'Ctrl+I',
+    macDisplayLabel: 'Cmd+I',
+    modes: ['edit'],
+    customizable: true,
+  },
+  {
+    id: 'editor.heading.one',
+    labelKey: 'shortcutsHelp.items.insertHeadingOne.action',
+    categoryKey: 'shortcutsHelp.categories.editing',
+    keyCombo: 'Mod+Alt+Digit1',
+    defaultDisplayLabel: 'Ctrl+Alt+1',
+    macDisplayLabel: 'Cmd+Option+1',
+    modes: ['edit'],
+    customizable: true,
+  },
+  {
+    id: 'editor.heading.two',
+    labelKey: 'shortcutsHelp.items.insertHeadingTwo.action',
+    categoryKey: 'shortcutsHelp.categories.editing',
+    keyCombo: 'Mod+Alt+Digit2',
+    defaultDisplayLabel: 'Ctrl+Alt+2',
+    macDisplayLabel: 'Cmd+Option+2',
+    modes: ['edit'],
+    customizable: true,
+  },
+  {
+    id: 'editor.heading.three',
+    labelKey: 'shortcutsHelp.items.insertHeadingThree.action',
+    categoryKey: 'shortcutsHelp.categories.editing',
+    keyCombo: 'Mod+Alt+Digit3',
+    defaultDisplayLabel: 'Ctrl+Alt+3',
+    macDisplayLabel: 'Cmd+Option+3',
+    modes: ['edit'],
+    customizable: true,
+  },
+  {
+    id: 'editor.format.inlineCode',
+    labelKey: 'shortcutsHelp.items.formatInlineCode.action',
+    categoryKey: 'shortcutsHelp.categories.editing',
+    keyCombo: 'Mod+Backquote',
+    defaultDisplayLabel: 'Ctrl+`',
+    macDisplayLabel: 'Cmd+`',
+    modes: ['edit'],
+    customizable: true,
+  },
+  {
+    id: 'editor.link.insert',
+    labelKey: 'shortcutsHelp.items.insertLink.action',
+    categoryKey: 'shortcutsHelp.categories.editing',
+    keyCombo: 'Mod+KeyK',
+    defaultDisplayLabel: 'Ctrl+K',
+    macDisplayLabel: 'Cmd+K',
+    modes: ['edit'],
+    customizable: true,
+  },
+  {
+    id: 'history.page.close',
+    labelKey: 'shortcutsHelp.items.backToPage.action',
+    categoryKey: 'shortcutsHelp.categories.navigation',
+    keyCombo: 'Escape',
+    defaultDisplayLabel: 'Esc',
+    modes: ['history'],
+    customizable: false,
+  },
+  {
+    id: 'asset.rename.confirm',
+    labelKey: 'shortcutsHelp.items.confirmRename.action',
+    categoryKey: 'shortcutsHelp.categories.dialogs',
+    keyCombo: 'Enter',
+    defaultDisplayLabel: 'Enter',
+    modes: ['dialog'],
+    customizable: false,
+  },
+  {
+    id: 'asset.rename.cancel',
+    labelKey: 'shortcutsHelp.items.cancelRename.action',
+    categoryKey: 'shortcutsHelp.categories.dialogs',
+    keyCombo: 'Escape',
+    defaultDisplayLabel: 'Esc',
+    modes: ['dialog'],
+    customizable: false,
+  },
+]
+
+const shortcutDefinitionMap = new Map(
+  shortcutDefinitions.map((definition) => [definition.id, definition]),
+)
+
+export function getShortcutDefinition(id: ShortcutId): ShortcutDefinition {
+  const definition = shortcutDefinitionMap.get(id)
+
+  if (!definition) {
+    throw new Error(`Shortcut definition for "${id}" not found.`)
+  }
+
+  return definition
+}
+
+export function getVisibleShortcutsForMode(mode: AppMode): ShortcutDefinition[] {
+  return shortcutDefinitions
+    .filter((definition) => definition.modes.includes(mode))
+    .sort((left, right) => {
+      if (left.modes.length !== right.modes.length) {
+        return left.modes.length - right.modes.length
+      }
+
+      return left.labelKey.localeCompare(right.labelKey)
+    })
+}
+
+export function getShortcutDisplayLabel(id: ShortcutId, isMacOS: boolean) {
+  const definition = getShortcutDefinition(id)
+  return isMacOS && definition.macDisplayLabel
+    ? definition.macDisplayLabel
+    : definition.defaultDisplayLabel
+}
+
+export function createHotkeyDefinition(
+  id: ShortcutId,
+  action: () => void,
+  options?: Partial<Pick<HotKeyDefinition, 'enabled' | 'shouldHandle'>>,
+): HotKeyDefinition {
+  const definition = getShortcutDefinition(id)
+
+  return {
+    keyCombo: definition.keyCombo,
+    enabled: options?.enabled ?? true,
+    mode: definition.modes,
+    shouldHandle: options?.shouldHandle,
+    action,
+  }
+}
+
+export function getShortcutLabel(id: ShortcutId) {
+  return i18next.t(getShortcutDefinition(id).labelKey, { ns: 'viewer' })
+}

--- a/ui/leafwiki-ui/src/lib/shortcuts/shortcutCatalog.ts
+++ b/ui/leafwiki-ui/src/lib/shortcuts/shortcutCatalog.ts
@@ -279,7 +279,9 @@ export function getShortcutDefinition(id: ShortcutId): ShortcutDefinition {
   return definition
 }
 
-export function getVisibleShortcutsForMode(mode: AppMode): ShortcutDefinition[] {
+export function getVisibleShortcutsForMode(
+  mode: AppMode,
+): ShortcutDefinition[] {
   return shortcutDefinitions
     .filter((definition) => definition.modes.includes(mode))
     .sort((left, right) => {

--- a/ui/leafwiki-ui/src/locales/en/viewer.json
+++ b/ui/leafwiki-ui/src/locales/en/viewer.json
@@ -26,10 +26,43 @@
     "menuItem": "Keyboard Shortcuts",
     "title": "Available keyboard shortcuts",
     "description": "A quick overview of the shortcuts that are currently available in LeafWiki.",
+    "currentMode": "Available in {{mode}} mode",
     "closeButton": "Close",
+    "categories": {
+      "navigation": "Navigation",
+      "editing": "Editing",
+      "viewing": "Viewing",
+      "dialogs": "Dialogs"
+    },
+    "modes": {
+      "view": "view",
+      "edit": "edit",
+      "history": "history",
+      "settings": "settings",
+      "user-management": "user management",
+      "dialog": "dialog"
+    },
     "items": {
       "goToPage": {
         "action": "Go to page"
+      },
+      "editPage": {
+        "action": "Edit page"
+      },
+      "sharePage": {
+        "action": "Share page"
+      },
+      "printPage": {
+        "action": "Print page"
+      },
+      "copyPage": {
+        "action": "Copy page"
+      },
+      "deletePage": {
+        "action": "Delete page"
+      },
+      "pageHistory": {
+        "action": "Page history"
       },
       "openExplorer": {
         "action": "Open explorer"
@@ -37,8 +70,47 @@
       "openSearch": {
         "action": "Open search"
       },
+      "savePage": {
+        "action": "Save page"
+      },
+      "closeEditor": {
+        "action": "Close editor"
+      },
+      "formatBold": {
+        "action": "Format bold"
+      },
+      "formatItalic": {
+        "action": "Format italic"
+      },
+      "insertHeadingOne": {
+        "action": "Insert heading 1"
+      },
+      "insertHeadingTwo": {
+        "action": "Insert heading 2"
+      },
+      "insertHeadingThree": {
+        "action": "Insert heading 3"
+      },
+      "formatInlineCode": {
+        "action": "Format inline code"
+      },
+      "insertLink": {
+        "action": "Insert link"
+      },
+      "backToPage": {
+        "action": "Back to page"
+      },
       "closeDialog": {
         "action": "Close dialog"
+      },
+      "confirmDialog": {
+        "action": "Confirm dialog"
+      },
+      "confirmRename": {
+        "action": "Confirm rename"
+      },
+      "cancelRename": {
+        "action": "Cancel rename"
       }
     }
   }

--- a/ui/leafwiki-ui/src/locales/en/viewer.json
+++ b/ui/leafwiki-ui/src/locales/en/viewer.json
@@ -21,5 +21,25 @@
     "noBrokenLinks": "No broken links.",
     "brokenOutgoingsTitle": "This page links to missing targets",
     "brokenIncomingTitle": "Pages linking to an old path"
+  },
+  "shortcutsHelp": {
+    "menuItem": "Keyboard Shortcuts",
+    "title": "Available keyboard shortcuts",
+    "description": "A quick overview of the shortcuts that are currently available in LeafWiki.",
+    "closeButton": "Close",
+    "items": {
+      "goToPage": {
+        "action": "Go to page"
+      },
+      "openExplorer": {
+        "action": "Open explorer"
+      },
+      "openSearch": {
+        "action": "Open search"
+      },
+      "closeDialog": {
+        "action": "Close dialog"
+      }
+    }
   }
 }


### PR DESCRIPTION
Add a shortcuts overview dialog to the user menu using the existing dialog registry so the first UI entry point lands without touching hotkey infrastructure.

Include viewer translations and a focused component test that verifies the dialog opens from the user menu.