### PR TITLE
fix: set 0644 permissions on uploaded asset files

### DIFF
--- a/internal/branding/branding_service.go
+++ b/internal/branding/branding_service.go
@@ -137,7 +137,7 @@ func (s *BrandingService) UploadLogo(file multipart.File, filename string) (stri
 	targetPath := filepath.Join(assetsDir, "logo"+ext)
 
 	// Write new logo atomically first
-	if err := shared.WriteStreamAtomic(targetPath, file, s.brandingConfig.BrandingConstraints.MaxLogoSize); err != nil {
+	if err := shared.WriteStreamAtomic(targetPath, file, s.brandingConfig.BrandingConstraints.MaxLogoSize, 0o644); err != nil {
 		return "", sharederrors.NewLocalizedError(
 			"branding_logo_upload_failed",
 			"Failed to save logo file",
@@ -227,7 +227,7 @@ func (s *BrandingService) UploadFavicon(file multipart.File, filename string) (s
 	targetPath := filepath.Join(assetsDir, "favicon"+ext)
 
 	// Write new favicon atomically first
-	if err := shared.WriteStreamAtomic(targetPath, file, s.brandingConfig.BrandingConstraints.MaxFaviconSize); err != nil {
+	if err := shared.WriteStreamAtomic(targetPath, file, s.brandingConfig.BrandingConstraints.MaxFaviconSize, 0o644); err != nil {
 		return "", sharederrors.NewLocalizedError(
 			"branding_favicon_upload_failed",
 			"Failed to save favicon file",

--- a/internal/core/assets/assets_service.go
+++ b/internal/core/assets/assets_service.go
@@ -122,7 +122,7 @@ func (s *AssetService) SaveAssetForPage(page *tree.PageNode, file multipart.File
 	finalFilename := s.slugger.GenerateUniqueFilename(existing, originalFilename)
 	fullPath := assetFileDiskPath(uploadPath, finalFilename)
 
-	if err := shared.WriteStreamAtomic(fullPath, file, maxBytes); err != nil {
+	if err := shared.WriteStreamAtomic(fullPath, file, maxBytes, 0o644); err != nil {
 		if errors.Is(err, shared.ErrFileTooLarge) {
 			return "", sharederrors.NewLocalizedError("asset_file_too_large", "File is too large", "file is too large", err)
 		}

--- a/internal/core/shared/utils.go
+++ b/internal/core/shared/utils.go
@@ -122,7 +122,7 @@ func CopyWithLimit(dst io.Writer, src io.Reader, max int64) error {
 	return nil
 }
 
-func WriteStreamAtomic(targetPath string, src io.Reader, maxBytes int64) error {
+func WriteStreamAtomic(targetPath string, src io.Reader, maxBytes int64, perm os.FileMode) error {
 	dir := atomicWriteDir(targetPath)
 
 	out, err := os.CreateTemp(dir, ".tmp-*")
@@ -149,6 +149,17 @@ func WriteStreamAtomic(targetPath string, src io.Reader, maxBytes int64) error {
 			_ = os.Remove(tmp)
 		}
 	}()
+
+	if perm != 0 {
+		if err := out.Chmod(perm); err != nil {
+			chmodErr := fmt.Errorf("chmod temp file: %w", err)
+			if closeErr := out.Close(); closeErr != nil {
+				slog.Default().Error("failed to close temp file", "operation", "chmod", "error", closeErr)
+			}
+			out = nil
+			return chmodErr
+		}
+	}
 
 	if err := CopyWithLimit(out, src, maxBytes); err != nil {
 		return err

--- a/internal/core/shared/utils.go
+++ b/internal/core/shared/utils.go
@@ -150,17 +150,6 @@ func WriteStreamAtomic(targetPath string, src io.Reader, maxBytes int64, perm os
 		}
 	}()
 
-	if perm != 0 {
-		if err := out.Chmod(perm); err != nil {
-			chmodErr := fmt.Errorf("chmod temp file: %w", err)
-			if closeErr := out.Close(); closeErr != nil {
-				slog.Default().Error("failed to close temp file", "operation", "chmod", "error", closeErr)
-			}
-			out = nil
-			return chmodErr
-		}
-	}
-
 	if err := CopyWithLimit(out, src, maxBytes); err != nil {
 		return err
 	}
@@ -169,6 +158,14 @@ func WriteStreamAtomic(targetPath string, src io.Reader, maxBytes int64, perm os
 	if err := out.Sync(); err != nil {
 		return err
 	}
+
+	// Chmod after writing so partial content is never world-readable.
+	if perm != 0 {
+		if err := out.Chmod(perm); err != nil {
+			return fmt.Errorf("chmod temp file: %w", err)
+		}
+	}
+
 	if err := out.Close(); err != nil {
 		return err
 	}

--- a/internal/core/shared/utils_test.go
+++ b/internal/core/shared/utils_test.go
@@ -57,7 +57,7 @@ func TestWriteStreamAtomic_WritesToTargetFile(t *testing.T) {
 	tmp := t.TempDir()
 	target := filepath.Join(tmp, "asset.bin")
 
-	if err := WriteStreamAtomic(target, bytes.NewBufferString("hello stream"), 1024); err != nil {
+	if err := WriteStreamAtomic(target, bytes.NewBufferString("hello stream"), 1024, 0o644); err != nil {
 		t.Fatalf("WriteStreamAtomic err: %v", err)
 	}
 
@@ -67,5 +67,13 @@ func TestWriteStreamAtomic_WritesToTargetFile(t *testing.T) {
 	}
 	if string(raw) != "hello stream" {
 		t.Fatalf("content = %q", string(raw))
+	}
+
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("Stat err: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o644 {
+		t.Fatalf("permissions = %04o, want 0644", got)
 	}
 }

--- a/internal/core/shared/utils_test.go
+++ b/internal/core/shared/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -73,7 +74,9 @@ func TestWriteStreamAtomic_WritesToTargetFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Stat err: %v", err)
 	}
-	if got := info.Mode().Perm(); got != 0o644 {
-		t.Fatalf("permissions = %04o, want 0644", got)
+	if runtime.GOOS != "windows" {
+		if got := info.Mode().Perm(); got != 0o644 {
+			t.Fatalf("permissions = %04o, want 0644", got)
+		}
 	}
 }


### PR DESCRIPTION
os.CreateTemp defaults to 0600, so uploaded files kept owner-only permissions after the atomic rename. Add a perm parameter to WriteStreamAtomic (mirroring WriteFileAtomic) and call Chmod before writing, so assets and branding files land with world-readable 0644.

Fixes #1158