### PR TITLE
fix(ui): prevent wide branding banner from pushing toolbar off screen on mobile

### DIFF
--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -487,7 +487,7 @@
   }
 
   .app-layout__logo-n-title {
-    @apply mr-6 ml-6 flex min-h-full items-center gap-2;
+    @apply mr-6 ml-6 flex min-h-full min-w-0 shrink items-center gap-2 max-sm:mr-2 max-sm:ml-2;
   }
 
   .app-layout__logo-n-title h2 {
@@ -499,7 +499,7 @@
   }
 
   .app-layout__logo-image {
-    @apply inline-block h-auto max-h-9 w-auto max-w-32 shrink-0 object-contain align-middle;
+    @apply inline-block h-auto max-h-9 w-auto max-w-32 object-contain align-middle max-sm:max-w-24;
   }
 
   .app-layout__logo-emoji {


### PR DESCRIPTION
Allow the logo container to shrink (min-w-0 + shrink), reduce its margins on small screens, and cap the image width at 96px on mobile so the save button and toolbar remain visible in portrait orientation.