### PR TITLE
fix(editor): prevent Page404 flash when navigating to edit mode

### DIFF
--- a/ui/leafwiki-ui/src/features/editor/pageEditorStore.ts
+++ b/ui/leafwiki-ui/src/features/editor/pageEditorStore.ts
@@ -293,6 +293,7 @@ export const usePageEditorStore = create<PageEditorState>((set, get) => ({
     return get().savePage()
   },
   loadPageData: async (path: string) => {
+    useProgressbarStore.getState().setLoading(true)
     set({
       error: null,
       notFound: false,
@@ -300,7 +301,6 @@ export const usePageEditorStore = create<PageEditorState>((set, get) => ({
       initialPage: null,
       frontmatterErrors: {},
     })
-    useProgressbarStore.getState().setLoading(true)
     try {
       const page = await getPageByPath(path)
       const fields: EditorFrontmatterField[] = Object.entries(


### PR DESCRIPTION
setLoading(true) was called after resetting initialPage to null, leaving a window where !initialPage && !loading was true on the first render — briefly showing the 404 page before the load even started. Moving setLoading(true) before the store reset ensures React 18 auto-batching renders both updates together, so the 404 condition is never met.