### PR TITLE
feat(preview): register additional highlight.js languages

### DIFF
--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
@@ -24,6 +24,11 @@ import {
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown'
 import { JSX } from 'react/jsx-runtime'
 import rehypeHighlight from 'rehype-highlight'
+import dockerfile from 'highlight.js/lib/languages/dockerfile'
+import http from 'highlight.js/lib/languages/http'
+import nginx from 'highlight.js/lib/languages/nginx'
+import nix from 'highlight.js/lib/languages/nix'
+import protobuf from 'highlight.js/lib/languages/protobuf'
 import rehypeKatex from 'rehype-katex'
 import rehypeRaw from 'rehype-raw'
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
@@ -617,7 +622,10 @@ export default function MarkdownPreview({
             rehypeWhitelistStyles,
             [rehypeKatex, { output: 'html', strict: 'ignore' }],
             [rehypeSanitize, schema],
-            rehypeHighlight,
+            [
+              rehypeHighlight,
+              { languages: { dockerfile, http, nginx, nix, protobuf } },
+            ],
           ]}
           components={components}
           urlTransform={transformMarkdownUrl}

--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
@@ -24,6 +24,7 @@ import {
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown'
 import { JSX } from 'react/jsx-runtime'
 import rehypeHighlight from 'rehype-highlight'
+import { common } from 'lowlight'
 import dockerfile from 'highlight.js/lib/languages/dockerfile'
 import http from 'highlight.js/lib/languages/http'
 import nginx from 'highlight.js/lib/languages/nginx'
@@ -624,7 +625,16 @@ export default function MarkdownPreview({
             [rehypeSanitize, schema],
             [
               rehypeHighlight,
-              { languages: { dockerfile, http, nginx, nix, protobuf } },
+              {
+                languages: {
+                  ...common,
+                  dockerfile,
+                  http,
+                  nginx,
+                  nix,
+                  protobuf,
+                },
+              },
             ],
           ]}
           components={components}


### PR DESCRIPTION
Adds nix, dockerfile, nginx, http, and protobuf to rehype-highlight. These are absent from highlight.js's default common subset but frequently appear in developer wikis.