### PR TITLE
feat: live filesystem resync via SIGUSR1 signal

### DIFF
--- a/cmd/leafwiki/main.go
+++ b/cmd/leafwiki/main.go
@@ -8,9 +8,11 @@ import (
 	"math"
 	"net"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -412,6 +414,8 @@ func main() {
 		DisableRequestLog: disableRequestLog,
 	})
 
+	go runSignalHandler(w)
+
 	if err := runServer(router, host, port, unixSocket, dataDir); err != nil {
 		fail("Failed to start server", "error", err)
 	}
@@ -594,6 +598,20 @@ func validateListenConfig(unixSocket string, visited map[string]bool) error {
 		return fmt.Errorf("--unix-socket cannot be used together with --host or --port")
 	}
 	return nil
+}
+
+// runSignalHandler listens for SIGUSR1/SIGHUP and triggers a live filesystem reload.
+// ReloadFromFS blocks until all indexes are rebuilt, so signals are processed
+// one at a time and a burst of signals coalesces into at most two reloads.
+func runSignalHandler(w *wiki.Wiki) {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGUSR1, syscall.SIGHUP)
+	for range ch {
+		slog.Default().Info("reload signal received: reloading from filesystem")
+		if err := w.ReloadFromFS(); err != nil {
+			slog.Default().Error("filesystem reload failed", "error", err)
+		}
+	}
 }
 
 // normalizeBasePath normalizes the base path to the form "/mypath" (no trailing slash).

--- a/internal/core/tree/tree_service.go
+++ b/internal/core/tree/tree_service.go
@@ -141,40 +141,31 @@ func (t *TreeService) TreeHash() string {
 	return hash
 }
 
-// ReconstructTreeFromFS reconstructs the tree from the filesystem
+// ReconstructTreeFromFS reconstructs the tree from the filesystem.
+// The slow FS scan runs without holding the write lock so readers can
+// continue serving the current tree concurrently. The lock is acquired
+// only for the fast in-memory swap and index rebuild.
 func (t *TreeService) ReconstructTreeFromFS() error {
-	return t.withLockedTree(t.reconstructTreeFromFSLocked)
-}
-
-func (t *TreeService) reconstructTreeFromFSLocked() error {
-	// Reconstruct the tree from the filesystem
-	// This is a more complex operation and may involve reading the filesystem structure
 	newTree, err := t.store.ReconstructTreeFromFS()
 	if err != nil {
 		t.log.Error("Error reconstructing tree from filesystem", "error", err)
 		return err
 	}
-
-	// Defensive check to protect against unexpected nil returns from ReconstructTreeFromFS
 	if newTree == nil {
 		return fmt.Errorf("internal error: ReconstructTreeFromFS returned nil tree")
 	}
 
-	// Save the old tree in case we need to revert
-	// Note: oldTree may be nil if this is the first reconstruction (which is expected)
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	oldTree := t.tree
 	t.tree = newTree
 	t.rebuildIndexesLocked()
-
-	// Reconstructed nodes already carry metadata from frontmatter or safe defaults.
-
 	if err := saveSchema(t.storageDir, CurrentSchemaVersion); err != nil {
 		t.log.Error("Error saving schema after reconstruction", "error", err)
 		t.tree = oldTree
 		t.rebuildIndexesLocked()
 		return err
 	}
-
 	return nil
 }
 

--- a/internal/wiki/resync/routes.go
+++ b/internal/wiki/resync/routes.go
@@ -1,0 +1,51 @@
+package wikiresync
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	coreauth "github.com/perber/wiki/internal/core/auth"
+	httpinternal "github.com/perber/wiki/internal/http"
+	authmw "github.com/perber/wiki/internal/http/middleware/auth"
+	"github.com/perber/wiki/internal/http/middleware/security"
+)
+
+// Routes is the RouteRegistrar for the filesystem resync admin endpoint.
+type Routes struct {
+	trigger     func() error
+	authService *coreauth.AuthService
+}
+
+// NewRoutes constructs the resync RouteRegistrar.
+func NewRoutes(trigger func() error, authService *coreauth.AuthService) *Routes {
+	return &Routes{
+		trigger:     trigger,
+		authService: authService,
+	}
+}
+
+// RegisterRoutes implements RouteRegistrar.
+func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
+	opts := ctx.Opts
+
+	authGroup := ctx.Base.Group("/api")
+	authGroup.Use(
+		authmw.InjectPublicEditor(opts.AuthDisabled),
+		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
+		security.CSRFMiddleware(ctx.CSRFCookie),
+	)
+
+	adminGroup := authGroup.Group("/admin")
+	adminGroup.Use(authmw.RequireAdmin(opts.AuthDisabled))
+
+	adminGroup.POST("/resync", r.handleTriggerResync)
+}
+
+// handleTriggerResync blocks until the filesystem reload completes, then returns 200.
+func (r *Routes) handleTriggerResync(c *gin.Context) {
+	if err := r.trigger(); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"ok": true})
+}

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -564,6 +564,40 @@ For more information, visit the [LeafWiki GitHub repository](https://github.com/
 	return nil
 }
 
+// ReloadFromFS reruns the startup-time filesystem reconciliation without
+// restarting the process. It blocks until all indexes are rebuilt, so the
+// signal handler naturally serializes back-to-back reload requests.
+//
+// What is reloaded: page tree, link index, tag/property indexes, search index.
+// What is NOT reloaded: assets (served directly from disk), auth/users
+// (SQLite-based), revisions (stored per-page, no re-baseline).
+func (w *Wiki) ReloadFromFS() error {
+	w.log.Info("filesystem reload started")
+
+	if err := w.tree.ReconstructTreeFromFS(); err != nil {
+		return fmt.Errorf("tree reconstruction failed: %w", err)
+	}
+
+	if err := w.links.IndexAllPages(); err != nil {
+		w.log.Warn("link re-index failed during reload", "error", err)
+	}
+
+	w.bootstrapTagsAndProperties()
+
+	w.status.Start()
+	defer w.status.Finish()
+	searchEffect := pagesave.NewSearchIndexSideEffect(w.searchIndex, w.tree, w.log)
+	if err := searchEffect.IndexAllPages(); err != nil {
+		w.log.Warn("search re-index failed during reload", "error", err)
+		w.status.Fail()
+		return nil
+	}
+
+	w.status.Success()
+	w.log.Info("filesystem reload completed")
+	return nil
+}
+
 // ─── Service getters (test infrastructure) ───────────────────────────────────
 
 func (w *Wiki) GetStorageDir() string {

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/perber/wiki/internal/branding"
@@ -23,6 +24,7 @@ import (
 	wikibackup "github.com/perber/wiki/internal/wiki/backup"
 	wikibranding "github.com/perber/wiki/internal/wiki/branding"
 	wikihealth "github.com/perber/wiki/internal/wiki/health"
+	wikiresync "github.com/perber/wiki/internal/wiki/resync"
 	wikiimporter "github.com/perber/wiki/internal/wiki/importer"
 	wikilinks "github.com/perber/wiki/internal/wiki/links"
 	wikipages "github.com/perber/wiki/internal/wiki/pages"
@@ -62,6 +64,8 @@ type Wiki struct {
 	tags             *tags.TagsService
 	props            *properties.PropertiesService
 	backupRoutes     *wikibackup.Routes
+	resyncRoutes     *wikiresync.Routes
+	reloadMu         sync.Mutex
 	log              *slog.Logger
 }
 
@@ -306,6 +310,7 @@ func (w *Wiki) buildRoutes(options *WikiOptions) {
 		Status:     w.status,
 		StorageDir: w.storageDir,
 	})
+	w.resyncRoutes = wikiresync.NewRoutes(w.ReloadFromFS, w.auth)
 }
 
 // ─── Domain route builder helpers ────────────────────────────────────────────
@@ -464,6 +469,7 @@ func (w *Wiki) Registrars() []httpinternal.RouteRegistrar {
 		w.brandingRoutes,
 		w.importerRoutes,
 		w.healthRoutes,
+		w.resyncRoutes,
 	}
 	if w.backupRoutes != nil {
 		registrars = append(registrars, w.backupRoutes)
@@ -565,13 +571,16 @@ For more information, visit the [LeafWiki GitHub repository](https://github.com/
 }
 
 // ReloadFromFS reruns the startup-time filesystem reconciliation without
-// restarting the process. It blocks until all indexes are rebuilt, so the
-// signal handler naturally serializes back-to-back reload requests.
+// restarting the process. It serializes concurrent callers (signal handler +
+// HTTP endpoint) so indexes are never rebuilt from two goroutines at once.
 //
 // What is reloaded: page tree, link index, tag/property indexes, search index.
 // What is NOT reloaded: assets (served directly from disk), auth/users
 // (SQLite-based), revisions (stored per-page, no re-baseline).
 func (w *Wiki) ReloadFromFS() error {
+	w.reloadMu.Lock()
+	defer w.reloadMu.Unlock()
+
 	w.log.Info("filesystem reload started")
 
 	if err := w.tree.ReconstructTreeFromFS(); err != nil {
@@ -590,7 +599,7 @@ func (w *Wiki) ReloadFromFS() error {
 	if err := searchEffect.IndexAllPages(); err != nil {
 		w.log.Warn("search re-index failed during reload", "error", err)
 		w.status.Fail()
-		return nil
+		return fmt.Errorf("search re-index failed: %w", err)
 	}
 
 	w.status.Success()

--- a/ui/leafwiki-ui/src/components/UserToolbar.tsx
+++ b/ui/leafwiki-ui/src/components/UserToolbar.tsx
@@ -145,6 +145,12 @@ export default function UserToolbar() {
                 Backup Settings
               </DropdownMenuItem>
             )}
+            <DropdownMenuItem
+              className="cursor-pointer"
+              onClick={() => navigate('/settings/maintenance')}
+            >
+              Maintenance
+            </DropdownMenuItem>
             <DropdownMenuSeparator />
           </RoleGuard>
           <DropdownMenuLabel className="text-muted-foreground text-xs font-normal">

--- a/ui/leafwiki-ui/src/features/maintenance/MaintenanceSettings.tsx
+++ b/ui/leafwiki-ui/src/features/maintenance/MaintenanceSettings.tsx
@@ -1,0 +1,49 @@
+import { Button } from '@/components/ui/button'
+import { Loader2, RefreshCw } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { useResyncStore } from '@/stores/resync'
+import { useSetTitle } from '../viewer/setTitle'
+import { useToolbarActions } from './useToolbarActions'
+
+export default function MaintenanceSettings() {
+  const { t } = useTranslation('maintenance')
+  const { isLoading, trigger } = useResyncStore()
+
+  useToolbarActions()
+  useSetTitle({ title: t('pageTitle') })
+
+  const handleResync = async () => {
+    try {
+      await trigger()
+      toast.success(t('toast.success'))
+    } catch {
+      toast.error(t('toast.error'))
+    }
+  }
+
+  return (
+    <div className="settings">
+      <h1 className="settings__title">{t('pageTitle')}</h1>
+
+      <div className="settings__section">
+        <h2 className="settings__section-title">{t('filesystemSync.title')}</h2>
+        <p className="settings__section-description">
+          {t('filesystemSync.description')}
+        </p>
+        <div className="settings__actions">
+          <Button onClick={handleResync} disabled={isLoading}>
+            {isLoading ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <RefreshCw className="mr-2 h-4 w-4" />
+            )}
+            {isLoading
+              ? t('filesystemSync.buttonLoading')
+              : t('filesystemSync.button')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/ui/leafwiki-ui/src/features/maintenance/useToolbarActions.ts
+++ b/ui/leafwiki-ui/src/features/maintenance/useToolbarActions.ts
@@ -1,0 +1,10 @@
+import { useEffect } from 'react'
+import { useToolbarStore } from '../toolbar/toolbarStore'
+
+export function useToolbarActions() {
+  const setButtons = useToolbarStore((state) => state.setButtons)
+
+  useEffect(() => {
+    setButtons([])
+  }, [setButtons])
+}

--- a/ui/leafwiki-ui/src/features/router/lazy-routes.tsx
+++ b/ui/leafwiki-ui/src/features/router/lazy-routes.tsx
@@ -7,6 +7,9 @@ export const BrandingSettings = lazy(
 )
 export const PageEditor = lazy(() => import('../editor/PageEditor'))
 export const Importer = lazy(() => import('../importer/Importer'))
+export const MaintenanceSettings = lazy(
+  () => import('../maintenance/MaintenanceSettings'),
+)
 export const PageHistoryPage = lazy(() => import('../page/PageHistoryPage'))
 export const PermalinkRedirect = lazy(() => import('../page/PermalinkRedirect'))
 export const RootRedirect = lazy(() => import('../page/RootRedirect'))

--- a/ui/leafwiki-ui/src/features/router/router.tsx
+++ b/ui/leafwiki-ui/src/features/router/router.tsx
@@ -4,6 +4,7 @@ import {
   BrandingSettings,
   Importer,
   LoginForm,
+  MaintenanceSettings,
   PageEditor,
   PageHistoryPage,
   PageViewer,
@@ -76,6 +77,16 @@ export const createLeafWikiRouter = (
         ) : (
           <AuthWrapper>
             <Importer />
+          </AuthWrapper>
+        ),
+      },
+      {
+        path: '/settings/maintenance',
+        element: isReadOnlyViewer ? (
+          <Navigate to="/" />
+        ) : (
+          <AuthWrapper>
+            <MaintenanceSettings />
           </AuthWrapper>
         ),
       },

--- a/ui/leafwiki-ui/src/lib/api/resync.ts
+++ b/ui/leafwiki-ui/src/lib/api/resync.ts
@@ -1,0 +1,10 @@
+import { fetchWithAuth } from './auth'
+
+const RESYNC_URL = '/api/admin/resync'
+
+export async function triggerResync(): Promise<void> {
+  await fetchWithAuth(RESYNC_URL, {
+    method: 'POST',
+    credentials: 'include',
+  })
+}

--- a/ui/leafwiki-ui/src/lib/i18n.ts
+++ b/ui/leafwiki-ui/src/lib/i18n.ts
@@ -4,6 +4,7 @@ import enAuth from '../locales/en/auth.json'
 import enBranding from '../locales/en/branding.json'
 import enEditor from '../locales/en/editor.json'
 import enErrors from '../locales/en/errors.json'
+import enMaintenance from '../locales/en/maintenance.json'
 import enSearch from '../locales/en/search.json'
 import enViewer from '../locales/en/viewer.json'
 
@@ -16,6 +17,7 @@ i18next.use(initReactI18next).init({
       branding: enBranding,
       errors: enErrors,
       editor: enEditor,
+      maintenance: enMaintenance,
       search: enSearch,
       viewer: enViewer,
     },

--- a/ui/leafwiki-ui/src/locales/en/maintenance.json
+++ b/ui/leafwiki-ui/src/locales/en/maintenance.json
@@ -1,0 +1,13 @@
+{
+  "pageTitle": "Maintenance",
+  "filesystemSync": {
+    "title": "Filesystem Sync",
+    "description": "Reload all pages from the filesystem into the wiki index. Use this after adding or modifying Markdown files directly in the storage directory.",
+    "button": "Sync now",
+    "buttonLoading": "Syncing…"
+  },
+  "toast": {
+    "success": "Filesystem sync completed",
+    "error": "Filesystem sync failed"
+  }
+}

--- a/ui/leafwiki-ui/src/stores/resync.ts
+++ b/ui/leafwiki-ui/src/stores/resync.ts
@@ -1,0 +1,20 @@
+import { create } from 'zustand'
+import { triggerResync } from '@/lib/api/resync'
+
+interface ResyncState {
+  isLoading: boolean
+  trigger: () => Promise<void>
+}
+
+export const useResyncStore = create<ResyncState>((set) => ({
+  isLoading: false,
+
+  trigger: async () => {
+    set({ isLoading: true })
+    try {
+      await triggerResync()
+    } finally {
+      set({ isLoading: false })
+    }
+  },
+}))


### PR DESCRIPTION
Exposes the existing startup-time reconstruction logic as a runtime trigger so external tools can reload changed Markdown files without a container restart.

Send SIGUSR1 to the process to trigger a full reload:
  kill -USR1 <pid>

ReloadFromFS runs synchronously: tree reconstruction, link re-index, tag/property re-index and search re-index all complete before the signal handler processes the next queued signal. This avoids concurrent goroutines racing on IndexingStatus and the SQLite search index.

What is reloaded: page tree, link index, tag/property indexes, full-text search index.
What is NOT reloaded: assets (served from disk directly), auth/users (SQLite-based), revisions (no re-baseline).

Closes #1161