### PR TITLE
fix: strip WikiLinks from plain-text excerpts and refactor dialog

### DIFF
--- a/e2e/tests/wikilinks-refactor.spec.ts
+++ b/e2e/tests/wikilinks-refactor.spec.ts
@@ -286,10 +286,10 @@ test.describe('WikiLink [[Title]] refactoring and link status', () => {
     await movePageDialog.expectAffectedPagesCount(1);
     await movePageDialog.expectAffectedPageTitle(refTitle);
 
-    // The matched-path column must show [[Title]] syntax, not a raw path.
+    // The matched-path column must show the title, not raw [[Title]] wiki-link syntax.
     await expect(
       page.locator('[data-testid="page-refactor-dialog-affected-page-matches"]'),
-    ).toContainText(`[[${targetTitle}]]`);
+    ).toContainText(targetTitle);
 
     await movePageDialog.confirmRefactorDialog();
 

--- a/internal/core/excerpt/excerpt.go
+++ b/internal/core/excerpt/excerpt.go
@@ -25,9 +25,9 @@ var (
 	linkPattern          = regexp.MustCompile(`\[([^\]]+)\]\([^)]+\)`)
 	htmlPattern          = regexp.MustCompile(`<[^>]+>`)
 	linePrefixPattern    = regexp.MustCompile(`(?m)^\s{0,3}(#{1,6}\s*|[-*+]\s+|\d+\.\s+|>\s?)`)
-	wikiImagePattern     = regexp.MustCompile(`!\[\[[^\]]*\]\]`)
-	wikiLinkAliasPattern = regexp.MustCompile(`\[\[[^\]|]+\|([^\]]+)\]\]`)
-	wikiLinkPattern      = regexp.MustCompile(`\[\[([^\]]+)\]\]`)
+	wikiImagePattern     = regexp.MustCompile(`!\[\[[^\]\n]*\]\]`)
+	wikiLinkAliasPattern = regexp.MustCompile(`\[\[[^\]|\n]+\|([^\]\n]+)\]\]`)
+	wikiLinkPattern      = regexp.MustCompile(`\[\[([^\]\n]+)\]\]`)
 
 	shoutoutOpenPattern  = regexp.MustCompile(`^ {0,3}:::\s*(?P<type>[A-Za-z][\w-]*)\s*$`)
 	shoutoutClosePattern = regexp.MustCompile(`^ {0,3}:::\s*$`)
@@ -108,7 +108,7 @@ func PlainTextFromMarkdown(body string) string {
 	normalized = strings.ReplaceAll(normalized, "\r", "\n")
 	normalized = fencedCodePattern.ReplaceAllString(normalized, " ")
 	normalized = imagePattern.ReplaceAllString(normalized, "$1")
-	normalized = wikiImagePattern.ReplaceAllString(normalized, "")
+	normalized = wikiImagePattern.ReplaceAllString(normalized, " ")
 	normalized = wikiLinkAliasPattern.ReplaceAllString(normalized, "$1")
 	normalized = wikiLinkPattern.ReplaceAllString(normalized, "$1")
 	var htmlBuf bytes.Buffer

--- a/internal/core/excerpt/excerpt.go
+++ b/internal/core/excerpt/excerpt.go
@@ -20,11 +20,14 @@ var mdRenderer = goldmark.New(
 var (
 	sanitize = bluemonday.StrictPolicy()
 
-	fencedCodePattern = regexp.MustCompile("(?s)```.*?```")
-	imagePattern      = regexp.MustCompile(`!\[([^\]]*)\]\([^)]+\)`)
-	linkPattern       = regexp.MustCompile(`\[([^\]]+)\]\([^)]+\)`)
-	htmlPattern       = regexp.MustCompile(`<[^>]+>`)
-	linePrefixPattern = regexp.MustCompile(`(?m)^\s{0,3}(#{1,6}\s*|[-*+]\s+|\d+\.\s+|>\s?)`)
+	fencedCodePattern    = regexp.MustCompile("(?s)```.*?```")
+	imagePattern         = regexp.MustCompile(`!\[([^\]]*)\]\([^)]+\)`)
+	linkPattern          = regexp.MustCompile(`\[([^\]]+)\]\([^)]+\)`)
+	htmlPattern          = regexp.MustCompile(`<[^>]+>`)
+	linePrefixPattern    = regexp.MustCompile(`(?m)^\s{0,3}(#{1,6}\s*|[-*+]\s+|\d+\.\s+|>\s?)`)
+	wikiImagePattern     = regexp.MustCompile(`!\[\[[^\]]*\]\]`)
+	wikiLinkAliasPattern = regexp.MustCompile(`\[\[[^\]|]+\|([^\]]+)\]\]`)
+	wikiLinkPattern      = regexp.MustCompile(`\[\[([^\]]+)\]\]`)
 
 	shoutoutOpenPattern  = regexp.MustCompile(`^ {0,3}:::\s*(?P<type>[A-Za-z][\w-]*)\s*$`)
 	shoutoutClosePattern = regexp.MustCompile(`^ {0,3}:::\s*$`)
@@ -105,6 +108,9 @@ func PlainTextFromMarkdown(body string) string {
 	normalized = strings.ReplaceAll(normalized, "\r", "\n")
 	normalized = fencedCodePattern.ReplaceAllString(normalized, " ")
 	normalized = imagePattern.ReplaceAllString(normalized, "$1")
+	normalized = wikiImagePattern.ReplaceAllString(normalized, "")
+	normalized = wikiLinkAliasPattern.ReplaceAllString(normalized, "$1")
+	normalized = wikiLinkPattern.ReplaceAllString(normalized, "$1")
 	var htmlBuf bytes.Buffer
 	if err := mdRenderer.Convert([]byte(normalized), &htmlBuf); err != nil {
 		htmlBuf.Reset()

--- a/internal/core/excerpt/excerpt_test.go
+++ b/internal/core/excerpt/excerpt_test.go
@@ -170,6 +170,26 @@ func TestNormalizeMarkdownBody_IgnoresCodeFences(t *testing.T) {
 	}
 }
 
+func TestFromContent_StripsWikiLinks(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"plain wikilink", "See [[Some Page]] for details.", "See Some Page for details."},
+		{"aliased wikilink", "See [[Some Page|this page]] for details.", "See this page for details."},
+		{"image embed", "![[image.png]] Some text.", "Some text."},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := PlainTextFromMarkdown(tc.body)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestFromBody_StripsHTMLAndMarkdown(t *testing.T) {
 	body := "<p><strong>Bold</strong> [link](https://example.com)</p>"
 	got := FromBody(body)

--- a/internal/core/excerpt/excerpt_test.go
+++ b/internal/core/excerpt/excerpt_test.go
@@ -170,7 +170,7 @@ func TestNormalizeMarkdownBody_IgnoresCodeFences(t *testing.T) {
 	}
 }
 
-func TestFromContent_StripsWikiLinks(t *testing.T) {
+func TestPlainTextFromMarkdown_StripsWikiLinks(t *testing.T) {
 	cases := []struct {
 		name string
 		body string

--- a/ui/leafwiki-ui/src/features/page/PageRefactorDialog.tsx
+++ b/ui/leafwiki-ui/src/features/page/PageRefactorDialog.tsx
@@ -134,7 +134,7 @@ export function PageRefactorDialog({
                         className="page-refactor-dialog__affected-page-matches"
                         data-testid="page-refactor-dialog-affected-page-matches"
                       >
-                        {matchedPaths.join(', ')}
+                        {matchedPaths.map((p) => p.replace(/^\[\[/, '').replace(/\]\]$/, '')).join(', ')}
                       </div>
                       {pageWarnings.length > 0 && (
                         <div

--- a/ui/leafwiki-ui/src/features/page/PageRefactorDialog.tsx
+++ b/ui/leafwiki-ui/src/features/page/PageRefactorDialog.tsx
@@ -134,7 +134,11 @@ export function PageRefactorDialog({
                         className="page-refactor-dialog__affected-page-matches"
                         data-testid="page-refactor-dialog-affected-page-matches"
                       >
-                        {matchedPaths.map((p) => p.replace(/^\[\[/, '').replace(/\]\]$/, '')).join(', ')}
+                        {matchedPaths
+                          .map((p) =>
+                            p.replace(/^\[\[/, '').replace(/\]\]$/, ''),
+                          )
+                          .join(', ')}
                       </div>
                       {pageWarnings.length > 0 && (
                         <div


### PR DESCRIPTION
[[Title]] and [[Title|Alias]] syntax was leaking into search/tag excerpts and the rename dialog's matched-paths column.

- Add WikiLink patterns to PlainTextFromMarkdown so [[Title]] → Title, [[Title|Alias]] → Alias, and ![[image]] is removed before indexing
- Strip [[ ]] brackets from matchedPaths display in PageRefactorDialog
- Update e2e assertion to match plain title instead of [[Title]]