### PR TITLE
fix(links): ignore [[ ]] wiki-link syntax inside code blocks

### DIFF
--- a/internal/links/helpers.go
+++ b/internal/links/helpers.go
@@ -92,14 +92,18 @@ func extractLinksFromMarkdown(content string) []string {
 // [[Target|Alias]] syntax found in content. The returned strings are the raw
 // target values (may be a title or a "Folder/Title" path hint).
 func extractWikiLinksFromMarkdown(content string) []string {
-	matches := wikiLinkRe.FindAllStringSubmatch(content, -1)
+	excluded := NewMarkdownRefactorEngine().collectExcludedRanges(content)
+	matches := wikiLinkRe.FindAllStringSubmatchIndex(content, -1)
 	if len(matches) == 0 {
 		return nil
 	}
 	seen := make(map[string]struct{}, len(matches))
 	targets := make([]string, 0, len(matches))
 	for _, m := range matches {
-		target := strings.TrimSpace(m[1])
+		if isExcludedOffset(m[0], excluded) || m[2] == -1 {
+			continue
+		}
+		target := strings.TrimSpace(content[m[2]:m[3]])
 		if target == "" {
 			continue
 		}

--- a/internal/links/link_service_test.go
+++ b/internal/links/link_service_test.go
@@ -1301,6 +1301,41 @@ func TestExtractWikiLinksFromMarkdown_DeduplicatesTargets(t *testing.T) {
 	}
 }
 
+func TestExtractWikiLinksFromMarkdown_IgnoresFencedCodeBlock(t *testing.T) {
+	md := "```bash\nif [[ -n \"$computed_hash\" && -n \"$src_hash\" ]]; then\n  [[ \"$src_hash\" == sha256-* ]]\nfi\n```\n"
+
+	got := extractWikiLinksFromMarkdown(md)
+	if len(got) != 0 {
+		t.Fatalf("expected no wiki links from fenced code block, got %v", got)
+	}
+}
+
+func TestExtractWikiLinksFromMarkdown_IgnoresInlineCode(t *testing.T) {
+	got := extractWikiLinksFromMarkdown("`[[ -n $x ]]`")
+	if len(got) != 0 {
+		t.Fatalf("expected no wiki links from inline code, got %v", got)
+	}
+}
+
+func TestExtractWikiLinksFromMarkdown_MixedRealAndCodeBlock(t *testing.T) {
+	md := "See [[Real Page]].\n\n```\n[[ -z \"$x\" ]]\n```\n"
+
+	got := extractWikiLinksFromMarkdown(md)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 wiki link, got %d: %v", len(got), got)
+	}
+	if got[0] != "Real Page" {
+		t.Errorf("got %q, want %q", got[0], "Real Page")
+	}
+}
+
+func TestExtractWikiLinksFromMarkdown_IgnoresIndentedCodeBlock(t *testing.T) {
+	got := extractWikiLinksFromMarkdown("    [[ Something ]]\n")
+	if len(got) != 0 {
+		t.Fatalf("expected no wiki links from indented code block, got %v", got)
+	}
+}
+
 func TestExtractWikiLinksFromMarkdown_Empty(t *testing.T) {
 	got := extractWikiLinksFromMarkdown("No wiki links here.")
 	if len(got) != 0 {


### PR DESCRIPTION
## Summary

`extractWikiLinksFromMarkdown` in `internal/links/helpers.go` ran the `[[Target]]` wiki-link regex over the entire raw page content with no awareness of code blocks. As a result, bash `[[ ... ]]` test expressions inside fenced or inline code were parsed as wiki-links and produced spurious "Broken links" records.

This change excludes code spans and code blocks from wiki-link extraction by reusing the goldmark-AST exclusion machinery that already exists in the same package for the link-rewrite engine.

## Why this matters

Saving a page whose body contains a bash code block such as:

```bash
if [[ -n "$computed_hash" && -n "$src_hash" ]]; then
```

previously generated false "Broken links" entries pointing at fragments like `-n "$computed_hash" && -n "$src_hash"` and `"$src_hash" == sha256-*` (reported in #1200). These are shell test expressions, not wiki-links, and should never have been indexed.

## Changes

- `internal/links/helpers.go`: `extractWikiLinksFromMarkdown` now computes excluded code ranges once via `NewMarkdownRefactorEngine().collectExcludedRanges(content)` (the existing goldmark walk over `*ast.CodeSpan` / `*ast.FencedCodeBlock` / `*ast.CodeBlock`), switches from `FindAllStringSubmatch` to `FindAllStringSubmatchIndex`, and skips any match whose `[[` start offset falls inside an excluded range via `isExcludedOffset`. Trimming, empty-skip, ordering, and dedup behavior for real wiki-links outside code is unchanged.
- `internal/links/link_service_test.go`: added regression tests for fenced bash code blocks (the exact #1200 repro), inline code spans, mixed real-link-plus-code-block bodies, and indented code blocks.

## Testing

```
go vet ./internal/links/...
go build ./...
go test ./internal/links/...
```

All pass. The new tests fail before the fix (the #1200 bash snippet yields two false targets) and pass after.

Note: this addresses the backend "Broken links" false-positive half of #1200. The separate client-side KaTeX preview parse error is rendered in the React/KaTeX frontend and is out of scope for this Go change.

Refs #1200
