### PR TITLE
feat(ui): add global ErrorBoundary with navigation-aware auto-reset

### DIFF
--- a/ui/leafwiki-ui/src/App.tsx
+++ b/ui/leafwiki-ui/src/App.tsx
@@ -1,3 +1,4 @@
+import { ErrorBoundary } from '@/components/ErrorBoundary'
 import { createLeafWikiRouter } from '@/features/router/router'
 import { useBootstrapAuth } from '@/lib/bootstrapAuth'
 import { BASE_PATH } from '@/lib/config'
@@ -66,15 +67,17 @@ function App() {
     <>
       <Toaster richColors position="bottom-right" />
       {configHasLoaded && !(isRefreshing && !authDisabled) ? (
-        <Suspense
-          fallback={
-            <div className="flex h-screen items-center justify-center">
-              <Loader2 className="text-muted-foreground h-8 w-8 animate-spin" />
-            </div>
-          }
-        >
-          <RouterProvider router={router} />
-        </Suspense>
+        <ErrorBoundary>
+          <Suspense
+            fallback={
+              <div className="flex h-screen items-center justify-center">
+                <Loader2 className="text-muted-foreground h-8 w-8 animate-spin" />
+              </div>
+            }
+          >
+            <RouterProvider router={router} />
+          </Suspense>
+        </ErrorBoundary>
       ) : null}
     </>
   )

--- a/ui/leafwiki-ui/src/components/ErrorBoundary.tsx
+++ b/ui/leafwiki-ui/src/components/ErrorBoundary.tsx
@@ -1,0 +1,83 @@
+import { Button } from '@/components/ui/button'
+import { AlertTriangle, RefreshCw } from 'lucide-react'
+import { Component, ErrorInfo } from 'react'
+import type { ReactNode } from 'react'
+
+type Props = {
+  children: ReactNode
+  resetKey?: string
+}
+
+type State = {
+  error: Error | null
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error }
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (this.state.error && prevProps.resetKey !== this.props.resetKey) {
+      this.setState({ error: null })
+    }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('[ErrorBoundary]', error, info.componentStack)
+  }
+
+  private handleReload = () => {
+    window.location.reload()
+  }
+
+  private handleReset = () => {
+    this.setState({ error: null })
+  }
+
+  render() {
+    const { error } = this.state
+
+    if (!error) return this.props.children
+
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
+        <div className="flex flex-col items-center gap-4 text-center">
+          <div className="bg-destructive/10 text-destructive flex h-16 w-16 items-center justify-center rounded-full">
+            <AlertTriangle className="h-8 w-8" />
+          </div>
+          <div className="flex flex-col gap-1">
+            <h1 className="text-foreground text-xl font-semibold">
+              Something went wrong
+            </h1>
+            <p className="text-muted-foreground max-w-md text-sm">
+              An unexpected error occurred. Reloading the page usually fixes
+              this.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex gap-3">
+          <Button onClick={this.handleReload} className="gap-2">
+            <RefreshCw className="h-4 w-4" />
+            Reload page
+          </Button>
+          <Button variant="outline" onClick={this.handleReset}>
+            Try to recover
+          </Button>
+        </div>
+
+        <details className="border-border bg-muted/40 w-full max-w-xl rounded-md border">
+          <summary className="text-muted-foreground cursor-pointer p-3 text-xs font-medium select-none">
+            Error details
+          </summary>
+          <pre className="text-destructive overflow-auto p-3 pt-0 text-xs break-all whitespace-pre-wrap">
+            {error.stack ?? error.message}
+          </pre>
+        </details>
+      </div>
+    )
+  }
+}

--- a/ui/leafwiki-ui/src/components/ErrorBoundary.tsx
+++ b/ui/leafwiki-ui/src/components/ErrorBoundary.tsx
@@ -15,8 +15,8 @@ type State = {
 export class ErrorBoundary extends Component<Props, State> {
   state: State = { error: null }
 
-  static getDerivedStateFromError(error: Error): State {
-    return { error }
+  static getDerivedStateFromError(error: unknown): State {
+    return { error: error instanceof Error ? error : new Error(String(error)) }
   }
 
   componentDidUpdate(prevProps: Props) {

--- a/ui/leafwiki-ui/src/features/router/RouterAuthWrapper.tsx
+++ b/ui/leafwiki-ui/src/features/router/RouterAuthWrapper.tsx
@@ -1,14 +1,19 @@
+import { ErrorBoundary } from '@/components/ErrorBoundary'
 import RequireAuth from '@/features/auth/RequireAuth'
 import AppLayout from '@/layout/AppLayout'
+import { useLocation } from 'react-router-dom'
 
 export default function AuthWrapper({
   children,
 }: {
   children: React.ReactNode
 }) {
+  const { pathname } = useLocation()
   return (
-    <RequireAuth>
-      <AppLayout>{children}</AppLayout>
-    </RequireAuth>
+    <ErrorBoundary resetKey={pathname}>
+      <RequireAuth>
+        <AppLayout>{children}</AppLayout>
+      </RequireAuth>
+    </ErrorBoundary>
   )
 }

--- a/ui/leafwiki-ui/src/features/router/RouterReadOnlyWrapper.tsx
+++ b/ui/leafwiki-ui/src/features/router/RouterReadOnlyWrapper.tsx
@@ -1,9 +1,16 @@
+import { ErrorBoundary } from '@/components/ErrorBoundary'
 import AppLayout from '@/layout/AppLayout'
+import { useLocation } from 'react-router-dom'
 
 export default function ReadOnlyWrapper({
   children,
 }: {
   children: React.ReactNode
 }) {
-  return <AppLayout>{children}</AppLayout>
+  const { pathname } = useLocation()
+  return (
+    <ErrorBoundary resetKey={pathname}>
+      <AppLayout>{children}</AppLayout>
+    </ErrorBoundary>
+  )
 }


### PR DESCRIPTION
Replaces unhandled React render crashes (white screen) with a user-facing error screen offering reload and soft recovery. The boundary auto-resets on navigation via a resetKey prop tied to pathname — users are not stuck on the error screen when moving to a different page.

Placed at two levels:
- App root: catches failures outside the router (e.g. RouterProvider crash)
- Route wrappers (auth + read-only): catches per-page render errors; sits outside RequireAuth so auth errors are also covered

Fixes: error.stack already contains the message on V8, so the details panel no longer renders it twice.