### PR TITLE
fix(editor): preserve wikilink line text

### DIFF
--- a/ui/leafwiki-ui/src/features/editor/internalLinkCompletion.test.ts
+++ b/ui/leafwiki-ui/src/features/editor/internalLinkCompletion.test.ts
@@ -81,6 +81,25 @@ describe('wikiLinkCompletionSource', () => {
     expect(result?.to).toBe(doc.length)
     expect(result?.options[0]?.apply).toBe('Target Page]]')
   })
+
+  it('does not replace text after the cursor on the same line', () => {
+    useTreeStore.setState({
+      flatPages: [item('Target Page', 'docs/target-page')],
+    })
+
+    const doc = 'Before [[Target after text'
+    const cursorPos = 'Before [[Target'.length
+    const state = EditorState.create({ doc })
+    const context = new CompletionContext(state, cursorPos, true)
+    const result = wikiLinkCompletionSource(context)
+
+    expect(result).not.toBeNull()
+    expect(result?.from).toBe('Before [['.length)
+    expect(result?.to).toBe(cursorPos)
+
+    const applied = `${doc.slice(0, result!.from)}${String(result!.options[0]!.apply)}${doc.slice(result!.to)}`
+    expect(applied).toBe('Before [[Target Page]] after text')
+  })
 })
 
 describe('buildMarkdownLinkOptions', () => {

--- a/ui/leafwiki-ui/src/features/editor/internalLinkCompletion.ts
+++ b/ui/leafwiki-ui/src/features/editor/internalLinkCompletion.ts
@@ -56,8 +56,9 @@ function getWikiLinkRange(context: CompletionContext) {
   if (!match) return null
 
   const typedQuery = match[1] ?? ''
-  // Include ] / ]] after cursor in the range so they get replaced on completion
-  const suffix = afterCursor.match(/^[^\]\n]*(\]{1,2})?/)?.[0] ?? ''
+  // Only replace text to the right when we're already inside a wikilink that
+  // closes later on the same line; otherwise preserve trailing line content.
+  const suffix = afterCursor.match(/^[^\]\n]*\]{1,2}/)?.[0] ?? ''
 
   return {
     from: pos - typedQuery.length,


### PR DESCRIPTION
Limit wikilink autocomplete replacement to the link suffix so text after the cursor on the same line is preserved.

Add a regression test covering completion in the middle of a line.