### PR TITLE
fix(ui): constrain branding logo to fit within header on mobile

### DIFF
--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -471,7 +471,7 @@
 
   /* App Layout */
   .app-layout__header {
-    @apply bg-surface fixed z-20 h-[55px] w-full border-b p-4;
+    @apply bg-surface fixed z-20 h-[55px] w-full overflow-hidden border-b p-4;
   }
 
   .app-layout__header-inner {
@@ -499,7 +499,7 @@
   }
 
   .app-layout__logo-image {
-    @apply inline-block h-16 w-auto max-w-32 shrink-0 object-contain align-middle;
+    @apply inline-block h-auto max-h-9 w-auto max-w-32 shrink-0 object-contain align-middle;
   }
 
   .app-layout__logo-emoji {


### PR DESCRIPTION
Logo image had h-16 (64px) but the header is only h-[55px] with p-4 padding, leaving only ~23px of inner space. On mobile this caused the banner to overflow and push other UI elements out of alignment.

Fix: replace h-16 with h-auto max-h-9 (36px) so the image scales down to fit. Add overflow-hidden to the header as a safety net.