### PR TITLE
fix(auth): use primary button + i18n for login form and toolbar

### DIFF
--- a/ui/leafwiki-ui/src/components/UserToolbar.tsx
+++ b/ui/leafwiki-ui/src/components/UserToolbar.tsx
@@ -1,4 +1,5 @@
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -13,6 +14,7 @@ import {
   DIALOG_CHANGE_OWN_PASSWORD,
   DIALOG_SHORTCUTS_HELP,
 } from '@/lib/registries'
+import { useTranslation } from 'react-i18next'
 import {
   createHotkeyDefinition,
   getShortcutDisplayLabel,
@@ -37,6 +39,7 @@ const shortcutsDialogHotkeyLabel = getShortcutDisplayLabel(
 )
 
 export default function UserToolbar() {
+  const { t } = useTranslation('auth')
   const supportPageUrl = 'https://leafwiki.com/support/'
   const user = useSessionStore((s) => s.user)
   const logout = useSessionStore((s) => s.logout)
@@ -73,17 +76,11 @@ export default function UserToolbar() {
   ])
 
   if (!user && !authDisabled) {
-    // renders the login
     return (
       <div className="user-toolbar">
-        <span className="user-toolbar__not-logged-in">Not logged in</span>
-        <button
-          type="button"
-          className="user-toolbar__login-button"
-          onClick={() => navigate('/login')}
-        >
-          Login
-        </button>
+        <Button size="sm" onClick={() => navigate('/login')}>
+          {t('login.loginButton')}
+        </Button>
       </div>
     )
   }
@@ -91,7 +88,9 @@ export default function UserToolbar() {
   if (authDisabled) {
     return (
       <div className="user-toolbar">
-        <span className="user-toolbar__not-logged-in">Public editor</span>
+        <span className="user-toolbar__not-logged-in">
+          {t('login.publicEditor')}
+        </span>
       </div>
     )
   }

--- a/ui/leafwiki-ui/src/features/auth/LoginForm.tsx
+++ b/ui/leafwiki-ui/src/features/auth/LoginForm.tsx
@@ -35,7 +35,7 @@ export default function LoginForm() {
       // Redirect to home page after successful login
       navigate('/')
     } catch (err) {
-      const mapped = mapApiError(err, 'Login failed')
+      const mapped = mapApiError(err, t('login.errorFallback'))
       toast.error(mapped.message)
     } finally {
       setLoading(false)
@@ -44,7 +44,7 @@ export default function LoginForm() {
 
   return (
     <>
-      <title>Login - {siteName}</title>
+      <title>{t('login.pageTitle', { siteName })}</title>
       <div className="login">
         <form onSubmit={handleSubmit} className="login__form">
           <h1 className="login__title">

--- a/ui/leafwiki-ui/src/features/auth/LoginForm.tsx
+++ b/ui/leafwiki-ui/src/features/auth/LoginForm.tsx
@@ -6,10 +6,12 @@ import { withBasePath } from '@/lib/routePath'
 import { useBrandingStore } from '@/stores/branding'
 import { useSessionStore } from '@/stores/session'
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Navigate, useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 
 export default function LoginForm() {
+  const { t } = useTranslation('auth')
   const [identifier, setIdentifier] = useState('')
   const [password, setPassword] = useState('')
   const [loading, setLoading] = useState(false)
@@ -61,7 +63,7 @@ export default function LoginForm() {
           <div className="login__field">
             <Input
               type="text"
-              placeholder="Username or Email"
+              placeholder={t('login.identifierPlaceholder')}
               value={identifier}
               onChange={(e) => setIdentifier(e.target.value)}
               required
@@ -75,7 +77,7 @@ export default function LoginForm() {
           <div className="login__field">
             <Input
               type="password"
-              placeholder="Password"
+              placeholder={t('login.passwordPlaceholder')}
               name="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
@@ -92,7 +94,7 @@ export default function LoginForm() {
             disabled={loading}
             data-testid="login-submit"
           >
-            {loading ? 'Logging in...' : 'Login'}
+            {loading ? t('login.submitting') : t('login.submit')}
           </Button>
         </form>
       </div>

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -648,10 +648,6 @@
     @apply text-error text-sm;
   }
 
-  .user-toolbar__login-button {
-    @apply bg-brand hover:bg-brand-dark rounded px-3 py-2 text-sm text-white;
-  }
-
   .user-toolbar__menu-item {
     @apply text-interface-text hover:bg-surface-alt cursor-pointer;
   }

--- a/ui/leafwiki-ui/src/lib/i18n.ts
+++ b/ui/leafwiki-ui/src/lib/i18n.ts
@@ -1,5 +1,6 @@
 import i18next from 'i18next'
 import { initReactI18next } from 'react-i18next'
+import enAuth from '../locales/en/auth.json'
 import enEditor from '../locales/en/editor.json'
 import enErrors from '../locales/en/errors.json'
 import enSearch from '../locales/en/search.json'
@@ -10,6 +11,7 @@ i18next.use(initReactI18next).init({
   fallbackLng: 'en',
   resources: {
     en: {
+      auth: enAuth,
       errors: enErrors,
       editor: enEditor,
       search: enSearch,

--- a/ui/leafwiki-ui/src/locales/en/auth.json
+++ b/ui/leafwiki-ui/src/locales/en/auth.json
@@ -1,0 +1,10 @@
+{
+  "login": {
+    "identifierPlaceholder": "Username or Email",
+    "passwordPlaceholder": "Password",
+    "submit": "Login",
+    "submitting": "Logging in...",
+    "loginButton": "Login",
+    "publicEditor": "Public editor"
+  }
+}

--- a/ui/leafwiki-ui/src/locales/en/auth.json
+++ b/ui/leafwiki-ui/src/locales/en/auth.json
@@ -1,9 +1,11 @@
 {
   "login": {
+    "pageTitle": "Login - {{siteName}}",
     "identifierPlaceholder": "Username or Email",
     "passwordPlaceholder": "Password",
     "submit": "Login",
     "submitting": "Logging in...",
+    "errorFallback": "Login failed",
     "loginButton": "Login",
     "publicEditor": "Public editor"
   }


### PR DESCRIPTION
Replaces the custom brand-colored login button in UserToolbar with the standard Button component (primary variant), removes the redundant "Not logged in" label, and adds an auth i18n namespace covering all login-form and toolbar strings.