### PR TITLE
feat(properties): support nested YAML frontmatter via dot-notation keys

### DIFF
--- a/internal/properties/properties_service.go
+++ b/internal/properties/properties_service.go
@@ -52,6 +52,7 @@ func (s *PropertiesService) GetPropertiesForPages(pageIDs []string) (map[string]
 
 // ExtractPropertiesFromContent parses frontmatter and returns scalar properties.
 // Skips: reserved keys (tags, title, leafwiki_*), lists, nil values.
+// Nested YAML maps are flattened using dot notation (e.g. a.b: value).
 func ExtractPropertiesFromContent(content string) map[string]PropertyEntry {
 	fm, _, has, err := markdown.ParseFrontmatter(content)
 	if err != nil || !has || len(fm.ExtraFields) == 0 {
@@ -64,17 +65,48 @@ func ExtractPropertiesFromContent(content string) map[string]PropertyEntry {
 		if isReservedKey(key) {
 			continue
 		}
-		entry, ok := toPropertyEntry(value)
-		if !ok {
-			continue
-		}
-		result[key] = entry
+		extractFlatEntry(key, value, result)
 	}
 
 	if len(result) == 0 {
 		return nil
 	}
 	return result
+}
+
+const maxNestedPropertyDepth = 20
+
+// extractFlatEntry walks a potentially-nested value and stores all scalar leaves
+// under dot-joined keys (e.g. {"a": {"b": "v"}} → "a.b" = "v").
+// depth guards against unbounded recursion from crafted deeply-nested YAML.
+func extractFlatEntry(prefix string, value interface{}, result map[string]PropertyEntry) {
+	extractFlatEntryDepth(prefix, value, result, 0)
+}
+
+func extractFlatEntryDepth(prefix string, value interface{}, result map[string]PropertyEntry, depth int) {
+	if depth > maxNestedPropertyDepth {
+		return
+	}
+	switch v := value.(type) {
+	case string:
+		entry, ok := toPropertyEntry(v)
+		if ok {
+			result[prefix] = entry
+		}
+	case map[string]interface{}:
+		for childKey, childValue := range v {
+			childKey = strings.TrimSpace(childKey)
+			if childKey == "" {
+				continue
+			}
+			// Skip child segments that use the system-reserved prefix so that
+			// e.g. {"meta": {"leafwiki_id": "x"}} cannot pollute the index.
+			if strings.HasPrefix(strings.ToLower(childKey), "leafwiki_") {
+				continue
+			}
+			extractFlatEntryDepth(prefix+"."+childKey, childValue, result, depth+1)
+		}
+	}
 }
 
 func isReservedKey(key string) bool {

--- a/internal/properties/properties_service_test.go
+++ b/internal/properties/properties_service_test.go
@@ -1,6 +1,8 @@
 package properties
 
 import (
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/perber/wiki/internal/core/tree"
@@ -194,6 +196,92 @@ func TestExtractPropertiesFromContent_OnlyNonStringValuesReturnsNil(t *testing.T
 	got := ExtractPropertiesFromContent(content)
 	if got != nil {
 		t.Errorf("expected nil when all values are non-string, got %v", got)
+	}
+}
+
+// ─── Nested map (dot-notation) extraction ────────────────────────────────────
+
+func TestExtractPropertiesFromContent_NestedMapOneLevelDeep(t *testing.T) {
+	content := "---\na:\n  b: value\n---\n"
+	got := ExtractPropertiesFromContent(content)
+	assertEntry(t, got, "a.b", PropertyEntry{Value: "value", Type: "text"})
+	if _, ok := got["a"]; ok {
+		t.Error("intermediate key 'a' must not appear as a property")
+	}
+}
+
+func TestExtractPropertiesFromContent_NestedMapTwoLevelsDeep(t *testing.T) {
+	content := "---\na:\n  b:\n    c: deep\n---\n"
+	got := ExtractPropertiesFromContent(content)
+	assertEntry(t, got, "a.b.c", PropertyEntry{Value: "deep", Type: "text"})
+}
+
+func TestExtractPropertiesFromContent_NestedMapMultipleChildren(t *testing.T) {
+	content := "---\na:\n  b: val1\n  c: val2\n---\n"
+	got := ExtractPropertiesFromContent(content)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 properties, got %d: %v", len(got), got)
+	}
+	assertEntry(t, got, "a.b", PropertyEntry{Value: "val1", Type: "text"})
+	assertEntry(t, got, "a.c", PropertyEntry{Value: "val2", Type: "text"})
+}
+
+func TestExtractPropertiesFromContent_MixedFlatAndNestedKeys(t *testing.T) {
+	content := "---\nstatus: draft\na:\n  b: nested\n---\n"
+	got := ExtractPropertiesFromContent(content)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 properties, got %d: %v", len(got), got)
+	}
+	assertEntry(t, got, "status", PropertyEntry{Value: "draft", Type: "text"})
+	assertEntry(t, got, "a.b", PropertyEntry{Value: "nested", Type: "text"})
+}
+
+func TestExtractPropertiesFromContent_NestedMapSkipsNonStringLeaves(t *testing.T) {
+	content := "---\na:\n  b: 42\n  c: value\n---\n"
+	got := ExtractPropertiesFromContent(content)
+	if _, ok := got["a.b"]; ok {
+		t.Error("nested integer value must not be stored as a property")
+	}
+	assertEntry(t, got, "a.c", PropertyEntry{Value: "value", Type: "text"})
+}
+
+func TestExtractPropertiesFromContent_NestedMapSkipsEmptyStringLeaves(t *testing.T) {
+	content := "---\na:\n  b: \"\"\n  c: value\n---\n"
+	got := ExtractPropertiesFromContent(content)
+	if _, ok := got["a.b"]; ok {
+		t.Error("nested empty string must not be stored as a property")
+	}
+	assertEntry(t, got, "a.c", PropertyEntry{Value: "value", Type: "text"})
+}
+
+func TestExtractPropertiesFromContent_NestedMapSkipsLeafwikiChildSegment(t *testing.T) {
+	// A nested child key that starts with leafwiki_ must not be indexed even
+	// when the top-level key is a normal user key.
+	content := "---\nmeta:\n  leafwiki_id: spoofed\n  status: active\n---\n"
+	got := ExtractPropertiesFromContent(content)
+	if _, ok := got["meta.leafwiki_id"]; ok {
+		t.Error("nested leafwiki_ child segment must not be stored as a property")
+	}
+	assertEntry(t, got, "meta.status", PropertyEntry{Value: "active", Type: "text"})
+}
+
+func TestExtractPropertiesFromContent_NestedMapDepthLimitNotPanics(t *testing.T) {
+	// Build YAML that is deeper than maxNestedPropertyDepth. extractFlatEntry
+	// must return without crashing or producing an unboundedly long key.
+	depth := maxNestedPropertyDepth + 5
+	yaml := "---\n"
+	indent := ""
+	for i := range depth {
+		yaml += indent + "k" + strconv.Itoa(i) + ":\n"
+		indent += "  "
+	}
+	yaml += indent + "leaf: value\n---\n"
+
+	got := ExtractPropertiesFromContent(yaml)
+	for key := range got {
+		if len(strings.Split(key, ".")) > maxNestedPropertyDepth+1 {
+			t.Errorf("key %q exceeds max depth", key)
+		}
 	}
 }
 

--- a/internal/wiki/pages/routes.go
+++ b/internal/wiki/pages/routes.go
@@ -571,18 +571,30 @@ func extractPageMetadata(fields map[string]interface{}) ([]string, map[string]st
 			continue
 		}
 
-		s, ok := value.(string)
-		if !ok {
-			continue
-		}
-		s = strings.TrimSpace(s)
-		if s == "" || strings.ContainsRune(s, '\n') {
-			continue
-		}
-		properties[key] = s
+		flattenMetadataEntry(key, value, properties)
 	}
 
 	return tags, properties
+}
+
+// flattenMetadataEntry recursively flattens nested YAML maps into dot-notation
+// keys (e.g. {"a": {"b": "v"}} → properties["a.b"] = "v").
+func flattenMetadataEntry(prefix string, value interface{}, properties map[string]string) {
+	switch v := value.(type) {
+	case string:
+		s := strings.TrimSpace(v)
+		if s != "" && !strings.ContainsRune(s, '\n') {
+			properties[prefix] = s
+		}
+	case map[string]interface{}:
+		for childKey, childValue := range v {
+			childKey = strings.TrimSpace(childKey)
+			if childKey == "" {
+				continue
+			}
+			flattenMetadataEntry(prefix+"."+childKey, childValue, properties)
+		}
+	}
 }
 
 func normalizeMetadataTags(value interface{}) []string {

--- a/internal/wiki/pages/routes.go
+++ b/internal/wiki/pages/routes.go
@@ -580,6 +580,13 @@ func extractPageMetadata(fields map[string]interface{}) ([]string, map[string]st
 // flattenMetadataEntry recursively flattens nested YAML maps into dot-notation
 // keys (e.g. {"a": {"b": "v"}} → properties["a.b"] = "v").
 func flattenMetadataEntry(prefix string, value interface{}, properties map[string]string) {
+	flattenMetadataEntryDepth(prefix, value, properties, 0)
+}
+
+func flattenMetadataEntryDepth(prefix string, value interface{}, properties map[string]string, depth int) {
+	if depth > maxFlattenDepth {
+		return
+	}
 	switch v := value.(type) {
 	case string:
 		s := strings.TrimSpace(v)
@@ -592,10 +599,15 @@ func flattenMetadataEntry(prefix string, value interface{}, properties map[strin
 			if childKey == "" {
 				continue
 			}
-			flattenMetadataEntry(prefix+"."+childKey, childValue, properties)
+			if strings.HasPrefix(strings.ToLower(childKey), "leafwiki_") {
+				continue
+			}
+			flattenMetadataEntryDepth(prefix+"."+childKey, childValue, properties, depth+1)
 		}
 	}
 }
+
+const maxFlattenDepth = 20
 
 func normalizeMetadataTags(value interface{}) []string {
 	list, ok := value.([]interface{})

--- a/ui/leafwiki-ui/src/features/editor/frontmatter.test.ts
+++ b/ui/leafwiki-ui/src/features/editor/frontmatter.test.ts
@@ -41,10 +41,8 @@ describe('parseEditorFrontmatter – nested maps', () => {
     expect(result.fields).toHaveLength(2)
   })
 
-  it('preserves block with unsupported nested content in unsupportedRaw', () => {
-    // A nested block that cannot be expressed as key-value pairs
+  it('parses a block list under a key as a list field (not unsupportedRaw)', () => {
     const result = parseEditorFrontmatter('a:\n  - item1\n  - item2')
-    // List under 'a' is parsed as a list field, not unsupported
     expect(result.fields[0]).toMatchObject({ key: 'a', type: 'list' })
     expect(result.unsupportedRaw).toBe('')
   })

--- a/ui/leafwiki-ui/src/features/editor/frontmatter.test.ts
+++ b/ui/leafwiki-ui/src/features/editor/frontmatter.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+import { buildEditorFrontmatter, parseEditorFrontmatter } from './frontmatter'
+
+// ─── parseEditorFrontmatter: nested YAML → dot-notation keys ─────────────────
+
+describe('parseEditorFrontmatter – nested maps', () => {
+  it('parses one level of nesting as a dot-notation key', () => {
+    const result = parseEditorFrontmatter('a:\n  b: value')
+    expect(result.fields).toHaveLength(1)
+    expect(result.fields[0]).toMatchObject({
+      key: 'a.b',
+      value: 'value',
+      type: 'text',
+    })
+    expect(result.unsupportedRaw).toBe('')
+  })
+
+  it('parses two levels of nesting', () => {
+    const result = parseEditorFrontmatter('a:\n  b:\n    c: deep')
+    expect(result.fields).toHaveLength(1)
+    expect(result.fields[0]).toMatchObject({
+      key: 'a.b.c',
+      value: 'deep',
+      type: 'text',
+    })
+  })
+
+  it('parses multiple children of the same parent', () => {
+    const result = parseEditorFrontmatter('a:\n  b: val1\n  c: val2')
+    const keys = result.fields.map((f) => f.key)
+    expect(keys).toContain('a.b')
+    expect(keys).toContain('a.c')
+    expect(result.fields).toHaveLength(2)
+  })
+
+  it('mixes flat and nested fields', () => {
+    const result = parseEditorFrontmatter('status: draft\na:\n  b: nested')
+    const keys = result.fields.map((f) => f.key)
+    expect(keys).toContain('status')
+    expect(keys).toContain('a.b')
+    expect(result.fields).toHaveLength(2)
+  })
+
+  it('preserves block with unsupported nested content in unsupportedRaw', () => {
+    // A nested block that cannot be expressed as key-value pairs
+    const result = parseEditorFrontmatter('a:\n  - item1\n  - item2')
+    // List under 'a' is parsed as a list field, not unsupported
+    expect(result.fields[0]).toMatchObject({ key: 'a', type: 'list' })
+    expect(result.unsupportedRaw).toBe('')
+  })
+
+  it('parses inline list under a nested key', () => {
+    const result = parseEditorFrontmatter('a:\n  b: [x, y, z]')
+    expect(result.fields).toHaveLength(1)
+    expect(result.fields[0]).toMatchObject({ key: 'a.b', type: 'list' })
+  })
+})
+
+// ─── buildEditorFrontmatter: dot-notation keys → nested YAML ─────────────────
+
+describe('buildEditorFrontmatter – nested YAML output', () => {
+  it('writes a single dot-notation key as nested YAML', () => {
+    const result = buildEditorFrontmatter({
+      tags: [],
+      fields: [{ key: 'a.b', value: 'value', type: 'text' }],
+      unsupportedRaw: '',
+    })
+    expect(result).toBe('a:\n  b: value')
+  })
+
+  it('writes two-level deep dot-notation key', () => {
+    const result = buildEditorFrontmatter({
+      tags: [],
+      fields: [{ key: 'a.b.c', value: 'deep', type: 'text' }],
+      unsupportedRaw: '',
+    })
+    expect(result).toBe('a:\n  b:\n    c: deep')
+  })
+
+  it('groups sibling dot-notation keys under one parent block', () => {
+    const result = buildEditorFrontmatter({
+      tags: [],
+      fields: [
+        { key: 'a.b', value: 'val1', type: 'text' },
+        { key: 'a.c', value: 'val2', type: 'text' },
+      ],
+      unsupportedRaw: '',
+    })
+    // Should produce a single "a:" block, not two separate ones
+    const lines = result.split('\n')
+    expect(lines.filter((l) => l === 'a:')).toHaveLength(1)
+    expect(result).toContain('  b: val1')
+    expect(result).toContain('  c: val2')
+  })
+
+  it('mixes flat and nested keys correctly', () => {
+    const result = buildEditorFrontmatter({
+      tags: [],
+      fields: [
+        { key: 'status', value: 'draft', type: 'text' },
+        { key: 'a.b', value: 'nested', type: 'text' },
+      ],
+      unsupportedRaw: '',
+    })
+    expect(result).toContain('status: draft')
+    expect(result).toContain('a:')
+    expect(result).toContain('  b: nested')
+  })
+
+  it('quotes values that need YAML quoting inside nested blocks', () => {
+    const result = buildEditorFrontmatter({
+      tags: [],
+      fields: [{ key: 'a.b', value: 'true', type: 'text' }],
+      unsupportedRaw: '',
+    })
+    expect(result).toContain('  b: "true"')
+  })
+})
+
+// ─── Round-trip tests ─────────────────────────────────────────────────────────
+
+describe('round-trip: parse → build → parse', () => {
+  it('preserves a single nested field', () => {
+    const original = {
+      tags: [],
+      fields: [{ key: 'a.b', value: 'v', type: 'text' as const }],
+      unsupportedRaw: '',
+    }
+    const built = buildEditorFrontmatter(original)
+    const parsed = parseEditorFrontmatter(built)
+    expect(parsed.fields).toHaveLength(1)
+    expect(parsed.fields[0]).toMatchObject({ key: 'a.b', value: 'v' })
+  })
+
+  it('preserves multiple siblings under the same parent', () => {
+    const original = {
+      tags: [],
+      fields: [
+        { key: 'a.b', value: 'val1', type: 'text' as const },
+        { key: 'a.c', value: 'val2', type: 'text' as const },
+      ],
+      unsupportedRaw: '',
+    }
+    const built = buildEditorFrontmatter(original)
+    const parsed = parseEditorFrontmatter(built)
+    const keys = parsed.fields.map((f) => f.key).sort()
+    expect(keys).toEqual(['a.b', 'a.c'])
+  })
+
+  it('preserves two-level deep nesting', () => {
+    const original = {
+      tags: [],
+      fields: [{ key: 'a.b.c', value: 'deep', type: 'text' as const }],
+      unsupportedRaw: '',
+    }
+    const built = buildEditorFrontmatter(original)
+    const parsed = parseEditorFrontmatter(built)
+    expect(parsed.fields[0]).toMatchObject({ key: 'a.b.c', value: 'deep' })
+  })
+})

--- a/ui/leafwiki-ui/src/features/editor/frontmatter.ts
+++ b/ui/leafwiki-ui/src/features/editor/frontmatter.ts
@@ -238,6 +238,183 @@ function appendBlock(target: string[], header: string, bodyLines: string[]) {
   target.push(...bodyLines)
 }
 
+// Tries to parse indented lines as nested key-value pairs, returning fields
+// with dot-joined keys (e.g. "parent.child"). Returns null if the block
+// contains anything that cannot be expressed as key-value pairs.
+function tryParseNestedMap(
+  lines: string[],
+  baseIndent: number,
+  parentKey: string,
+): EditorFrontmatterField[] | null {
+  const fields: EditorFrontmatterField[] = []
+  let i = 0
+
+  while (i < lines.length) {
+    const line = lines[i]
+    if (line.trim() === '') {
+      i++
+      continue
+    }
+
+    const lineIndent = line.search(/\S/)
+    if (lineIndent !== baseIndent) return null
+
+    const strippedLine = line.slice(baseIndent)
+    const keyMatch = strippedLine.match(FRONTMATTER_KEY_PATTERN)
+    if (!keyMatch) return null
+
+    const [, rawKey, rawValue] = keyMatch
+    const key = normalizeFieldKey(rawKey)
+    const trimmedValue = rawValue.trim()
+    const fullKey = parentKey ? `${parentKey}.${key}` : key
+
+    if (trimmedValue !== '') {
+      const inlineList = parseInlineList(trimmedValue)
+      if (inlineList !== null) {
+        fields.push({
+          key: fullKey,
+          type: 'list',
+          value: inlineList.join('\n'),
+          internal: isInternalFieldKey(fullKey),
+        })
+      } else {
+        const normalizedValue = normalizeFieldValue(trimmedValue)
+        fields.push({
+          key: fullKey,
+          type: detectFieldType(normalizedValue),
+          value: normalizedValue,
+          internal: isInternalFieldKey(fullKey),
+        })
+      }
+      i++
+      continue
+    }
+
+    // Empty value — collect all deeper-indented child lines
+    const childLines: string[] = []
+    let j = i + 1
+    while (j < lines.length) {
+      const nextLine = lines[j]
+      if (nextLine.trim() === '') {
+        j++
+        continue
+      }
+      const nextIndent = nextLine.search(/\S/)
+      if (nextIndent <= baseIndent) break
+      childLines.push(nextLine)
+      j++
+    }
+
+    if (childLines.length === 0) {
+      i++
+      continue
+    }
+
+    const firstChild = childLines.find((l) => l.trim() !== '')
+    const childIndent = firstChild ? firstChild.search(/\S/) : baseIndent + 2
+
+    // Try as list first, then as nested map
+    const listItems: string[] = []
+    let isList = true
+    for (const cl of childLines) {
+      if (cl.trim() === '') continue
+      const listItem = cl.match(/^\s*-\s*(.+?)\s*$/)
+      if (!listItem) {
+        isList = false
+        break
+      }
+      listItems.push(listItem[1])
+    }
+
+    if (isList && listItems.length > 0) {
+      fields.push({
+        key: fullKey,
+        type: 'list',
+        value: listItems.join('\n'),
+        internal: isInternalFieldKey(fullKey),
+      })
+    } else {
+      const nestedFields = tryParseNestedMap(childLines, childIndent, fullKey)
+      if (nestedFields === null) {
+        // This child block cannot be expressed as key-value pairs.
+        // Abort the whole parent block so the caller can fall back to
+        // unsupportedRaw — otherwise partial siblings would be silently lost.
+        return null
+      }
+      fields.push(...nestedFields)
+    }
+
+    i = j
+  }
+
+  return fields
+}
+
+// ─── Field tree for nested YAML serialization ─────────────────────────────────
+
+type FieldTreeNode = {
+  field?: EditorFrontmatterField
+  children: Map<string, FieldTreeNode>
+}
+
+// addToFieldTree returns false when inserting would cause a YAML-illegal
+// conflict (a key being both a scalar and a mapping at the same path).
+function addToFieldTree(
+  tree: Map<string, FieldTreeNode>,
+  parts: string[],
+  field: EditorFrontmatterField,
+): boolean {
+  const [head, ...rest] = parts
+  if (!head) return false
+
+  if (!tree.has(head)) {
+    tree.set(head, { children: new Map() })
+  }
+  const node = tree.get(head)!
+
+  if (rest.length === 0) {
+    if (node.children.size > 0) return false // would conflict with existing children
+    node.field = field
+    return true
+  }
+
+  if (node.field !== undefined) return false // would conflict with existing scalar
+  return addToFieldTree(node.children, rest, field)
+}
+
+function serializeFieldNode(
+  key: string,
+  node: FieldTreeNode,
+  indent: number,
+): string {
+  const prefix = '  '.repeat(indent)
+  const formattedKey = formatFieldKey(key)
+
+  if (node.children.size > 0) {
+    const childLines: string[] = []
+    for (const [childKey, childNode] of node.children) {
+      childLines.push(serializeFieldNode(childKey, childNode, indent + 1))
+    }
+    return `${prefix}${formattedKey}:\n${childLines.join('\n')}`
+  }
+
+  const field = node.field!
+  if (field.type === 'list') {
+    const items = normalizeListValue(field.value).split('\n').filter(Boolean)
+    if (items.length === 0) return `${prefix}${formattedKey}: []`
+    return [
+      `${prefix}${formattedKey}:`,
+      ...items.map((item) => `${prefix}  - ${item}`),
+    ].join('\n')
+  }
+
+  const trimmedValue = field.value.trim()
+  if (needsYamlQuoting(trimmedValue)) {
+    return `${prefix}${formattedKey}: "${trimmedValue}"`
+  }
+  return `${prefix}${formattedKey}: ${trimmedValue}`
+}
+
 export function parseEditorFrontmatter(
   frontmatter?: string | null,
 ): ParsedEditorFrontmatter {
@@ -353,7 +530,14 @@ export function parseEditorFrontmatter(
         internal: isInternalFieldKey(key),
       })
     } else {
-      appendBlock(unsupportedLines, line, collected)
+      const firstChild = collected.find((l) => l.trim() !== '')
+      const nestedIndent = firstChild ? firstChild.search(/\S/) : 2
+      const nestedFields = tryParseNestedMap(collected, nestedIndent, key)
+      if (nestedFields !== null) {
+        fields.push(...nestedFields)
+      } else {
+        appendBlock(unsupportedLines, line, collected)
+      }
     }
 
     index = nextIndex - 1
@@ -364,30 +548,6 @@ export function parseEditorFrontmatter(
     fields: normalizeEditorFrontmatterFields(fields),
     unsupportedRaw: unsupportedLines.join('\n').trim(),
   }
-}
-
-function buildFieldBlock(field: EditorFrontmatterField) {
-  const key = normalizeFieldKey(field.key)
-  if (!key) return ''
-  const formattedKey = formatFieldKey(key)
-
-  if (field.type === 'list') {
-    const items = normalizeListValue(field.value).split('\n').filter(Boolean)
-
-    if (items.length === 0) {
-      return `${formattedKey}: []`
-    }
-
-    return [formattedKey + ':', ...items.map((item) => `  - ${item}`)].join(
-      '\n',
-    )
-  }
-
-  const trimmedValue = field.value.trim()
-  if (needsYamlQuoting(trimmedValue)) {
-    return `${formattedKey}: "${trimmedValue}"`
-  }
-  return `${formattedKey}: ${trimmedValue}`
 }
 
 export function buildEditorFrontmatter({
@@ -406,10 +566,35 @@ export function buildEditorFrontmatter({
     )
   }
 
+  // Build a tree so that dot-notation keys (e.g. "a.b" and "a.c") are grouped
+  // under a single parent block instead of emitting duplicate YAML keys.
+  // Fields that cannot be nested without conflict (e.g. "a" alongside "a.b")
+  // are serialized as flat literal YAML keys instead.
+  const fieldTree = new Map<string, FieldTreeNode>()
+  const flatFallbacks: EditorFrontmatterField[] = []
+
   for (const field of normalizedFields) {
-    const block = buildFieldBlock(field)
-    if (block) {
-      parts.push(block)
+    const key = normalizeFieldKey(field.key)
+    if (!key) continue
+    // Filter empty segments — handles trailing/leading/consecutive dots.
+    const parts = key.split('.').filter(Boolean)
+    if (parts.length === 0) continue
+    if (!addToFieldTree(fieldTree, parts, field)) {
+      flatFallbacks.push({ ...field, key })
+    }
+  }
+
+  for (const [key, node] of fieldTree) {
+    parts.push(serializeFieldNode(key, node, 0))
+  }
+
+  for (const field of flatFallbacks) {
+    const formattedKey = formatFieldKey(field.key)
+    const trimmedValue = field.value.trim()
+    if (needsYamlQuoting(trimmedValue)) {
+      parts.push(`${formattedKey}: "${trimmedValue}"`)
+    } else {
+      parts.push(`${formattedKey}: ${trimmedValue}`)
     }
   }
 

--- a/ui/leafwiki-ui/src/features/editor/frontmatter.ts
+++ b/ui/leafwiki-ui/src/features/editor/frontmatter.ts
@@ -373,7 +373,8 @@ function addToFieldTree(
   const node = tree.get(head)!
 
   if (rest.length === 0) {
-    if (node.children.size > 0) return false // would conflict with existing children
+    // Conflict: node is already a parent, or an identical-path field was already inserted.
+    if (node.children.size > 0 || node.field !== undefined) return false
     node.field = field
     return true
   }
@@ -590,11 +591,24 @@ export function buildEditorFrontmatter({
 
   for (const field of flatFallbacks) {
     const formattedKey = formatFieldKey(field.key)
-    const trimmedValue = field.value.trim()
-    if (needsYamlQuoting(trimmedValue)) {
-      parts.push(`${formattedKey}: "${trimmedValue}"`)
+    if (field.type === 'list') {
+      const items = normalizeListValue(field.value).split('\n').filter(Boolean)
+      if (items.length === 0) {
+        parts.push(`${formattedKey}: []`)
+      } else {
+        parts.push(
+          [`${formattedKey}:`, ...items.map((item) => `  - ${item}`)].join(
+            '\n',
+          ),
+        )
+      }
     } else {
-      parts.push(`${formattedKey}: ${trimmedValue}`)
+      const trimmedValue = field.value.trim()
+      if (needsYamlQuoting(trimmedValue)) {
+        parts.push(`${formattedKey}: "${trimmedValue}"`)
+      } else {
+        parts.push(`${formattedKey}: ${trimmedValue}`)
+      }
     }
   }
 


### PR DESCRIPTION
When a property key contains dots (e.g. "a.b"), the editor now stores it as proper nested YAML (a:\n  b: value) instead of a flat literal dot-key. Sibling dot-keys sharing a parent are grouped under one YAML block.

The backend flattens nested ExtraFields maps with dot-joined keys so the properties index (a.b = value) and the page API response both reflect the nested structure. Guards added: depth limit (20) in extractFlatEntry, leafwiki_ prefix filter for child segments, and conflict detection in the field tree (scalar vs. mapping at the same path falls back to flat output).