### PR TITLE
feat(importer): keep plain page wikilinks as native [[...]] syntax

### DIFF
--- a/internal/core/excerpt/excerpt.go
+++ b/internal/core/excerpt/excerpt.go
@@ -110,7 +110,17 @@ func PlainTextFromMarkdown(body string) string {
 	normalized = imagePattern.ReplaceAllString(normalized, "$1")
 	normalized = wikiImagePattern.ReplaceAllString(normalized, " ")
 	normalized = wikiLinkAliasPattern.ReplaceAllString(normalized, "$1")
-	normalized = wikiLinkPattern.ReplaceAllString(normalized, "$1")
+	normalized = wikiLinkPattern.ReplaceAllStringFunc(normalized, func(m string) string {
+		subs := wikiLinkPattern.FindStringSubmatch(m)
+		if len(subs) < 2 {
+			return ""
+		}
+		target := subs[1]
+		if idx := strings.LastIndex(target, "/"); idx >= 0 {
+			return target[idx+1:]
+		}
+		return target
+	})
 	var htmlBuf bytes.Buffer
 	if err := mdRenderer.Convert([]byte(normalized), &htmlBuf); err != nil {
 		htmlBuf.Reset()

--- a/internal/core/excerpt/excerpt_test.go
+++ b/internal/core/excerpt/excerpt_test.go
@@ -179,6 +179,8 @@ func TestPlainTextFromMarkdown_StripsWikiLinks(t *testing.T) {
 		{"plain wikilink", "See [[Some Page]] for details.", "See Some Page for details."},
 		{"aliased wikilink", "See [[Some Page|this page]] for details.", "See this page for details."},
 		{"image embed", "![[image.png]] Some text.", "Some text."},
+		{"path-hinted wikilink shows last segment", "See [[reference/endpoints]] for details.", "See endpoints for details."},
+		{"path-hinted aliased wikilink shows alias", "See [[reference/endpoints|API]] for details.", "See API for details."},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/http/router_test.go
+++ b/internal/http/router_test.go
@@ -1427,8 +1427,8 @@ func TestImportExecuteEndpoint_WithZipUpload_ImportsPagesLinksAndAssets(t *testi
 		"[Relative MD](/reference/endpoints)",
 		"[Absolute MD](/reference/endpoints)",
 		"[Container](/guides)",
-		"[Endpoints](/reference/endpoints)",
-		"[API Alias](/reference/endpoints)",
+		"[[reference/endpoints]]",
+		"[[reference/endpoints|API Alias]]",
 		"![Relative Image](/assets/" + setupPage.ID + "/logo.png)",
 		"[Manual](/assets/" + setupPage.ID + "/manual.pdf)",
 	} {

--- a/internal/importer/content_transformer.go
+++ b/internal/importer/content_transformer.go
@@ -182,37 +182,77 @@ func (t *contentTransformer) rewriteWikiLinks(
 		inner := strings.TrimSpace(content[next+startOffset : end])
 		targetPart, label := splitWikiLink(inner)
 		targetPart = normalizeImportedHref(targetPart)
+		_, anchorSuffix := splitURLSuffix(targetPart)
 		href, isAsset, err := t.resolveDestination(userID, sourcePath, page, targetPart, wiki)
 		if err != nil {
 			return "", err
 		}
-		if href == "" {
-			fallbackHref, ok := t.fallbackWikiPageHref(sourcePath, targetPart)
-			if !ok {
-				out.WriteString(content[next : end+2])
-				i = end + 2
-				continue
+
+		if isAsset {
+			if label == "" {
+				label = defaultWikiLinkLabel(targetPart)
 			}
-			href = fallbackHref
-		}
-
-		if label == "" {
-			label = defaultWikiLinkLabel(targetPart)
-		}
-
-		if shouldRenderWikiLinkAsImage(isImage, isAsset, targetPart) {
-			out.WriteString("![")
-			out.WriteString(label)
-			out.WriteString("](")
-			out.WriteString(href)
-			out.WriteByte(')')
-		} else {
+			if shouldRenderWikiLinkAsImage(isImage, targetPart) {
+				out.WriteByte('!')
+			}
 			out.WriteString("[")
 			out.WriteString(label)
 			out.WriteString("](")
 			out.WriteString(href)
 			out.WriteByte(')')
+			i = end + 2
+			continue
 		}
+
+		// Native WikiLinks don't support anchors — convert anchor links to Markdown.
+		if anchorSuffix != "" {
+			if href == "" {
+				fallbackHref, ok := t.fallbackWikiPageHref(sourcePath, targetPart)
+				if !ok {
+					out.WriteString(content[next : end+2])
+					i = end + 2
+					continue
+				}
+				href = fallbackHref
+			}
+			if label == "" {
+				label = defaultWikiLinkLabel(targetPart)
+			}
+			out.WriteString("[")
+			out.WriteString(label)
+			out.WriteString("](")
+			out.WriteString(href)
+			out.WriteByte(')')
+			i = end + 2
+			continue
+		}
+
+		// Plain page WikiLink (no anchor, no asset): keep as [[...]] so LeafWiki's
+		// native title-based resolution handles it — rename-aware and self-healing.
+		//
+		// Path-hinted links ([[Folder/Page]]) use the plan's resolved slug path so the
+		// refactoring engine's path-hint regex matches exactly on rename. Unresolved
+		// path-hinted links are slugified so the link indexer and heal mechanism can
+		// match them when the target page is later created.
+		// Obsidian page-embeds (![[Page]]) are kept as plain [[...]] because LeafWiki
+		// has no page-transclusion support.
+		target := targetPart
+		if strings.Contains(targetPart, "/") {
+			if href != "" {
+				target = strings.TrimPrefix(href, "/")
+			} else if slugged, ok := t.normalizeWikiHrefToRoutePath(targetPart); ok {
+				target = slugged
+			}
+		}
+		out.WriteString("[[")
+		if label != "" {
+			out.WriteString(target)
+			out.WriteByte('|')
+			out.WriteString(label)
+		} else {
+			out.WriteString(target)
+		}
+		out.WriteString("]]")
 		i = end + 2
 	}
 
@@ -666,14 +706,8 @@ func defaultWikiLinkLabel(target string) string {
 	return base
 }
 
-func shouldRenderWikiLinkAsImage(isEmbed bool, resolvedAsset bool, target string) bool {
-	if isEmbed {
-		return true
-	}
-	if !resolvedAsset {
-		return false
-	}
-	return isImageAssetTarget(target)
+func shouldRenderWikiLinkAsImage(isEmbed bool, target string) bool {
+	return isEmbed || isImageAssetTarget(target)
 }
 
 func isImageAssetTarget(target string) bool {

--- a/internal/importer/content_transformer_test.go
+++ b/internal/importer/content_transformer_test.go
@@ -49,13 +49,43 @@ func TestContentTransformer_TransformContent_TableDriven(t *testing.T) {
 			name:       "wiki link",
 			sourcePath: "docs/current.md",
 			content:    "[[Note]]",
-			want:       "[Note](/note)",
+			want:       "[[Note]]",
 		},
 		{
 			name:       "wiki link alias",
 			sourcePath: "docs/current.md",
 			content:    "[[Note|Alias]]",
-			want:       "[Alias](/note)",
+			want:       "[[Note|Alias]]",
+		},
+		{
+			name:       "wiki link path hint normalized to route path",
+			sourcePath: "docs/current.md",
+			content:    "[[foo/bar]]",
+			want:       "[[foo/bar]]",
+		},
+		{
+			name:       "wiki link path hint with alias normalized to route path",
+			sourcePath: "docs/current.md",
+			content:    "[[foo/bar|My Bar]]",
+			want:       "[[foo/bar|My Bar]]",
+		},
+		{
+			name:       "unresolved wiki link path hint is slugified",
+			sourcePath: "docs/current.md",
+			content:    "[[Unknown/Page]]",
+			want:       "[[unknown/page]]",
+		},
+		{
+			name:       "unresolved wiki link path hint with spaces is slugified",
+			sourcePath: "docs/current.md",
+			content:    "[[Research/Climate Change]]",
+			want:       "[[research/climate-change]]",
+		},
+		{
+			name:       "page embed drops embed marker (no transclusion support)",
+			sourcePath: "docs/current.md",
+			content:    "![[Note]]",
+			want:       "[[Note]]",
 		},
 		{
 			name:       "wiki link anchor",
@@ -76,10 +106,10 @@ func TestContentTransformer_TransformContent_TableDriven(t *testing.T) {
 			want:       "[Note](/note#^block-id)",
 		},
 		{
-			name:       "unresolved wiki link falls back to dead markdown link",
+			name:       "unresolved wiki link stays as wikilink",
 			sourcePath: "docs/current.md",
 			content:    "[[Missing Note]]",
-			want:       "[Missing Note](/missing-note)",
+			want:       "[[Missing Note]]",
 		},
 		{
 			name:       "asset embed",

--- a/internal/importer/content_transformer_test.go
+++ b/internal/importer/content_transformer_test.go
@@ -154,6 +154,18 @@ func TestContentTransformer_TransformContent_TableDriven(t *testing.T) {
 			want:       "[CDN](//example.com/assets/note.md)",
 		},
 		{
+			name:       "wiki link https url stays unchanged",
+			sourcePath: "docs/current.md",
+			content:    "[[https://example.com/page]]",
+			want:       "[[https://example.com/page]]",
+		},
+		{
+			name:       "wiki link scheme-relative url stays unchanged",
+			sourcePath: "docs/current.md",
+			content:    "[[//cdn.example.com/asset]]",
+			want:       "[[//cdn.example.com/asset]]",
+		},
+		{
 			name:       "inline code stays unchanged",
 			sourcePath: "docs/current.md",
 			content:    "`[[Note]]`",

--- a/internal/importer/executor_test.go
+++ b/internal/importer/executor_test.go
@@ -554,7 +554,7 @@ func TestExecutor_Create_WikiLinkResolvesUniqueNestedPathSuffix(t *testing.T) {
 	}
 }
 
-func TestExecutor_Create_UnresolvedWikiLinkFallsBackToDeadMarkdownLink(t *testing.T) {
+func TestExecutor_Create_UnresolvedWikiLinkStaysAsWikiLink(t *testing.T) {
 	tmp := t.TempDir()
 	writeTmp(t, tmp, "Home.md", strings.Join([]string{
 		"# Home",

--- a/internal/importer/executor_test.go
+++ b/internal/importer/executor_test.go
@@ -377,7 +377,7 @@ func TestExecutor_Create_RewritesMarkdownAndWikiLinksToImportedPages(t *testing.
 		"[Absolute](/guides)",
 		"[RouteStyle](/reference/endpoints)",
 		"[Container](/guides)",
-		"[API Alias](/reference/endpoints)",
+		"[[reference/endpoints|API Alias]]",
 	} {
 		if !strings.Contains(setupContent, expected) {
 			t.Fatalf("expected rewritten content to contain %q, got:\n%s", expected, setupContent)
@@ -506,8 +506,8 @@ func TestExecutor_Create_WikiLinkFallsBackToUniqueNestedBasenameOnly(t *testing.
 	}
 
 	homeContent := updatedContentByTitle["Home"]
-	if !strings.Contains(homeContent, "[Brainstorm](/daily/brainstorm)") {
-		t.Fatalf("expected unique basename wiki link rewrite, got:\n%s", homeContent)
+	if !strings.Contains(homeContent, "[[Brainstorm]]") {
+		t.Fatalf("expected unique basename wiki link to stay as wikilink, got:\n%s", homeContent)
 	}
 	if !strings.Contains(homeContent, "[[Meeting Notes]]") {
 		t.Fatalf("expected ambiguous basename wiki link to stay unchanged, got:\n%s", homeContent)
@@ -549,8 +549,8 @@ func TestExecutor_Create_WikiLinkResolvesUniqueNestedPathSuffix(t *testing.T) {
 	}
 
 	statefulSetContent := updatedContentByTitle["StatefulSet"]
-	if !strings.Contains(statefulSetContent, "[Deployment](/knowledge-main/tools/kubernetes/resources/deployment)") {
-		t.Fatalf("expected unique nested path suffix wiki link rewrite, got:\n%s", statefulSetContent)
+	if !strings.Contains(statefulSetContent, "[[knowledge-main/tools/kubernetes/resources/deployment|Deployment]]") {
+		t.Fatalf("expected unique nested path suffix wiki link to stay as wikilink, got:\n%s", statefulSetContent)
 	}
 }
 
@@ -587,8 +587,8 @@ func TestExecutor_Create_UnresolvedWikiLinkFallsBackToDeadMarkdownLink(t *testin
 	}
 
 	homeContent := updatedContentByTitle["Home"]
-	if !strings.Contains(homeContent, "[Missing Note](/missing-note)") {
-		t.Fatalf("expected unresolved wiki link fallback to dead markdown link, got:\n%s", homeContent)
+	if !strings.Contains(homeContent, "[[Missing Note]]") {
+		t.Fatalf("expected unresolved wiki link to stay as wikilink, got:\n%s", homeContent)
 	}
 }
 
@@ -640,7 +640,7 @@ func TestExecutor_Create_DoesNotRewriteLinksInsideCode(t *testing.T) {
 		"[Fence](../Reference/Endpoints.md)",
 		"[[Reference/Endpoints|Fence Alias]]",
 		"[Real](/reference/endpoints)",
-		"[Real Alias](/reference/endpoints)",
+		"[[reference/endpoints|Real Alias]]",
 	} {
 		if !strings.Contains(setupContent, expected) {
 			t.Fatalf("expected content to contain %q, got:\n%s", expected, setupContent)

--- a/internal/importer/importer_integration_test.go
+++ b/internal/importer/importer_integration_test.go
@@ -275,7 +275,7 @@ func TestImporterService_ExecuteCurrentPlan_RewritesLinksAndUploadsAssetsToDisk(
 	for _, expected := range []string{
 		"[Guide Home](/guides)",
 		"[API](/reference/endpoints#intro)",
-		"[API Alias](/reference/endpoints)",
+		"[[reference/endpoints|API Alias]]",
 		"/assets/" + setupPage.ID + "/logo.png",
 		"/assets/" + setupPage.ID + "/manual.pdf",
 	} {
@@ -322,8 +322,8 @@ func TestImporterService_ExecuteCurrentPlan_ImportsFixturePackage(t *testing.T) 
 		"[Relative MD](/reference/endpoints)",
 		"[Absolute MD](/reference/endpoints)",
 		"[Container](/guides)",
-		"[Endpoints](/reference/endpoints)",
-		"[API Alias](/reference/endpoints)",
+		"[[reference/endpoints]]",
+		"[[reference/endpoints|API Alias]]",
 		"![Relative Image](/assets/" + setupPage.ID + "/logo.png)",
 		"[Manual](/assets/" + setupPage.ID + "/manual.pdf)",
 		"![logo.png](/assets/" + setupPage.ID + "/logo.png)",
@@ -401,7 +401,7 @@ func TestImporterService_ExecuteCurrentPlan_ImportsLeafWikiNestedFixture(t *test
 
 	for _, expected := range []string{
 		"[Getting Started](/docs/getting-started)",
-		"[Basic Guide](/docs/guides/basic-guide)",
+		"[[docs/guides/basic-guide|Basic Guide]]",
 	} {
 		if !strings.Contains(introPage.Content, expected) {
 			t.Fatalf("expected intro content to contain %q, got:\n%s", expected, introPage.Content)
@@ -513,10 +513,10 @@ func TestImporterService_ExecuteCurrentPlan_ImportsObsidianWikiLinksFixture(t *t
 	}
 
 	for _, expected := range []string{
-		"[Project Plan](/project-plan)",
-		"[Brainstorm](/daily/brainstorm)",
+		"[[Project Plan]]",
+		"[[Brainstorm]]",
 		"[[Meeting Notes]]",
-		"[Meeting Alias](/daily/meeting-notes)",
+		"[[daily/meeting-notes|Meeting Alias]]",
 		"![diagram.png](/assets/" + homePage.ID + "/diagram.png)",
 		"`[[Project Plan]]`",
 		"[[Daily/Meeting Notes]]",
@@ -528,7 +528,7 @@ func TestImporterService_ExecuteCurrentPlan_ImportsObsidianWikiLinksFixture(t *t
 	}
 
 	for _, expected := range []string{
-		"[Meeting Notes](/daily/meeting-notes)",
+		"[[daily/meeting-notes]]",
 		"[Home](/home)",
 	} {
 		if !strings.Contains(projectPlanPage.Content, expected) {
@@ -536,11 +536,11 @@ func TestImporterService_ExecuteCurrentPlan_ImportsObsidianWikiLinksFixture(t *t
 		}
 	}
 
-	if !strings.Contains(meetingNotesPage.Content, "[Home](/home)") {
-		t.Fatalf("expected meeting-notes content to contain rewritten home link, got:\n%s", meetingNotesPage.Content)
+	if !strings.Contains(meetingNotesPage.Content, "[[Home]]") {
+		t.Fatalf("expected meeting-notes content to contain home wikilink, got:\n%s", meetingNotesPage.Content)
 	}
-	if !strings.Contains(brainstormPage.Content, "[Home](/home)") {
-		t.Fatalf("expected brainstorm content to contain rewritten home link, got:\n%s", brainstormPage.Content)
+	if !strings.Contains(brainstormPage.Content, "[[Home]]") {
+		t.Fatalf("expected brainstorm content to contain home wikilink, got:\n%s", brainstormPage.Content)
 	}
 
 	assets, err := probe.ListAssets(homePage.ID)


### PR DESCRIPTION
Plain page WikiLinks (no anchor, no asset) are now preserved as [[...]] so LeafWiki's native title-based resolution handles them — rename-aware and self-healing. Path-hinted links ([[Folder/Page]]) use the resolved slug path or fall back to slugified form. Anchor links and asset links continue to be converted to Markdown syntax.

Excerpt extraction also updated to correctly strip path prefix from wikilink targets, returning only the final page title.