### PR TITLE
perf(ui): load PageViewer and MarkdownPreview eagerly to eliminate render waterfall

### DIFF
--- a/ui/leafwiki-ui/src/features/router/lazy-routes.tsx
+++ b/ui/leafwiki-ui/src/features/router/lazy-routes.tsx
@@ -11,4 +11,4 @@ export const PageHistoryPage = lazy(() => import('../page/PageHistoryPage'))
 export const PermalinkRedirect = lazy(() => import('../page/PermalinkRedirect'))
 export const RootRedirect = lazy(() => import('../page/RootRedirect'))
 export const UserManagement = lazy(() => import('../users/UserManagement'))
-export const PageViewer = lazy(() => import('../viewer/PageViewer'))
+export { default as PageViewer } from '../viewer/PageViewer'


### PR DESCRIPTION
Every page view requires both PageViewer and MarkdownPreview. Lazy loading them caused a 3-step sequential fetch (index → PageViewer → MarkdownPreview) on every page load. Making PageViewer eager pulls MarkdownPreview into the main bundle, eliminating the waterfall at the cost of a larger initial chunk (446 kB → 1261 kB unminified; 141 kB → 389 kB gzip). Total bytes transferred remain nearly identical.