### PR TITLE
Add version info for --unix-socket option

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ For plain HTTP: add `--allow-insecure=true` so login and CSRF cookies work.
 |----------------------------------|-------------------------------------------------------------------------|---------------|---------|
 | `--host`                         | Host/IP the server binds to                                             | `127.0.0.1`   | –       |
 | `--port`                         | Port the server listens on                                              | `8080`        | –       |
-| `--unix-socket`                  | Unix domain socket path; overrides `--host` and `--port`                | `""`          | –       |
+| `--unix-socket`                  | Unix domain socket path; overrides `--host` and `--port`                | `""`          | v0.11.3 |
 | `--data-dir`                     | Directory where data is stored                                          | `./data`      | –       |
 | `--public-access`                | Allow public read-only access                                           | `false`       | –       |
 | `--base-path`                    | URL prefix for reverse proxy setups (e.g. `/wiki`)                      | `""`          | v0.8.2  |
@@ -298,7 +298,7 @@ For plain HTTP: add `--allow-insecure=true` so login and CSRF cookies work.
 |-----------------------------------------|------------------------------------------------------|---------------|---------|
 | `LEAFWIKI_HOST`                         | Host/IP address                                      | `127.0.0.1`   | –       |
 | `LEAFWIKI_PORT`                         | Port                                                 | `8080`        | –       |
-| `LEAFWIKI_UNIX_SOCKET`                  | Unix domain socket path; overrides host/port         | `""`          | –       |
+| `LEAFWIKI_UNIX_SOCKET`                  | Unix domain socket path; overrides host/port         | `""`          | v0.11.3 |
 | `LEAFWIKI_DATA_DIR`                     | Data directory path                                  | `./data`      | –       |
 | `LEAFWIKI_ADMIN_PASSWORD`               | Initial admin password *(required)*                  | –             | –       |
 | `LEAFWIKI_JWT_SECRET`                   | JWT signing secret *(required)*                      | –             | –       |
@@ -355,7 +355,7 @@ Available since v0.10.0. Use when an upstream proxy authenticates users and forw
 - If the forwarded username doesn't exist in LeafWiki, the request is rejected
 - Do not enable without configuring `--trusted-proxy-ips`
 
-### Unix Socket
+### Unix Socket (v0.11.3)
 
 Use `--unix-socket` when LeafWiki should listen on a local unix domain socket instead of TCP.
 


### PR DESCRIPTION
Updated the documentation to reflect the versioning of the `--unix-socket` option.