### PR TITLE
fix(editor): allow save without rewrite

### DIFF
--- a/ui/leafwiki-ui/src/features/editor/pageEditorStore.ts
+++ b/ui/leafwiki-ui/src/features/editor/pageEditorStore.ts
@@ -170,7 +170,9 @@ export const usePageEditorStore = create<PageEditorState>((set, get) => ({
           title,
           slug,
         })
-        const rewriteLinks = await confirmPageRefactor(preview)
+        const rewriteLinks = await confirmPageRefactor(preview, {
+          allowSkipRewrite: true,
+        })
         if (rewriteLinks === null) {
           return null
         }

--- a/ui/leafwiki-ui/src/features/page/PageRefactorDialog.test.tsx
+++ b/ui/leafwiki-ui/src/features/page/PageRefactorDialog.test.tsx
@@ -1,0 +1,62 @@
+import { DIALOG_PAGE_REFACTOR_CONFIRMATION } from '@/lib/registries'
+import { useDialogsStore } from '@/stores/dialogs'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { PageRefactorDialog } from './PageRefactorDialog'
+
+const preview = {
+  kind: 'rename' as const,
+  pageId: 'page-1',
+  oldPath: '/docs/alpha',
+  newPath: '/docs/beta',
+  affectedPages: [],
+  counts: {
+    affectedPages: 1,
+    matchedLinks: 2,
+  },
+  warnings: [],
+}
+
+describe('PageRefactorDialog', () => {
+  beforeEach(() => {
+    useDialogsStore.setState({
+      dialogType: DIALOG_PAGE_REFACTOR_CONFIRMATION,
+      dialogProps: null,
+    })
+  })
+
+  it('lets the editor save without rewriting links when enabled', async () => {
+    const user = userEvent.setup()
+    const onResolve = vi.fn()
+
+    render(
+      <PageRefactorDialog
+        preview={preview}
+        onResolve={onResolve}
+        allowSkipRewrite
+      />,
+    )
+
+    await user.click(
+      screen.getByTestId('page-refactor-dialog-button-save-without-rewrite'),
+    )
+
+    expect(onResolve).toHaveBeenCalledWith(false)
+  })
+
+  it('keeps cancel as an abort path by default', async () => {
+    const user = userEvent.setup()
+    const onResolve = vi.fn()
+
+    render(<PageRefactorDialog preview={preview} onResolve={onResolve} />)
+
+    expect(
+      screen.queryByTestId('page-refactor-dialog-button-save-without-rewrite'),
+    ).not.toBeInTheDocument()
+
+    await user.click(screen.getByTestId('page-refactor-dialog-button-cancel'))
+
+    expect(onResolve).toHaveBeenCalledWith(null)
+  })
+})

--- a/ui/leafwiki-ui/src/features/page/PageRefactorDialog.tsx
+++ b/ui/leafwiki-ui/src/features/page/PageRefactorDialog.tsx
@@ -7,11 +7,13 @@ import { useRef, useState } from 'react'
 
 export type PageRefactorDialogProps = {
   preview: PageRefactorPreview
+  allowSkipRewrite?: boolean
   onResolve: (rewriteLinks: boolean | null) => void
 }
 
 export function PageRefactorDialog({
   preview,
+  allowSkipRewrite = false,
   onResolve,
 }: PageRefactorDialogProps) {
   const previewWarnings = preview.warnings ?? []
@@ -41,6 +43,10 @@ export function PageRefactorDialog({
           resolveOnce(rewriteLinks)
           return true
         }
+        if (type === 'save-without-rewrite') {
+          resolveOnce(false)
+          return true
+        }
         return false
       }}
       defaultAction="cancel"
@@ -51,6 +57,15 @@ export function PageRefactorDialog({
         autoFocus: false,
       }}
       buttons={[
+        ...(allowSkipRewrite
+          ? [
+              {
+                label: 'Save without updating links',
+                actionType: 'save-without-rewrite',
+                variant: 'secondary' as const,
+              },
+            ]
+          : []),
         {
           label: 'Continue',
           actionType: 'confirm',

--- a/ui/leafwiki-ui/src/features/page/pageRefactorDialogState.ts
+++ b/ui/leafwiki-ui/src/features/page/pageRefactorDialogState.ts
@@ -3,8 +3,13 @@ import { DIALOG_PAGE_REFACTOR_CONFIRMATION } from '@/lib/registries'
 import { useConfigStore } from '@/stores/config'
 import { useDialogsStore } from '@/stores/dialogs'
 
+type ConfirmPageRefactorOptions = {
+  allowSkipRewrite?: boolean
+}
+
 export function confirmPageRefactor(
   preview: PageRefactorPreview,
+  options?: ConfirmPageRefactorOptions,
 ): Promise<boolean | null> {
   if (!useConfigStore.getState().enableLinkRefactor) {
     return Promise.resolve(false)
@@ -20,6 +25,7 @@ export function confirmPageRefactor(
   return new Promise((resolve) => {
     useDialogsStore.getState().openDialog(DIALOG_PAGE_REFACTOR_CONFIRMATION, {
       preview,
+      allowSkipRewrite: options?.allowSkipRewrite ?? false,
       onResolve: (rewriteLinks: boolean | null) => {
         resolve(rewriteLinks)
       },


### PR DESCRIPTION
Add an explicit save path for editor refactors that keeps the page rename but skips link rewriting when requested.

Keep cancel as a true abort path for shared dialog usage so move flows remain unchanged.