### PR TITLE
refactor(backup): use time.Duration for backup interval end-to-end

### DIFF
--- a/cmd/leafwiki/main.go
+++ b/cmd/leafwiki/main.go
@@ -63,7 +63,7 @@ func writeUsage(w io.Writer) {
 	--git-backup-ssh-key-path      Path to SSH private key for git backup
 	--git-backup-ssh-key           Raw SSH private key for git backup (env var preferred)
 	--git-backup-ssh-known-hosts   Path to known_hosts file for SSH host key verification (MITM protection)
-	--git-backup-interval          Git backup interval in minutes; 0 = manual-only, no automatic scheduling (default: 60)
+	--git-backup-interval          Git backup interval (e.g. 60m, 2h); 0 = manual-only, no automatic scheduling (default: 60m)
 
 	Environment variables:
 	LEAFWIKI_HOST
@@ -163,7 +163,7 @@ type cliFlags struct {
 	gitBackupSSHKeyPath     *string
 	gitBackupSSHKey         *string
 	gitBackupSSHKnownHosts  *string
-	gitBackupInterval       *int
+	gitBackupInterval       *time.Duration
 }
 
 func registerFlags(fs *flag.FlagSet) *cliFlags {
@@ -199,7 +199,7 @@ func registerFlags(fs *flag.FlagSet) *cliFlags {
 		gitBackupSSHKeyPath:     fs.String("git-backup-ssh-key-path", "", "path to SSH private key for git backup"),
 		gitBackupSSHKey:         fs.String("git-backup-ssh-key", "", "raw SSH private key for git backup (env var preferred)"),
 		gitBackupSSHKnownHosts:  fs.String("git-backup-ssh-known-hosts", "", "path to known_hosts file for SSH host key verification (MITM protection)"),
-		gitBackupInterval:       fs.Int("git-backup-interval", 0, "git backup interval in minutes (default: 60)"),
+		gitBackupInterval:       fs.Duration("git-backup-interval", 60*time.Minute, "git backup interval (e.g. 60m, 2h); 0 = manual-only, no automatic scheduling (default: 60m)"),
 	}
 }
 
@@ -250,7 +250,7 @@ func main() {
 	gitBackupBranch := resolveString("git-backup-branch", *flags.gitBackupBranch, visited, "LEAFWIKI_GIT_BACKUP_BRANCH", "main")
 	gitBackupSSHKeyPath := resolveString("git-backup-ssh-key-path", *flags.gitBackupSSHKeyPath, visited, "LEAFWIKI_GIT_BACKUP_SSH_KEY_PATH", "")
 	gitBackupSSHKey := resolveString("git-backup-ssh-key", *flags.gitBackupSSHKey, visited, "LEAFWIKI_GIT_BACKUP_SSH_KEY", "")
-	gitBackupInterval := resolveInt("git-backup-interval", *flags.gitBackupInterval, visited, "LEAFWIKI_GIT_BACKUP_INTERVAL", 60)
+	gitBackupInterval := resolveDuration("git-backup-interval", *flags.gitBackupInterval, visited, "LEAFWIKI_GIT_BACKUP_INTERVAL")
 	gitBackupSSHKnownHosts := resolveString("git-backup-ssh-known-hosts", *flags.gitBackupSSHKnownHosts, visited, "LEAFWIKI_GIT_BACKUP_SSH_KNOWN_HOSTS", "")
 	trustedProxies, err := authmw.ParseTrustedProxies(trustedProxyIPsRaw)
 	if err != nil {
@@ -362,12 +362,12 @@ func main() {
 			SSHKeyPath:        gitBackupSSHKeyPath,
 			SSHKey:            gitBackupSSHKey,
 			SSHKnownHostsPath: gitBackupSSHKnownHosts,
-			IntervalMinutes:   gitBackupInterval,
+			Interval:          gitBackupInterval,
 		})
 		if err != nil {
 			fail("git backup init failed: %v", err)
 		}
-		backupScheduler = backup.NewScheduler(backupRepo, time.Duration(gitBackupInterval)*time.Minute)
+		backupScheduler = backup.NewScheduler(backupRepo)
 		defer backupScheduler.Stop()
 		w.SetBackupRoutes(wikibackup.NewRoutes(backupRepo, backupScheduler, w.AuthService()))
 	}

--- a/internal/backup/config.go
+++ b/internal/backup/config.go
@@ -3,20 +3,15 @@ package backup
 import "time"
 
 type Config struct {
-	Enabled        bool
-	RootDir        string   // path to LeafWiki root/ content directory
-	AssetsDir      string   // path to LeafWiki assets/ directory
-	AuthorName     string
-	AuthorEmail    string
-	RemoteURL      string   // SSH remote, e.g. git@github.com:user/repo.git
-	Branch         string   // remote branch to push to, default "main"
-	SSHKeyPath     string   // path to private key file (optional if SSHKey set)
-	SSHKey         string   // raw PEM private key (env var preferred)
-	SSHKnownHostsPath string // path to known_hosts file for MITM protection (optional)
-	IntervalMinutes int     // how often to run the scheduled backup, default 60
-}
-
-// Duration returns the interval as a time.Duration.
-func (c *Config) Duration() time.Duration {
-	return time.Duration(c.IntervalMinutes) * time.Minute
+	Enabled           bool
+	RootDir           string // path to LeafWiki root/ content directory
+	AssetsDir         string // path to LeafWiki assets/ directory
+	AuthorName        string
+	AuthorEmail       string
+	RemoteURL         string        // SSH remote, e.g. git@github.com:user/repo.git
+	Branch            string        // remote branch to push to, default "main"
+	SSHKeyPath        string        // path to private key file (optional if SSHKey set)
+	SSHKey            string        // raw PEM private key (env var preferred)
+	SSHKnownHostsPath string        // path to known_hosts file for MITM protection (optional)
+	Interval          time.Duration // how often to run the scheduled backup; 0 = manual-only
 }

--- a/internal/backup/scheduler.go
+++ b/internal/backup/scheduler.go
@@ -22,8 +22,16 @@ type Scheduler struct {
 }
 
 // NewScheduler creates and starts the background goroutine.
-// Pass interval == 0 to disable automatic periodic backups (manual-only mode).
-func NewScheduler(repo *Repository, interval time.Duration) *Scheduler {
+// The interval is taken from repo.cfg.Interval; 0 = manual-only mode.
+func NewScheduler(repo *Repository) *Scheduler {
+	interval := repo.cfg.Interval
+
+	if interval < 0 {
+		slog.Warn("backup scheduler interval is negative, switching to manual-only mode", "requested", interval)
+		interval = 0
+		repo.cfg.Interval = 0
+	}
+
 	s := &Scheduler{
 		repo:   repo,
 		manual: make(chan struct{}, 1),
@@ -34,6 +42,7 @@ func NewScheduler(repo *Repository, interval time.Duration) *Scheduler {
 		if interval < minInterval {
 			slog.Warn("backup scheduler interval too small, using minimum", "requested", interval, "using", minInterval)
 			interval = minInterval
+			repo.cfg.Interval = minInterval
 		}
 		s.ticker = time.NewTicker(interval)
 	}

--- a/internal/backup/scheduler_test.go
+++ b/internal/backup/scheduler_test.go
@@ -40,12 +40,12 @@ func TestScheduler_TriggerNow(t *testing.T) {
 	}
 
 	cfg := Config{
-		RootDir:       rootDir,
-		AssetsDir:     assetsDir,
-		AuthorName:    "Test Author",
-		AuthorEmail:   "test@example.com",
-		Branch:        "main",
-		IntervalMinutes: 10,
+		RootDir:     rootDir,
+		AssetsDir:   assetsDir,
+		AuthorName:  "Test Author",
+		AuthorEmail: "test@example.com",
+		Branch:      "main",
+		Interval:    10 * time.Minute,
 	}
 
 	repo, err := Init(cfg)
@@ -59,7 +59,7 @@ func TestScheduler_TriggerNow(t *testing.T) {
 	}
 
 	// Create scheduler with a long interval so it won't fire naturally
-	scheduler := NewScheduler(repo, cfg.Duration())
+	scheduler := NewScheduler(repo)
 	defer scheduler.Stop()
 
 	// Wait for the initial run to complete
@@ -100,12 +100,12 @@ func TestScheduler_Stop(t *testing.T) {
 	}
 
 	cfg := Config{
-		RootDir:       rootDir,
-		AssetsDir:     assetsDir,
-		AuthorName:    "Test Author",
-		AuthorEmail:   "test@example.com",
-		Branch:        "main",
-		IntervalMinutes: 10,
+		RootDir:     rootDir,
+		AssetsDir:   assetsDir,
+		AuthorName:  "Test Author",
+		AuthorEmail: "test@example.com",
+		Branch:      "main",
+		Interval:    10 * time.Minute,
 	}
 
 	repo, err := Init(cfg)
@@ -113,7 +113,7 @@ func TestScheduler_Stop(t *testing.T) {
 		t.Fatalf("Init failed: %v", err)
 	}
 
-	scheduler := NewScheduler(repo, cfg.Duration())
+	scheduler := NewScheduler(repo)
 
 	// Stop should block until goroutine finishes
 	scheduler.Stop()
@@ -137,12 +137,12 @@ func TestScheduler_RunsOnStart(t *testing.T) {
 	}
 
 	cfg := Config{
-		RootDir:       rootDir,
-		AssetsDir:     assetsDir,
-		AuthorName:    "Test Author",
-		AuthorEmail:   "test@example.com",
-		Branch:        "main",
-		IntervalMinutes: 600,
+		RootDir:     rootDir,
+		AssetsDir:   assetsDir,
+		AuthorName:  "Test Author",
+		AuthorEmail: "test@example.com",
+		Branch:      "main",
+		Interval:    600 * time.Minute,
 	}
 
 	repo, err := Init(cfg)
@@ -156,7 +156,7 @@ func TestScheduler_RunsOnStart(t *testing.T) {
 	}
 
 	// Create scheduler with very long interval
-	scheduler := NewScheduler(repo, cfg.Duration())
+	scheduler := NewScheduler(repo)
 	defer scheduler.Stop()
 
 	// Wait for the initial run to complete

--- a/internal/backup/scheduler_test.go
+++ b/internal/backup/scheduler_test.go
@@ -122,6 +122,57 @@ func TestScheduler_Stop(t *testing.T) {
 	scheduler.Stop()
 }
 
+func makeRepo(t *testing.T, interval time.Duration) *Repository {
+	t.Helper()
+	tmpDir := t.TempDir()
+	rootDir := filepath.Join(tmpDir, "root")
+	assetsDir := filepath.Join(tmpDir, "assets")
+	if err := os.MkdirAll(rootDir, 0755); err != nil {
+		t.Fatalf("failed to create root dir: %v", err)
+	}
+	if err := os.MkdirAll(assetsDir, 0755); err != nil {
+		t.Fatalf("failed to create assets dir: %v", err)
+	}
+	repo, err := Init(Config{
+		RootDir:     rootDir,
+		AssetsDir:   assetsDir,
+		AuthorName:  "Test Author",
+		AuthorEmail: "test@example.com",
+		Branch:      "main",
+		Interval:    interval,
+	})
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	return repo
+}
+
+func TestScheduler_NegativeInterval_ManualOnly(t *testing.T) {
+	repo := makeRepo(t, -5*time.Minute)
+	scheduler := NewScheduler(repo)
+	defer scheduler.Stop()
+
+	if repo.cfg.Interval != 0 {
+		t.Errorf("expected cfg.Interval to be clamped to 0, got %v", repo.cfg.Interval)
+	}
+	if scheduler.ticker != nil {
+		t.Error("expected no ticker in manual-only mode")
+	}
+}
+
+func TestScheduler_SubMinuteInterval_ClampedToMinimum(t *testing.T) {
+	repo := makeRepo(t, 10*time.Second)
+	scheduler := NewScheduler(repo)
+	defer scheduler.Stop()
+
+	if repo.cfg.Interval != minInterval {
+		t.Errorf("expected cfg.Interval to be clamped to %v, got %v", minInterval, repo.cfg.Interval)
+	}
+	if scheduler.ticker == nil {
+		t.Error("expected ticker to be running at minimum interval")
+	}
+}
+
 func TestScheduler_RunsOnStart(t *testing.T) {
 	tmpDir := t.TempDir()
 	rootDir := filepath.Join(tmpDir, "root")


### PR DESCRIPTION
Replace IntervalMinutes int with Interval time.Duration in Config, migrate --git-backup-interval flag from fs.Int (minutes) to fs.Duration so operators can use duration strings like 60m or 2h, and remove the redundant interval parameter from NewScheduler so Config is the single source of truth. Negative and sub-minute values are now guarded with an explicit warning and written back to cfg.Interval so the stored config always reflects what the scheduler actually uses.