### PR TITLE
fix: add graceful shutdown

### DIFF
--- a/cmd/leafwiki/main.go
+++ b/cmd/leafwiki/main.go
@@ -1,17 +1,22 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"log/slog"
 	"math"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -140,6 +145,8 @@ func fail(msg string, args ...any) {
 	os.Exit(1)
 }
 
+var gracefulShutdownTimeout = 10 * time.Second
+
 type cliFlags struct {
 	host                    *string
 	port                    *string
@@ -218,6 +225,13 @@ func registerFlags(fs *flag.FlagSet) *cliFlags {
 
 func main() {
 	setupLogger()
+	exitCode := 0
+	defer func() {
+		if exitCode != 0 {
+			os.Exit(exitCode)
+		}
+	}()
+
 	flag.Usage = func() {
 		writeUsage(flag.CommandLine.Output())
 	}
@@ -414,28 +428,51 @@ func main() {
 		DisableRequestLog: disableRequestLog,
 	})
 
-	go runSignalHandler(w)
+	reloadSignals := make(chan os.Signal, 1)
+	signal.Notify(reloadSignals, syscall.SIGUSR1, syscall.SIGHUP)
+	defer signal.Stop(reloadSignals)
 
-	if err := runServer(router, host, port, unixSocket, dataDir); err != nil {
-		fail("Failed to start server", "error", err)
+	shutdownSignals := make(chan os.Signal, 1)
+	signal.Notify(shutdownSignals, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(shutdownSignals)
+
+	if err := runServer(router, host, port, unixSocket, dataDir, w.ReloadFromFSContext, reloadSignals, shutdownSignals); err != nil {
+		slog.Default().Error("Failed to start server", "error", err)
+		exitCode = 1
+		return
 	}
 }
 
-func runServer(router *gin.Engine, host, port, unixSocket, dataDir string) error {
+func runServer(
+	router *gin.Engine,
+	host, port, unixSocket, dataDir string,
+	reload func(context.Context) error,
+	reloadSignals, shutdownSignals <-chan os.Signal,
+) error {
+	server := &http.Server{
+		Handler: router.Handler(),
+	}
+
 	if unixSocket == "" {
 		listenAddr := host + ":" + port
 		slog.Default().Info("Starting LeafWiki", "address", listenAddr, "data_dir", dataDir)
-		return router.Run(listenAddr)
+		listener, err := net.Listen("tcp", listenAddr)
+		if err != nil {
+			return err
+		}
+		return serveWithLifecycle(server, listener, nil, reload, reloadSignals, shutdownSignals)
 	}
 
 	listener, err := listenOnUnixSocket(unixSocket)
 	if err != nil {
 		return err
 	}
-	defer func() {
+
+	cleanup := func() {
 		_ = listener.Close()
 		_ = os.Remove(unixSocket)
-	}()
+	}
+	defer cleanup()
 
 	slog.Default().Info(
 		"Starting LeafWiki",
@@ -444,7 +481,7 @@ func runServer(router *gin.Engine, host, port, unixSocket, dataDir string) error
 		"host_port_overridden", true,
 	)
 
-	return router.RunListener(listener)
+	return serveWithLifecycle(server, listener, cleanup, reload, reloadSignals, shutdownSignals)
 }
 
 func listenOnUnixSocket(socketPath string) (net.Listener, error) {
@@ -600,16 +637,99 @@ func validateListenConfig(unixSocket string, visited map[string]bool) error {
 	return nil
 }
 
-// runSignalHandler listens for SIGUSR1/SIGHUP and triggers a live filesystem reload.
-// ReloadFromFS blocks until all indexes are rebuilt, so signals are processed
-// one at a time and a burst of signals coalesces into at most two reloads.
-func runSignalHandler(w *wiki.Wiki) {
-	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, syscall.SIGUSR1, syscall.SIGHUP)
-	for range ch {
-		slog.Default().Info("reload signal received: reloading from filesystem")
-		if err := w.ReloadFromFS(); err != nil {
-			slog.Default().Error("filesystem reload failed", "error", err)
+// serveWithLifecycle runs the HTTP server while handling live reload signals and
+// graceful shutdown signals. Reloads are serialized by the reload callback itself.
+func serveWithLifecycle(
+	server *http.Server,
+	listener net.Listener,
+	cleanup func(),
+	reload func(context.Context) error,
+	reloadSignals, shutdownSignals <-chan os.Signal,
+) error {
+	serveErrCh := make(chan error, 1)
+	go func() {
+		err := server.Serve(listener)
+		if errors.Is(err, http.ErrServerClosed) {
+			err = nil
+		}
+		serveErrCh <- err
+	}()
+
+	stopReloads := make(chan struct{})
+	var shuttingDown atomic.Bool
+	reloadCtx, cancelReload := context.WithCancel(context.Background())
+	var reloadWG sync.WaitGroup
+	reloadWG.Add(1)
+	go func() {
+		defer reloadWG.Done()
+		for {
+			select {
+			case <-stopReloads:
+				return
+			case sig, ok := <-reloadSignals:
+				if !ok {
+					return
+				}
+				if shuttingDown.Load() {
+					return
+				}
+				slog.Default().Info("reload signal received: reloading from filesystem", "signal", sig.String())
+				if err := reload(reloadCtx); err != nil {
+					if errors.Is(err, context.Canceled) {
+						slog.Default().Info("filesystem reload canceled")
+						return
+					}
+					slog.Default().Error("filesystem reload failed", "error", err)
+				}
+			}
+		}
+	}()
+
+	stopReloader := sync.OnceFunc(func() {
+		cancelReload()
+		close(stopReloads)
+	})
+	defer stopReloader()
+
+	waitForReloader := sync.OnceFunc(func() {
+		reloadWG.Wait()
+	})
+	defer waitForReloader()
+
+	for {
+		select {
+		case err := <-serveErrCh:
+			return err
+		case sig, ok := <-shutdownSignals:
+			if !ok {
+				shutdownSignals = nil
+				continue
+			}
+
+			slog.Default().Info("shutdown signal received: shutting down server", "signal", sig.String())
+			shuttingDown.Store(true)
+			stopReloader()
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
+			err := server.Shutdown(shutdownCtx)
+			cancel()
+			if err != nil {
+				closeErr := server.Close()
+				if closeErr != nil && !errors.Is(closeErr, http.ErrServerClosed) {
+					err = errors.Join(err, closeErr)
+				}
+			}
+
+			if cleanup != nil {
+				cleanup()
+				cleanup = nil
+			}
+
+			waitForReloader()
+			serveErr := <-serveErrCh
+			if err != nil {
+				return err
+			}
+			return serveErr
 		}
 	}
 }

--- a/cmd/leafwiki/main_test.go
+++ b/cmd/leafwiki/main_test.go
@@ -2,13 +2,19 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"flag"
+	"io"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestWriteUsage_UsesLongFlags(t *testing.T) {
@@ -244,5 +250,280 @@ func TestListenOnUnixSocket_WindowsReturnsHelpfulError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not supported on windows") {
 		t.Fatalf("expected windows support error, got %v", err)
+	}
+}
+
+type testSignal string
+
+func (s testSignal) String() string { return string(s) }
+func (testSignal) Signal()          {}
+
+func TestServeWithLifecycle_GracefulShutdownWaitsForInFlightRequest(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			close(started)
+			<-release
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		}),
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen failed: %v", err)
+	}
+
+	reloadSignals := make(chan os.Signal)
+	shutdownSignals := make(chan os.Signal, 1)
+
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- serveWithLifecycle(server, listener, nil, func(context.Context) error { return nil }, reloadSignals, shutdownSignals)
+	}()
+
+	respCh := make(chan *http.Response, 1)
+	reqErrCh := make(chan error, 1)
+	go func() {
+		resp, err := http.Get("http://" + listener.Addr().String())
+		if err != nil {
+			reqErrCh <- err
+			return
+		}
+		respCh <- resp
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("request did not reach handler")
+	}
+
+	shutdownSignals <- testSignal("shutdown")
+
+	select {
+	case err := <-runErr:
+		t.Fatalf("server exited before request completed: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	close(release)
+
+	var resp *http.Response
+	select {
+	case err := <-reqErrCh:
+		t.Fatalf("request failed: %v", err)
+	case resp = <-respCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("request did not complete")
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading response failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+	if string(body) != "ok" {
+		t.Fatalf("expected body ok, got %q", string(body))
+	}
+
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Fatalf("expected clean shutdown, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not exit after request completed")
+	}
+}
+
+func TestServeWithLifecycle_ReloadSignalTriggersCallbackWithoutStoppingServer(t *testing.T) {
+	var reloadCalls atomic.Int32
+
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}),
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen failed: %v", err)
+	}
+
+	reloadDone := make(chan struct{}, 1)
+	reloadSignals := make(chan os.Signal, 1)
+	shutdownSignals := make(chan os.Signal, 1)
+
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- serveWithLifecycle(server, listener, nil, func(context.Context) error {
+			reloadCalls.Add(1)
+			reloadDone <- struct{}{}
+			return nil
+		}, reloadSignals, shutdownSignals)
+	}()
+
+	reloadSignals <- testSignal("reload")
+
+	select {
+	case <-reloadDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reload callback was not triggered")
+	}
+
+	resp, err := http.Get("http://" + listener.Addr().String())
+	if err != nil {
+		t.Fatalf("request after reload failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", resp.StatusCode)
+	}
+
+	if reloadCalls.Load() != 1 {
+		t.Fatalf("expected one reload call, got %d", reloadCalls.Load())
+	}
+
+	shutdownSignals <- testSignal("shutdown")
+
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Fatalf("expected clean shutdown, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not stop after shutdown signal")
+	}
+}
+
+func TestServeWithLifecycle_ShutdownTimeoutStillRunsCleanup(t *testing.T) {
+	previousTimeout := gracefulShutdownTimeout
+	gracefulShutdownTimeout = 50 * time.Millisecond
+	t.Cleanup(func() {
+		gracefulShutdownTimeout = previousTimeout
+	})
+
+	started := make(chan struct{})
+	handlerCanceled := make(chan struct{}, 1)
+	cleanupCalled := make(chan struct{}, 1)
+
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			close(started)
+			<-r.Context().Done()
+			handlerCanceled <- struct{}{}
+		}),
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen failed: %v", err)
+	}
+
+	reloadSignals := make(chan os.Signal)
+	shutdownSignals := make(chan os.Signal, 1)
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- serveWithLifecycle(server, listener, func() {
+			select {
+			case cleanupCalled <- struct{}{}:
+			default:
+			}
+		}, func(context.Context) error { return nil }, reloadSignals, shutdownSignals)
+	}()
+
+	go func() {
+		resp, err := http.Get("http://" + listener.Addr().String())
+		if err == nil && resp != nil {
+			resp.Body.Close()
+		}
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("request did not reach handler")
+	}
+
+	shutdownSignals <- testSignal("shutdown")
+
+	select {
+	case err := <-runErr:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected context deadline exceeded, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not exit after shutdown timeout")
+	}
+
+	select {
+	case <-cleanupCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cleanup was not called on shutdown timeout")
+	}
+
+	select {
+	case <-handlerCanceled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler was not canceled after shutdown timeout")
+	}
+}
+
+func TestServeWithLifecycle_ShutdownCancelsInFlightReload(t *testing.T) {
+	reloadStarted := make(chan struct{})
+	reloadCanceled := make(chan struct{})
+
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}),
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen failed: %v", err)
+	}
+
+	reloadSignals := make(chan os.Signal, 1)
+	shutdownSignals := make(chan os.Signal, 1)
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- serveWithLifecycle(server, listener, nil, func(ctx context.Context) error {
+			close(reloadStarted)
+			<-ctx.Done()
+			close(reloadCanceled)
+			return ctx.Err()
+		}, reloadSignals, shutdownSignals)
+	}()
+
+	reloadSignals <- testSignal("reload")
+
+	select {
+	case <-reloadStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reload did not start")
+	}
+
+	shutdownSignals <- testSignal("shutdown")
+
+	select {
+	case <-reloadCanceled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reload was not canceled by shutdown")
+	}
+
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Fatalf("expected clean shutdown, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not stop after canceling reload")
 	}
 }

--- a/internal/core/auth/auth_service.go
+++ b/internal/core/auth/auth_service.go
@@ -39,6 +39,24 @@ func NewAuthService(userService *UserService, sessionStore *SessionStore, secret
 	}
 }
 
+func (a *AuthService) Close() error {
+	var errs []error
+
+	if a.sessionStore != nil {
+		if err := a.sessionStore.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if a.userService != nil {
+		if err := a.userService.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
 type AuthToken struct {
 	Token                string      `json:"token"`
 	RefreshToken         string      `json:"refresh_token"`

--- a/internal/core/auth/auth_service_test.go
+++ b/internal/core/auth/auth_service_test.go
@@ -219,3 +219,31 @@ func TestAuthService_RevokeAllUserSessions_MultipleUsers(t *testing.T) {
 		t.Fatalf("Second user's refresh token should still work: %v", err)
 	}
 }
+
+func TestAuthService_Close_ClosesSessionAndUserStores(t *testing.T) {
+	authService := setupTestAuthService(t)
+
+	if authService.sessionStore == nil {
+		t.Fatal("expected session store to be initialized")
+	}
+	if authService.sessionStore.db == nil {
+		t.Fatal("expected session store db to be initialized")
+	}
+	if authService.userService == nil || authService.userService.store == nil {
+		t.Fatal("expected user service store to be initialized")
+	}
+	if authService.userService.store.db == nil {
+		t.Fatal("expected user store db to be initialized")
+	}
+
+	if err := authService.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	if authService.sessionStore.db != nil {
+		t.Fatal("expected session store db to be closed")
+	}
+	if authService.userService.store.db != nil {
+		t.Fatal("expected user store db to be closed")
+	}
+}

--- a/internal/core/tree/node_store.go
+++ b/internal/core/tree/node_store.go
@@ -1,6 +1,7 @@
 package tree
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -237,6 +238,10 @@ func (f *NodeStore) LoadTree(filename string) (*PageNode, error) {
 }
 
 func (f *NodeStore) ReconstructTreeFromFS() (*PageNode, error) {
+	return f.ReconstructTreeFromFSContext(context.Background())
+}
+
+func (f *NodeStore) ReconstructTreeFromFSContext(ctx context.Context) (*PageNode, error) {
 	reconstructNow := time.Now().UTC()
 	rootDir := filepath.Join(f.storageDir, "root")
 	root := &PageNode{
@@ -264,13 +269,21 @@ func (f *NodeStore) ReconstructTreeFromFS() (*PageNode, error) {
 		return nil, fmt.Errorf("root path %s is not a directory", rootDir)
 	}
 
-	if err := f.reconstructTreeRecursive(rootDir, root, reconstructNow, seenIDs); err != nil {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	if err := f.reconstructTreeRecursive(ctx, rootDir, root, reconstructNow, seenIDs); err != nil {
 		return nil, fmt.Errorf("reconstruct tree from fs: %w", err)
 	}
 
 	return root, nil
 }
-func (f *NodeStore) reconstructTreeRecursive(currentPath string, parent *PageNode, reconstructNow time.Time, seenIDs map[string]string) error {
+func (f *NodeStore) reconstructTreeRecursive(ctx context.Context, currentPath string, parent *PageNode, reconstructNow time.Time, seenIDs map[string]string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	entries, err := os.ReadDir(currentPath)
 	if err != nil {
 		return fmt.Errorf("read dir %s: %w", currentPath, err)
@@ -288,6 +301,10 @@ func (f *NodeStore) reconstructTreeRecursive(currentPath string, parent *PageNod
 	})
 
 	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		name := entry.Name()
 
 		// optional: skip hidden stuff
@@ -363,7 +380,7 @@ func (f *NodeStore) reconstructTreeRecursive(currentPath string, parent *PageNod
 				}
 			}
 
-			if err := f.reconstructTreeRecursive(filepath.Join(currentPath, name), child, reconstructNow, seenIDs); err != nil {
+			if err := f.reconstructTreeRecursive(ctx, filepath.Join(currentPath, name), child, reconstructNow, seenIDs); err != nil {
 				return err
 			}
 			continue

--- a/internal/core/tree/tree_service.go
+++ b/internal/core/tree/tree_service.go
@@ -1,6 +1,7 @@
 package tree
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -146,13 +147,25 @@ func (t *TreeService) TreeHash() string {
 // continue serving the current tree concurrently. The lock is acquired
 // only for the fast in-memory swap and index rebuild.
 func (t *TreeService) ReconstructTreeFromFS() error {
-	newTree, err := t.store.ReconstructTreeFromFS()
+	return t.ReconstructTreeFromFSContext(context.Background())
+}
+
+func (t *TreeService) ReconstructTreeFromFSContext(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	newTree, err := t.store.ReconstructTreeFromFSContext(ctx)
 	if err != nil {
 		t.log.Error("Error reconstructing tree from filesystem", "error", err)
 		return err
 	}
 	if newTree == nil {
 		return fmt.Errorf("internal error: ReconstructTreeFromFS returned nil tree")
+	}
+
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	t.mu.Lock()

--- a/internal/links/link_service.go
+++ b/internal/links/link_service.go
@@ -1,6 +1,8 @@
 package links
 
 import (
+	"context"
+
 	"github.com/perber/wiki/internal/core/tree"
 )
 
@@ -19,8 +21,16 @@ func NewLinkService(storageDir string, treeService *tree.TreeService, store *Lin
 }
 
 func (b *LinkService) IndexAllPages() error {
+	return b.IndexAllPagesContext(context.Background())
+}
+
+func (b *LinkService) IndexAllPagesContext(ctx context.Context) error {
 	if !b.treeService.IsLoaded() {
 		return nil
+	}
+
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	if err := b.store.Clear(); err != nil {
@@ -29,6 +39,9 @@ func (b *LinkService) IndexAllPages() error {
 
 	var ids []string
 	if err := b.treeService.WalkNodes(func(id string) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		ids = append(ids, id)
 		return nil
 	}); err != nil {
@@ -37,6 +50,9 @@ func (b *LinkService) IndexAllPages() error {
 
 	pages, errs := b.treeService.GetPages(ids)
 	for i, page := range pages {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if errs[i] != nil {
 			return errs[i]
 		}

--- a/internal/wiki/pagesave/search_effect.go
+++ b/internal/wiki/pagesave/search_effect.go
@@ -1,6 +1,7 @@
 package pagesave
 
 import (
+	"context"
 	"log/slog"
 	"strings"
 
@@ -50,8 +51,15 @@ func (e *SearchIndexSideEffect) Apply(event PageSaveEvent) {
 // IndexAllPages clears the search index and rebuilds it from the current tree state.
 // Call this once at startup; runtime updates are handled via Apply.
 func (e *SearchIndexSideEffect) IndexAllPages() error {
+	return e.IndexAllPagesContext(context.Background())
+}
+
+func (e *SearchIndexSideEffect) IndexAllPagesContext(ctx context.Context) error {
 	if e.index == nil {
 		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	if err := e.index.Clear(); err != nil {
 		return err
@@ -59,6 +67,9 @@ func (e *SearchIndexSideEffect) IndexAllPages() error {
 
 	var ids []string
 	if err := e.tree.WalkNodes(func(id string) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		ids = append(ids, id)
 		return nil
 	}); err != nil {
@@ -67,6 +78,9 @@ func (e *SearchIndexSideEffect) IndexAllPages() error {
 
 	pages, errs := e.tree.GetPages(ids)
 	for i, page := range pages {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if errs[i] != nil {
 			e.log.Warn("skipping page during search bootstrap", "pageID", ids[i], "error", errs[i])
 			continue

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -24,12 +24,12 @@ import (
 	wikibackup "github.com/perber/wiki/internal/wiki/backup"
 	wikibranding "github.com/perber/wiki/internal/wiki/branding"
 	wikihealth "github.com/perber/wiki/internal/wiki/health"
-	wikiresync "github.com/perber/wiki/internal/wiki/resync"
 	wikiimporter "github.com/perber/wiki/internal/wiki/importer"
 	wikilinks "github.com/perber/wiki/internal/wiki/links"
 	wikipages "github.com/perber/wiki/internal/wiki/pages"
 	"github.com/perber/wiki/internal/wiki/pagesave"
 	wikiproperties "github.com/perber/wiki/internal/wiki/properties"
+	wikiresync "github.com/perber/wiki/internal/wiki/resync"
 	wikirevisions "github.com/perber/wiki/internal/wiki/revisions"
 	wikisearch "github.com/perber/wiki/internal/wiki/search"
 	wikitags "github.com/perber/wiki/internal/wiki/tags"
@@ -578,17 +578,33 @@ For more information, visit the [LeafWiki GitHub repository](https://github.com/
 // What is NOT reloaded: assets (served directly from disk), auth/users
 // (SQLite-based), revisions (stored per-page, no re-baseline).
 func (w *Wiki) ReloadFromFS() error {
+	return w.ReloadFromFSContext(context.Background())
+}
+
+func (w *Wiki) ReloadFromFSContext(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	w.reloadMu.Lock()
 	defer w.reloadMu.Unlock()
 
 	w.log.Info("filesystem reload started")
 
-	if err := w.tree.ReconstructTreeFromFS(); err != nil {
+	if err := w.tree.ReconstructTreeFromFSContext(ctx); err != nil {
 		return fmt.Errorf("tree reconstruction failed: %w", err)
 	}
 
-	if err := w.links.IndexAllPages(); err != nil {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	if err := w.links.IndexAllPagesContext(ctx); err != nil {
 		w.log.Warn("link re-index failed during reload", "error", err)
+	}
+
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	w.bootstrapTagsAndProperties()
@@ -596,7 +612,7 @@ func (w *Wiki) ReloadFromFS() error {
 	w.status.Start()
 	defer w.status.Finish()
 	searchEffect := pagesave.NewSearchIndexSideEffect(w.searchIndex, w.tree, w.log)
-	if err := searchEffect.IndexAllPages(); err != nil {
+	if err := searchEffect.IndexAllPagesContext(ctx); err != nil {
 		w.log.Warn("search re-index failed during reload", "error", err)
 		w.status.Fail()
 		return fmt.Errorf("search re-index failed: %w", err)
@@ -619,8 +635,15 @@ func (w *Wiki) UserService() *auth.UserService {
 
 func (w *Wiki) Close() error {
 	w.status.Finish()
-	if err := w.user.Close(); err != nil {
-		return err
+	if w.auth != nil {
+		// When auth is enabled, AuthService owns both the session store and user store.
+		if err := w.auth.Close(); err != nil {
+			return err
+		}
+	} else if w.user != nil {
+		if err := w.user.Close(); err != nil {
+			return err
+		}
 	}
 
 	if w.links != nil {


### PR DESCRIPTION
Use an explicit HTTP server so shutdown signals stop accepting new requests while in-flight requests can finish before resources are closed.

Close the auth session store during wiki shutdown so the session SQLite database and cleanup goroutine terminate with the process.