### PR TITLE
fix: ignore bash [[ ]] conditionals and disable single-dollar math

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ docker run -p 8080:8080 -v ~/leafwiki-data:/app/data \
 - Backlinks and link status per page (incoming, outgoing, broken links)
 - Built-in Markdown editor with live preview, keyboard shortcuts, and autocomplete for internal page links
 - Optimistic locking for concurrent edits
-- Markdown: tables, task lists, footnotes, callouts (`:::info` / `:::warning`), Mermaid diagrams, KaTeX math blocks (`$$...$$`), sanitized inline HTML
+- Markdown: tables, task lists, footnotes, callouts (`:::info` / `:::warning`), Mermaid diagrams, KaTeX math blocks (`$$...$$`, inline `$...$` not supported), sanitized inline HTML
 
 **Customization:**
 - Custom stylesheet (`--custom-stylesheet`, v0.8.5+)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ docker run -p 8080:8080 -v ~/leafwiki-data:/app/data \
 - Backlinks and link status per page (incoming, outgoing, broken links)
 - Built-in Markdown editor with live preview, keyboard shortcuts, and autocomplete for internal page links
 - Optimistic locking for concurrent edits
-- Markdown: tables, task lists, footnotes, callouts (`:::info` / `:::warning`), Mermaid diagrams, sanitized inline HTML
+- Markdown: tables, task lists, footnotes, callouts (`:::info` / `:::warning`), Mermaid diagrams, KaTeX math blocks (`$$...$$`), sanitized inline HTML
 
 **Customization:**
 - Custom stylesheet (`--custom-stylesheet`, v0.8.5+)

--- a/internal/links/helpers.go
+++ b/internal/links/helpers.go
@@ -13,7 +13,9 @@ import (
 
 // wikiLinkRe matches [[Target]] and [[Target|Alias]] syntax.
 // Capture group 1 is the target (title or path hint).
-var wikiLinkRe = regexp.MustCompile(`\[\[([^\]|#\n]+?)(?:\|[^\]\n]+?)?\]\]`)
+// \S as first character rejects bash-style [[ -n ... ]] conditionals (which always
+// start with a space after [[) without affecting real wiki-link titles.
+var wikiLinkRe = regexp.MustCompile(`\[\[(\S[^\]|#\n]*?)(?:\|[^\]\n]+?)?\]\]`)
 
 // wikilinkSentinelPrefix is the to_path prefix used for broken wiki-link
 // records in the link store. It must never collide with real wiki route paths

--- a/internal/links/link_service_test.go
+++ b/internal/links/link_service_test.go
@@ -1336,6 +1336,19 @@ func TestExtractWikiLinksFromMarkdown_IgnoresIndentedCodeBlock(t *testing.T) {
 	}
 }
 
+func TestExtractWikiLinksFromMarkdown_IgnoresBashConditionalsOutsideCodeBlocks(t *testing.T) {
+	cases := []string{
+		`if [[ -n "$computed_hash" && -n "$src_hash" ]]; then`,
+		`if [[ "$src_hash" == sha256-* ]]; then`,
+	}
+	for _, content := range cases {
+		got := extractWikiLinksFromMarkdown(content)
+		if len(got) != 0 {
+			t.Errorf("input %q: expected no wiki links, got %v", content, got)
+		}
+	}
+}
+
 func TestExtractWikiLinksFromMarkdown_Empty(t *testing.T) {
 	got := extractWikiLinksFromMarkdown("No wiki links here.")
 	if len(got) != 0 {

--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
@@ -616,7 +616,12 @@ export default function MarkdownPreview({
     <MarkdownPreviewErrorBoundary resetKey={`${path ?? ''}:${content}`}>
       <>
         <ReactMarkdown
-          remarkPlugins={[remarkMath, remarkGfm]}
+          // singleDollarTextMath disabled: $var in bash/code prose would be parsed
+          // as math delimiters and conflict with wikilink preprocessing. Use $$...$$ for math.
+          remarkPlugins={[
+            [remarkMath, { singleDollarTextMath: false }],
+            remarkGfm,
+          ]}
           rehypePlugins={[
             rehypeRaw,
             rehypeLineNumber,

--- a/ui/leafwiki-ui/src/lib/preprocessWikilinks.test.ts
+++ b/ui/leafwiki-ui/src/lib/preprocessWikilinks.test.ts
@@ -155,6 +155,14 @@ describe('preprocessWikilinks', () => {
       const result = preprocessWikilinks(content, noMatch)
       expect(result).toBe(content)
     })
+
+    // [[ <space>Title ]] is intentionally not supported — leading whitespace after [[
+    // is the distinguishing marker of bash conditionals and is therefore rejected.
+    it('does not treat [[ Title ]] with leading space as a wikilink', () => {
+      const content = '[[ Intro ]]'
+      const result = preprocessWikilinks(content, noMatch)
+      expect(result).toBe(content)
+    })
   })
 
   describe('edge cases', () => {

--- a/ui/leafwiki-ui/src/lib/preprocessWikilinks.test.ts
+++ b/ui/leafwiki-ui/src/lib/preprocessWikilinks.test.ts
@@ -36,10 +36,10 @@ describe('preprocessWikilinks', () => {
       expect(result).toBe('[our intro](/docs/intro)')
     })
 
-    it('trims whitespace from target and alias', () => {
+    it('trims trailing whitespace from target and alias', () => {
       const docs = page('1', 'docs/intro', 'Intro')
       const result = preprocessWikilinks(
-        '[[ Intro | our intro ]]',
+        '[[Intro |our intro ]]',
         singleMatch(docs),
       )
       expect(result).toBe('[our intro](/docs/intro)')
@@ -139,6 +139,21 @@ describe('preprocessWikilinks', () => {
       preprocessWikilinks('[[Notes]] and [[notes]]', getPagesByTitle)
       // cache key is lowercased, so both resolve from the same cache entry
       expect(getPagesByTitle).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // Regression for #1200: bash [[ ... ]] conditionals must not be treated as wikilinks
+  describe('bash double-bracket conditionals', () => {
+    it('does not treat [[ ]] in bash conditionals as a wikilink', () => {
+      const content = 'if [[ -n "$computed_hash" && -n "$src_hash" ]]; then'
+      const result = preprocessWikilinks(content, noMatch)
+      expect(result).toBe(content)
+    })
+
+    it('does not treat [[ ]] with == operator as a wikilink', () => {
+      const content = 'if [[ "$src_hash" == sha256-* ]]; then'
+      const result = preprocessWikilinks(content, noMatch)
+      expect(result).toBe(content)
     })
   })
 

--- a/ui/leafwiki-ui/src/lib/preprocessWikilinks.ts
+++ b/ui/leafwiki-ui/src/lib/preprocessWikilinks.ts
@@ -1,6 +1,6 @@
 import { PageNode } from '@/lib/api/pages'
 
-const WIKILINK_RE = /\[\[([^\]|#\n]+?)(?:\|([^\]\n]+?))?\]\]/g
+const WIKILINK_RE = /\[\[(\S[^\]|#\n]*?)(?:\|([^\]\n]+?))?\]\]/g
 
 // Splits content into alternating [text, code, text, code, ...] segments.
 // The capture group keeps the code spans in the result array at odd indices.


### PR DESCRIPTION
Wiki-link regex now requires a non-whitespace first character after [[, which prevents bash-style conditionals (e.g. [[ -n "$var" ]]) from being matched as wiki-links in both the Go backend and the TS preprocessor.

Disables singleDollarTextMath in remarkMath to avoid conflicts between $var in bash prose and math delimiters; use $$...$$ for math blocks.