### PR TITLE
feat: async filesystem resync with progress polling

### DIFF
--- a/cmd/leafwiki/main.go
+++ b/cmd/leafwiki/main.go
@@ -436,7 +436,7 @@ func main() {
 	signal.Notify(shutdownSignals, syscall.SIGINT, syscall.SIGTERM)
 	defer signal.Stop(shutdownSignals)
 
-	if err := runServer(router, host, port, unixSocket, dataDir, w.ReloadFromFSContext, reloadSignals, shutdownSignals); err != nil {
+	if err := runServer(router, host, port, unixSocket, dataDir, w.TriggerResyncAsync, reloadSignals, shutdownSignals); err != nil {
 		slog.Default().Error("Failed to start server", "error", err)
 		exitCode = 1
 		return
@@ -446,7 +446,7 @@ func main() {
 func runServer(
 	router *gin.Engine,
 	host, port, unixSocket, dataDir string,
-	reload func(context.Context) error,
+	reload func(),
 	reloadSignals, shutdownSignals <-chan os.Signal,
 ) error {
 	server := &http.Server{
@@ -638,12 +638,12 @@ func validateListenConfig(unixSocket string, visited map[string]bool) error {
 }
 
 // serveWithLifecycle runs the HTTP server while handling live reload signals and
-// graceful shutdown signals. Reloads are serialized by the reload callback itself.
+// graceful shutdown signals. reload is non-blocking (fires a goroutine internally).
 func serveWithLifecycle(
 	server *http.Server,
 	listener net.Listener,
 	cleanup func(),
-	reload func(context.Context) error,
+	reload func(),
 	reloadSignals, shutdownSignals <-chan os.Signal,
 ) error {
 	serveErrCh := make(chan error, 1)
@@ -657,7 +657,6 @@ func serveWithLifecycle(
 
 	stopReloads := make(chan struct{})
 	var shuttingDown atomic.Bool
-	reloadCtx, cancelReload := context.WithCancel(context.Background())
 	var reloadWG sync.WaitGroup
 	reloadWG.Add(1)
 	go func() {
@@ -674,19 +673,12 @@ func serveWithLifecycle(
 					return
 				}
 				slog.Default().Info("reload signal received: reloading from filesystem", "signal", sig.String())
-				if err := reload(reloadCtx); err != nil {
-					if errors.Is(err, context.Canceled) {
-						slog.Default().Info("filesystem reload canceled")
-						return
-					}
-					slog.Default().Error("filesystem reload failed", "error", err)
-				}
+				reload()
 			}
 		}
 	}()
 
 	stopReloader := sync.OnceFunc(func() {
-		cancelReload()
 		close(stopReloads)
 	})
 	defer stopReloader()

--- a/cmd/leafwiki/main_test.go
+++ b/cmd/leafwiki/main_test.go
@@ -281,7 +281,7 @@ func TestServeWithLifecycle_GracefulShutdownWaitsForInFlightRequest(t *testing.T
 
 	runErr := make(chan error, 1)
 	go func() {
-		runErr <- serveWithLifecycle(server, listener, nil, func(context.Context) error { return nil }, reloadSignals, shutdownSignals)
+		runErr <- serveWithLifecycle(server, listener, nil, func() {}, reloadSignals, shutdownSignals)
 	}()
 
 	respCh := make(chan *http.Response, 1)
@@ -366,10 +366,9 @@ func TestServeWithLifecycle_ReloadSignalTriggersCallbackWithoutStoppingServer(t 
 
 	runErr := make(chan error, 1)
 	go func() {
-		runErr <- serveWithLifecycle(server, listener, nil, func(context.Context) error {
+		runErr <- serveWithLifecycle(server, listener, nil, func() {
 			reloadCalls.Add(1)
 			reloadDone <- struct{}{}
-			return nil
 		}, reloadSignals, shutdownSignals)
 	}()
 
@@ -441,7 +440,7 @@ func TestServeWithLifecycle_ShutdownTimeoutStillRunsCleanup(t *testing.T) {
 			case cleanupCalled <- struct{}{}:
 			default:
 			}
-		}, func(context.Context) error { return nil }, reloadSignals, shutdownSignals)
+		}, func() {}, reloadSignals, shutdownSignals)
 	}()
 
 	go func() {
@@ -481,9 +480,10 @@ func TestServeWithLifecycle_ShutdownTimeoutStillRunsCleanup(t *testing.T) {
 	}
 }
 
-func TestServeWithLifecycle_ShutdownCancelsInFlightReload(t *testing.T) {
+func TestServeWithLifecycle_ShutdownDoesNotWaitForInFlightReload(t *testing.T) {
 	reloadStarted := make(chan struct{})
-	reloadCanceled := make(chan struct{})
+	releaseReload := make(chan struct{})
+	reloadFinished := make(chan struct{})
 
 	server := &http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -500,11 +500,12 @@ func TestServeWithLifecycle_ShutdownCancelsInFlightReload(t *testing.T) {
 	shutdownSignals := make(chan os.Signal, 1)
 	runErr := make(chan error, 1)
 	go func() {
-		runErr <- serveWithLifecycle(server, listener, nil, func(ctx context.Context) error {
+		runErr <- serveWithLifecycle(server, listener, nil, func() {
 			close(reloadStarted)
-			<-ctx.Done()
-			close(reloadCanceled)
-			return ctx.Err()
+			go func() {
+				<-releaseReload
+				close(reloadFinished)
+			}()
 		}, reloadSignals, shutdownSignals)
 	}()
 
@@ -519,17 +520,19 @@ func TestServeWithLifecycle_ShutdownCancelsInFlightReload(t *testing.T) {
 	shutdownSignals <- testSignal("shutdown")
 
 	select {
-	case <-reloadCanceled:
-	case <-time.After(2 * time.Second):
-		t.Fatal("reload was not canceled by shutdown")
-	}
-
-	select {
 	case err := <-runErr:
 		if err != nil {
 			t.Fatalf("expected clean shutdown, got %v", err)
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("server did not stop after canceling reload")
+		t.Fatal("server did not stop while reload was still running")
+	}
+
+	close(releaseReload)
+
+	select {
+	case <-reloadFinished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reload did not finish after release")
 	}
 }

--- a/internal/wiki/resync/errors.go
+++ b/internal/wiki/resync/errors.go
@@ -1,0 +1,61 @@
+package wikiresync
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	sharederrors "github.com/perber/wiki/internal/core/shared/errors"
+)
+
+const (
+	ErrCodeResyncAlreadyRunning = "resync_already_running"
+	ErrCodeResyncInternalError  = "resync_internal_error"
+)
+
+var ErrResyncAlreadyRunning = sharederrors.NewLocalizedError(
+	ErrCodeResyncAlreadyRunning,
+	"A sync is already in progress",
+	"a sync is already in progress",
+	nil,
+)
+
+// ResyncErrorResponse is the structured JSON error body returned by resync endpoints.
+type ResyncErrorResponse struct {
+	Error ResyncErrorDetail `json:"error"`
+}
+
+// ResyncErrorDetail carries the localization-ready error data.
+type ResyncErrorDetail struct {
+	Code     string   `json:"code"`
+	Message  string   `json:"message"`
+	Template string   `json:"template"`
+	Args     []string `json:"args,omitempty"`
+}
+
+func respondWithResyncStatusError(c *gin.Context, status int, code, message, template string, args ...string) {
+	c.JSON(status, ResyncErrorResponse{
+		Error: ResyncErrorDetail{
+			Code:     code,
+			Message:  message,
+			Template: template,
+			Args:     append([]string(nil), args...),
+		},
+	})
+}
+
+func respondWithResyncError(c *gin.Context, err error) {
+	if loc, ok := sharederrors.AsLocalizedError(err); ok {
+		respondWithResyncStatusError(c, resyncErrorStatus(loc.Code), loc.Code, loc.Message, loc.Template, loc.Args...)
+		return
+	}
+	respondWithResyncStatusError(c, http.StatusInternalServerError, ErrCodeResyncInternalError, "Resync request failed", "resync request failed")
+}
+
+func resyncErrorStatus(code string) int {
+	switch code {
+	case ErrCodeResyncAlreadyRunning:
+		return http.StatusConflict
+	default:
+		return http.StatusInternalServerError
+	}
+}

--- a/internal/wiki/resync/job.go
+++ b/internal/wiki/resync/job.go
@@ -1,0 +1,82 @@
+package wikiresync
+
+import "sync"
+
+type Phase string
+
+const (
+	PhaseTree   Phase = "tree"
+	PhaseLinks  Phase = "links"
+	PhaseTags   Phase = "tags"
+	PhaseSearch Phase = "search"
+)
+
+// JobStatus is the snapshot returned by Status().
+type JobStatus struct {
+	Running bool   `json:"running"`
+	Phase   string `json:"phase,omitempty"`
+	Done    bool   `json:"done"`
+	Error   string `json:"error,omitempty"`
+}
+
+// ResyncJob tracks the lifecycle of a single background resync operation.
+// It is safe for concurrent use.
+type ResyncJob struct {
+	mu      sync.RWMutex
+	running bool
+	phase   Phase
+	done    bool
+	err     error
+}
+
+func NewResyncJob() *ResyncJob {
+	return &ResyncJob{}
+}
+
+// Start marks the job as running and resets all state from a previous run.
+// Returns false if the job is already running (caller should not start a new goroutine).
+func (j *ResyncJob) Start() bool {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	if j.running {
+		return false
+	}
+	j.running = true
+	j.done = false
+	j.phase = ""
+	j.err = nil
+	return true
+}
+
+// SetPhase updates the current phase and is safe to call from the worker goroutine.
+func (j *ResyncJob) SetPhase(p Phase) {
+	j.mu.Lock()
+	j.phase = p
+	j.mu.Unlock()
+}
+
+// Finish marks the job as completed (with or without an error).
+func (j *ResyncJob) Finish(err error) {
+	j.mu.Lock()
+	j.running = false
+	j.done = true
+	j.err = err
+	j.mu.Unlock()
+}
+
+// Status returns a point-in-time snapshot of the job state.
+func (j *ResyncJob) Status() JobStatus {
+	j.mu.RLock()
+	defer j.mu.RUnlock()
+
+	s := JobStatus{
+		Running: j.running,
+		Phase:   string(j.phase),
+		Done:    j.done,
+	}
+	if j.err != nil {
+		s.Error = j.err.Error()
+	}
+	return s
+}

--- a/internal/wiki/resync/job_test.go
+++ b/internal/wiki/resync/job_test.go
@@ -1,0 +1,151 @@
+package wikiresync_test
+
+import (
+	"sync"
+	"testing"
+
+	wikiresync "github.com/perber/wiki/internal/wiki/resync"
+)
+
+func TestResyncJob_NewJobIsIdle(t *testing.T) {
+	job := wikiresync.NewResyncJob()
+	s := job.Status()
+
+	if s.Running {
+		t.Error("new job should not be running")
+	}
+	if s.Done {
+		t.Error("new job should not be done")
+	}
+	if s.Phase != "" {
+		t.Errorf("new job should have no phase, got %q", s.Phase)
+	}
+	if s.Error != "" {
+		t.Errorf("new job should have no error, got %q", s.Error)
+	}
+}
+
+func TestResyncJob_StartSetsRunning(t *testing.T) {
+	job := wikiresync.NewResyncJob()
+
+	if !job.Start() {
+		t.Fatal("Start() should return true for a new idle job")
+	}
+
+	s := job.Status()
+	if !s.Running {
+		t.Error("job should be running after Start()")
+	}
+	if s.Done {
+		t.Error("job should not be done after Start()")
+	}
+}
+
+func TestResyncJob_StartReturnsFalseWhenAlreadyRunning(t *testing.T) {
+	job := wikiresync.NewResyncJob()
+	job.Start()
+
+	if job.Start() {
+		t.Error("Start() should return false when job is already running")
+	}
+}
+
+func TestResyncJob_SetPhaseUpdatesPhase(t *testing.T) {
+	job := wikiresync.NewResyncJob()
+	job.Start()
+	job.SetPhase(wikiresync.PhaseLinks)
+
+	s := job.Status()
+	if s.Phase != string(wikiresync.PhaseLinks) {
+		t.Errorf("expected phase %q, got %q", wikiresync.PhaseLinks, s.Phase)
+	}
+}
+
+func TestResyncJob_FinishSuccess(t *testing.T) {
+	job := wikiresync.NewResyncJob()
+	job.Start()
+	job.SetPhase(wikiresync.PhaseSearch)
+	job.Finish(nil)
+
+	s := job.Status()
+	if s.Running {
+		t.Error("job should not be running after Finish()")
+	}
+	if !s.Done {
+		t.Error("job should be done after Finish()")
+	}
+	if s.Error != "" {
+		t.Errorf("expected no error, got %q", s.Error)
+	}
+}
+
+func TestResyncJob_FinishWithError(t *testing.T) {
+	job := wikiresync.NewResyncJob()
+	job.Start()
+	job.SetPhase(wikiresync.PhaseTree)
+
+	job.Finish(errTest("tree reconstruction failed"))
+
+	s := job.Status()
+	if s.Running {
+		t.Error("job should not be running after Finish(err)")
+	}
+	if !s.Done {
+		t.Error("job should be done after Finish(err)")
+	}
+	if s.Error != "tree reconstruction failed" {
+		t.Errorf("expected error message, got %q", s.Error)
+	}
+}
+
+func TestResyncJob_StartAfterFinishResetsState(t *testing.T) {
+	job := wikiresync.NewResyncJob()
+	job.Start()
+	job.SetPhase(wikiresync.PhaseSearch)
+	job.Finish(nil)
+
+	// Should be startable again after finishing
+	if !job.Start() {
+		t.Fatal("Start() should return true after job has finished")
+	}
+	s := job.Status()
+	if !s.Running {
+		t.Error("job should be running after second Start()")
+	}
+	if s.Done {
+		t.Error("job should not be done right after re-Start()")
+	}
+	if s.Phase != "" {
+		t.Errorf("phase should be reset after re-Start(), got %q", s.Phase)
+	}
+}
+
+func TestResyncJob_ConcurrentStartIsSafe(t *testing.T) {
+	job := wikiresync.NewResyncJob()
+
+	var wg sync.WaitGroup
+	started := make([]bool, 10)
+	for i := range started {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			started[idx] = job.Start()
+		}(i)
+	}
+	wg.Wait()
+
+	count := 0
+	for _, ok := range started {
+		if ok {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("exactly one goroutine should win Start(), got %d", count)
+	}
+}
+
+// errTest is a minimal error for testing.
+type errTest string
+
+func (e errTest) Error() string { return string(e) }

--- a/internal/wiki/resync/routes.go
+++ b/internal/wiki/resync/routes.go
@@ -10,16 +10,18 @@ import (
 	"github.com/perber/wiki/internal/http/middleware/security"
 )
 
-// Routes is the RouteRegistrar for the filesystem resync admin endpoint.
+// Routes is the RouteRegistrar for the filesystem resync admin endpoints.
 type Routes struct {
-	trigger     func() error
+	triggerUC   *TriggerResyncUseCase
+	statusUC    *GetResyncStatusUseCase
 	authService *coreauth.AuthService
 }
 
 // NewRoutes constructs the resync RouteRegistrar.
-func NewRoutes(trigger func() error, authService *coreauth.AuthService) *Routes {
+func NewRoutes(triggerUC *TriggerResyncUseCase, statusUC *GetResyncStatusUseCase, authService *coreauth.AuthService) *Routes {
 	return &Routes{
-		trigger:     trigger,
+		triggerUC:   triggerUC,
+		statusUC:    statusUC,
 		authService: authService,
 	}
 }
@@ -39,13 +41,21 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	adminGroup.Use(authmw.RequireAdmin(opts.AuthDisabled))
 
 	adminGroup.POST("/resync", r.handleTriggerResync)
+	adminGroup.GET("/resync/status", r.handleResyncStatus)
 }
 
-// handleTriggerResync blocks until the filesystem reload completes, then returns 200.
+// handleTriggerResync starts a background resync and returns 202 immediately.
+// Returns 409 if a resync is already running.
 func (r *Routes) handleTriggerResync(c *gin.Context) {
-	if err := r.trigger(); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	if err := r.triggerUC.Execute(c.Request.Context()); err != nil {
+		respondWithResyncError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"ok": true})
+	c.JSON(http.StatusAccepted, gin.H{"ok": true})
+}
+
+// handleResyncStatus returns the current resync job state for client polling.
+func (r *Routes) handleResyncStatus(c *gin.Context) {
+	out := r.statusUC.Execute(c.Request.Context())
+	c.JSON(http.StatusOK, out.Status)
 }

--- a/internal/wiki/resync/routes_test.go
+++ b/internal/wiki/resync/routes_test.go
@@ -1,0 +1,198 @@
+// White-box test: package wikiresync so we can register the real handler methods.
+package wikiresync
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// newTestRouter builds a minimal Gin engine wiring the real handler methods so
+// any change to handleTriggerResync or handleResyncStatus is exercised.
+func newTestRouter(job *ResyncJob, trigger func()) *gin.Engine {
+	r := gin.New()
+	routes := &Routes{
+		triggerUC: NewTriggerResyncUseCase(job, trigger),
+		statusUC:  NewGetResyncStatusUseCase(job),
+	}
+	r.POST("/resync", routes.handleTriggerResync)
+	r.GET("/resync/status", routes.handleResyncStatus)
+	return r
+}
+
+func TestHandleTriggerResync_Returns202(t *testing.T) {
+	job := NewResyncJob()
+	launched := make(chan struct{}, 1)
+	router := newTestRouter(job, func() {
+		launched <- struct{}{}
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/resync", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Errorf("expected 202, got %d", w.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if body["ok"] != true {
+		t.Errorf("expected {ok:true}, got %v", body)
+	}
+	select {
+	case <-launched:
+	default:
+		t.Error("trigger was not called")
+	}
+}
+
+func TestHandleTriggerResync_Returns409WhenAlreadyRunning(t *testing.T) {
+	job := NewResyncJob()
+	job.Start() // simulate a running job
+
+	called := false
+	router := newTestRouter(job, func() { called = true })
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/resync", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d", w.Code)
+	}
+	var body ResyncErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if body.Error.Code != ErrCodeResyncAlreadyRunning {
+		t.Errorf("expected code %q, got %q", ErrCodeResyncAlreadyRunning, body.Error.Code)
+	}
+	if called {
+		t.Error("trigger must not be called when job is already running")
+	}
+}
+
+func TestHandleResyncStatus_IdleState(t *testing.T) {
+	job := NewResyncJob()
+	router := newTestRouter(job, func() {})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/resync/status", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	var s JobStatus
+	if err := json.Unmarshal(w.Body.Bytes(), &s); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if s.Running {
+		t.Error("idle job should not be running")
+	}
+	if s.Done {
+		t.Error("idle job should not be done")
+	}
+}
+
+func TestHandleResyncStatus_RunningState(t *testing.T) {
+	job := NewResyncJob()
+	job.Start()
+	job.SetPhase(PhaseLinks)
+
+	router := newTestRouter(job, func() {})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/resync/status", nil)
+	router.ServeHTTP(w, req)
+
+	var s JobStatus
+	if err := json.Unmarshal(w.Body.Bytes(), &s); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if !s.Running {
+		t.Error("job should be running")
+	}
+	if s.Phase != "links" {
+		t.Errorf("expected phase 'links', got %q", s.Phase)
+	}
+}
+
+func TestHandleResyncStatus_DoneState(t *testing.T) {
+	job := NewResyncJob()
+	job.Start()
+	job.SetPhase(PhaseSearch)
+	job.Finish(nil)
+
+	router := newTestRouter(job, func() {})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/resync/status", nil)
+	router.ServeHTTP(w, req)
+
+	var s JobStatus
+	if err := json.Unmarshal(w.Body.Bytes(), &s); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if s.Running {
+		t.Error("finished job should not be running")
+	}
+	if !s.Done {
+		t.Error("finished job should be done")
+	}
+	if s.Error != "" {
+		t.Errorf("expected no error, got %q", s.Error)
+	}
+}
+
+func TestHandleResyncStatus_DoneWithError(t *testing.T) {
+	job := NewResyncJob()
+	job.Start()
+	job.SetPhase(PhaseTree)
+	job.Finish(errors.New("tree failed"))
+
+	router := newTestRouter(job, func() {})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/resync/status", nil)
+	router.ServeHTTP(w, req)
+
+	var s JobStatus
+	if err := json.Unmarshal(w.Body.Bytes(), &s); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if !s.Done {
+		t.Error("expected done=true")
+	}
+	if s.Error != "tree failed" {
+		t.Errorf("expected error message, got %q", s.Error)
+	}
+}
+
+func TestHandleTriggerResync_PhaseOmittedWhenEmpty(t *testing.T) {
+	job := NewResyncJob()
+	router := newTestRouter(job, func() {})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/resync/status", nil)
+	router.ServeHTTP(w, req)
+
+	// phase must be absent (omitempty) when empty so JS ?? null works correctly.
+	var raw map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if _, ok := raw["phase"]; ok {
+		t.Errorf("phase key must be absent when empty, got %v", raw["phase"])
+	}
+}

--- a/internal/wiki/resync/use_cases.go
+++ b/internal/wiki/resync/use_cases.go
@@ -1,0 +1,40 @@
+package wikiresync
+
+import "context"
+
+// ─── TriggerResyncUseCase ─────────────────────────────────────────────────────
+
+type TriggerResyncUseCase struct {
+	job     *ResyncJob
+	trigger func()
+}
+
+func NewTriggerResyncUseCase(job *ResyncJob, trigger func()) *TriggerResyncUseCase {
+	return &TriggerResyncUseCase{job: job, trigger: trigger}
+}
+
+func (uc *TriggerResyncUseCase) Execute(_ context.Context) error {
+	if !uc.job.Start() {
+		return ErrResyncAlreadyRunning
+	}
+	uc.trigger()
+	return nil
+}
+
+// ─── GetResyncStatusUseCase ───────────────────────────────────────────────────
+
+type GetResyncStatusOutput struct {
+	Status JobStatus
+}
+
+type GetResyncStatusUseCase struct {
+	job *ResyncJob
+}
+
+func NewGetResyncStatusUseCase(job *ResyncJob) *GetResyncStatusUseCase {
+	return &GetResyncStatusUseCase{job: job}
+}
+
+func (uc *GetResyncStatusUseCase) Execute(_ context.Context) GetResyncStatusOutput {
+	return GetResyncStatusOutput{Status: uc.job.Status()}
+}

--- a/internal/wiki/resync/use_cases_test.go
+++ b/internal/wiki/resync/use_cases_test.go
@@ -1,0 +1,62 @@
+package wikiresync_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	sharederrors "github.com/perber/wiki/internal/core/shared/errors"
+	. "github.com/perber/wiki/internal/wiki/resync"
+)
+
+func TestTriggerResyncUseCase_Execute_LaunchesTrigger(t *testing.T) {
+	job := NewResyncJob()
+	called := false
+	uc := NewTriggerResyncUseCase(job, func() { called = true })
+
+	if err := uc.Execute(context.Background()); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if !called {
+		t.Error("trigger was not called")
+	}
+}
+
+func TestTriggerResyncUseCase_Execute_ReturnsLocalizedErrorWhenAlreadyRunning(t *testing.T) {
+	job := NewResyncJob()
+	job.Start() // simulate running
+
+	uc := NewTriggerResyncUseCase(job, func() { t.Error("trigger must not be called") })
+	err := uc.Execute(context.Background())
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	loc, ok := sharederrors.AsLocalizedError(err)
+	if !ok {
+		t.Fatalf("expected LocalizedError, got %T", err)
+	}
+	if loc.Code != ErrCodeResyncAlreadyRunning {
+		t.Errorf("expected code %q, got %q", ErrCodeResyncAlreadyRunning, loc.Code)
+	}
+}
+
+func TestGetResyncStatusUseCase_Execute_ReturnsJobStatus(t *testing.T) {
+	job := NewResyncJob()
+	job.Start()
+	job.SetPhase(PhaseTags)
+	job.Finish(errors.New("something went wrong"))
+
+	uc := NewGetResyncStatusUseCase(job)
+	out := uc.Execute(context.Background())
+
+	if out.Status.Running {
+		t.Error("finished job should not be running")
+	}
+	if !out.Status.Done {
+		t.Error("expected done=true")
+	}
+	if out.Status.Error != "something went wrong" {
+		t.Errorf("unexpected error message: %q", out.Status.Error)
+	}
+}

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -65,7 +65,11 @@ type Wiki struct {
 	props            *properties.PropertiesService
 	backupRoutes     *wikibackup.Routes
 	resyncRoutes     *wikiresync.Routes
+	resyncJob        *wikiresync.ResyncJob
 	reloadMu         sync.Mutex
+	reloadWG         sync.WaitGroup
+	shutdownCtx      context.Context
+	shutdownCancel   context.CancelFunc
 	log              *slog.Logger
 }
 
@@ -85,9 +89,13 @@ type WikiOptions struct {
 }
 
 func NewWiki(options *WikiOptions) (*Wiki, error) {
+	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 	w := &Wiki{
-		storageDir: options.StorageDir,
-		log:        slog.Default().With("component", "Wiki"),
+		storageDir:     options.StorageDir,
+		log:            slog.Default().With("component", "Wiki"),
+		resyncJob:      wikiresync.NewResyncJob(),
+		shutdownCtx:    shutdownCtx,
+		shutdownCancel: shutdownCancel,
 	}
 	if err := w.initAuth(options); err != nil {
 		return nil, err
@@ -271,10 +279,12 @@ func (w *Wiki) initSearch() error {
 	w.status = search.NewIndexingStatus()
 	searchEffect := pagesave.NewSearchIndexSideEffect(w.searchIndex, w.tree, w.log)
 	w.log.Info("search indexing started")
+	w.reloadWG.Add(1)
 	go func() {
+		defer w.reloadWG.Done()
 		w.status.Start()
 		defer w.status.Finish()
-		if err := searchEffect.IndexAllPages(); err != nil {
+		if err := searchEffect.IndexAllPagesContext(w.shutdownCtx); err != nil {
 			w.log.Warn("search bootstrap failed", "error", err)
 			w.status.Fail()
 		} else {
@@ -310,7 +320,11 @@ func (w *Wiki) buildRoutes(options *WikiOptions) {
 		Status:     w.status,
 		StorageDir: w.storageDir,
 	})
-	w.resyncRoutes = wikiresync.NewRoutes(w.ReloadFromFS, w.auth)
+	w.resyncRoutes = wikiresync.NewRoutes(
+		wikiresync.NewTriggerResyncUseCase(w.resyncJob, w.launchReloadWithProgress),
+		wikiresync.NewGetResyncStatusUseCase(w.resyncJob),
+		w.auth,
+	)
 }
 
 // ─── Domain route builder helpers ────────────────────────────────────────────
@@ -623,6 +637,89 @@ func (w *Wiki) ReloadFromFSContext(ctx context.Context) error {
 	return nil
 }
 
+// launchReloadWithProgress adds to reloadWG and starts reloadWithProgress in a goroutine.
+// The caller is responsible for having already called resyncJob.Start().
+func (w *Wiki) launchReloadWithProgress() {
+	w.reloadWG.Add(1)
+	go func() {
+		defer w.reloadWG.Done()
+		w.reloadWithProgress(w.shutdownCtx)
+	}()
+}
+
+// reloadWithProgress runs the filesystem reload while updating resyncJob phases.
+// Must only be called via launchReloadWithProgress (which tracks the WG).
+func (w *Wiki) reloadWithProgress(ctx context.Context) {
+	job := w.resyncJob
+
+	// Catch panics so a bug in any phase always releases the job and mutex.
+	defer func() {
+		if r := recover(); r != nil {
+			w.log.Error("panic during filesystem reload", "panic", r)
+			job.Finish(fmt.Errorf("panic during reload: %v", r))
+		}
+	}()
+
+	w.reloadMu.Lock()
+	defer w.reloadMu.Unlock()
+
+	w.log.Info("filesystem reload started (async)")
+
+	job.SetPhase(wikiresync.PhaseTree)
+	if err := w.tree.ReconstructTreeFromFSContext(ctx); err != nil {
+		job.Finish(fmt.Errorf("tree reconstruction failed: %w", err))
+		return
+	}
+
+	if ctx.Err() != nil {
+		job.Finish(ctx.Err())
+		return
+	}
+
+	job.SetPhase(wikiresync.PhaseLinks)
+	if err := w.links.IndexAllPagesContext(ctx); err != nil {
+		if ctx.Err() != nil {
+			job.Finish(ctx.Err())
+			return
+		}
+		w.log.Warn("link re-index failed during reload", "error", err)
+	}
+
+	if ctx.Err() != nil {
+		job.Finish(ctx.Err())
+		return
+	}
+
+	job.SetPhase(wikiresync.PhaseTags)
+	w.bootstrapTagsAndProperties()
+
+	job.SetPhase(wikiresync.PhaseSearch)
+	w.status.Start()
+	searchEffect := pagesave.NewSearchIndexSideEffect(w.searchIndex, w.tree, w.log)
+	if err := searchEffect.IndexAllPagesContext(ctx); err != nil {
+		w.log.Warn("search re-index failed during reload", "error", err)
+		w.status.Fail()
+		w.status.Finish()
+		job.Finish(fmt.Errorf("search re-index failed: %w", err))
+		return
+	}
+	w.status.Success()
+	w.status.Finish()
+
+	w.log.Info("filesystem reload completed (async)")
+	job.Finish(nil)
+}
+
+// TriggerResyncAsync starts a background filesystem reload if none is already running.
+// Used by the signal handler so SIGUSR1/SIGHUP also goes through the shared ResyncJob.
+func (w *Wiki) TriggerResyncAsync() {
+	if !w.resyncJob.Start() {
+		w.log.Info("resync already running, signal ignored")
+		return
+	}
+	w.launchReloadWithProgress()
+}
+
 // ─── Service getters (test infrastructure) ───────────────────────────────────
 
 func (w *Wiki) GetStorageDir() string {
@@ -634,6 +731,8 @@ func (w *Wiki) UserService() *auth.UserService {
 }
 
 func (w *Wiki) Close() error {
+	w.shutdownCancel()  // signal in-flight reloads to abort
+	w.reloadWG.Wait()   // drain goroutines before closing stores
 	w.status.Finish()
 	if w.auth != nil {
 		// When auth is enabled, AuthService owns both the session store and user store.

--- a/ui/leafwiki-ui/src/features/maintenance/MaintenanceSettings.tsx
+++ b/ui/leafwiki-ui/src/features/maintenance/MaintenanceSettings.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button'
+import { ApiLocalizedError, mapApiError } from '@/lib/api/errors'
 import { Loader2, RefreshCw } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -6,19 +7,33 @@ import { useResyncStore } from '@/stores/resync'
 import { useSetTitle } from '../viewer/setTitle'
 import { useToolbarActions } from './useToolbarActions'
 
+const PHASE_ORDER = ['tree', 'links', 'tags', 'search'] as const
+
 export default function MaintenanceSettings() {
   const { t } = useTranslation('maintenance')
-  const { isLoading, trigger } = useResyncStore()
+  const { isLoading, phase, trigger } = useResyncStore()
 
   useToolbarActions()
   useSetTitle({ title: t('pageTitle') })
+
+  const phaseIndex = phase
+    ? PHASE_ORDER.indexOf(phase as (typeof PHASE_ORDER)[number]) + 1
+    : 0
+  const progressPercent = Math.round((phaseIndex / PHASE_ORDER.length) * 100)
 
   const handleResync = async () => {
     try {
       await trigger()
       toast.success(t('toast.success'))
-    } catch {
-      toast.error(t('toast.error'))
+    } catch (err) {
+      if (
+        err instanceof ApiLocalizedError &&
+        err.code === 'resync_already_running'
+      ) {
+        toast.info(t('toast.alreadyRunning'))
+      } else {
+        toast.error(mapApiError(err, t('toast.error')).message)
+      }
     }
   }
 
@@ -43,6 +58,33 @@ export default function MaintenanceSettings() {
               : t('filesystemSync.button')}
           </Button>
         </div>
+
+        {isLoading && (
+          <div className="importer__status-banner">
+            <div className="importer__status-header">
+              <div>
+                <div className="settings__preview-label">
+                  {t('progress.label')}
+                </div>
+                <div className="importer__status-title">
+                  {phase ? t(`progress.${phase}`) : '…'}
+                </div>
+              </div>
+            </div>
+            <div className="importer__status-meta">
+              <span>
+                {phaseIndex} / {PHASE_ORDER.length}
+              </span>
+              <span>{progressPercent}%</span>
+            </div>
+            <div className="importer__progress">
+              <div
+                className="importer__progress-bar"
+                style={{ width: `${progressPercent}%` }}
+              />
+            </div>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/ui/leafwiki-ui/src/lib/api/resync.ts
+++ b/ui/leafwiki-ui/src/lib/api/resync.ts
@@ -2,9 +2,23 @@ import { fetchWithAuth } from './auth'
 
 const RESYNC_URL = '/api/admin/resync'
 
+export interface ResyncStatus {
+  running: boolean
+  phase: string | null
+  done: boolean
+  error?: string
+}
+
 export async function triggerResync(): Promise<void> {
   await fetchWithAuth(RESYNC_URL, {
     method: 'POST',
     credentials: 'include',
   })
+}
+
+export async function getResyncStatus(): Promise<ResyncStatus> {
+  const res = await fetchWithAuth(`${RESYNC_URL}/status`, {
+    credentials: 'include',
+  })
+  return res as ResyncStatus
 }

--- a/ui/leafwiki-ui/src/locales/en/errors.json
+++ b/ui/leafwiki-ui/src/locales/en/errors.json
@@ -72,6 +72,8 @@
   "revision request failed": "Revision request failed",
   "revision resource not found": "Revision resource not found",
   "revision %s for page %s not found": "Revision %s for page %s not found",
+  "a sync is already in progress": "A sync is already in progress",
+  "resync request failed": "Resync request failed",
   "search is currently unavailable": "Search is currently unavailable",
   "title query param is required": "Title query parameter is required",
   "tree not loaded": "Tree not loaded",

--- a/ui/leafwiki-ui/src/locales/en/maintenance.json
+++ b/ui/leafwiki-ui/src/locales/en/maintenance.json
@@ -8,6 +8,14 @@
   },
   "toast": {
     "success": "Filesystem sync completed",
-    "error": "Filesystem sync failed"
+    "error": "Filesystem sync failed",
+    "alreadyRunning": "Sync already in progress"
+  },
+  "progress": {
+    "label": "Current Phase",
+    "tree": "Rebuilding page tree",
+    "links": "Indexing links",
+    "tags": "Rebuilding tags & properties",
+    "search": "Indexing search"
   }
 }

--- a/ui/leafwiki-ui/src/stores/resync.ts
+++ b/ui/leafwiki-ui/src/stores/resync.ts
@@ -1,20 +1,69 @@
 import { create } from 'zustand'
-import { triggerResync } from '@/lib/api/resync'
+import { getResyncStatus, triggerResync } from '@/lib/api/resync'
+
+const POLL_INTERVAL_MS = 800
+const POLL_ERROR_LIMIT = 3
 
 interface ResyncState {
   isLoading: boolean
+  phase: string | null
   trigger: () => Promise<void>
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms))
 }
 
 export const useResyncStore = create<ResyncState>((set) => ({
   isLoading: false,
+  phase: null,
 
   trigger: async () => {
-    set({ isLoading: true })
+    // Set loading before the POST so the button is disabled immediately,
+    // preventing a second concurrent trigger during the network round-trip.
+    set({ isLoading: true, phase: null })
     try {
       await triggerResync()
-    } finally {
+    } catch (err) {
       set({ isLoading: false })
+      throw err
+    }
+
+    // Poll until the job reports done or a network error is unrecoverable.
+    let consecutiveErrors = 0
+    for (;;) {
+      await sleep(POLL_INTERVAL_MS)
+
+      let status: Awaited<ReturnType<typeof getResyncStatus>>
+      try {
+        status = await getResyncStatus()
+        consecutiveErrors = 0
+      } catch (err) {
+        consecutiveErrors++
+        if (consecutiveErrors >= POLL_ERROR_LIMIT) {
+          set({ isLoading: false, phase: null })
+          throw err
+        }
+        continue
+      }
+
+      // || null converts "" (Go's zero-value for omitted phase) to null.
+      set({ phase: status.phase || null })
+
+      if (status.done) {
+        set({ isLoading: false, phase: null })
+        // Throw application error outside the try/catch so it is not
+        // mistaken for a network error and does not increment consecutiveErrors.
+        if (status.error) {
+          throw new Error(status.error)
+        }
+        return
+      }
+      // running=false without done=true means the job was lost (server restart).
+      if (!status.running) {
+        set({ isLoading: false, phase: null })
+        throw new Error('Sync job lost — server may have restarted')
+      }
     }
   },
 }))


### PR DESCRIPTION
Adds a non-blocking POST /api/admin/resync endpoint that starts a background reload and returns 202 immediately. Clients poll GET /api/admin/resync/status (running/phase/done/error) until the job completes. The UI shows a live phase-progress banner.

Backend:
- internal/wiki/resync/job.go: ResyncJob state machine (tree→links→tags→search)
- internal/wiki/resync/use_cases.go: TriggerResyncUseCase + GetResyncStatusUseCase
- internal/wiki/resync/errors.go: LocalizedError codes + HTTP mapper
- wiki.go: reloadWithProgress (context-aware, shutdown-cancellable via shutdownCtx), initSearch goroutine tracked in reloadWG, Close() cancels context before Wait()
- cmd/leafwiki/main.go: signal handler uses TriggerResyncAsync (fire-and-forget)

Frontend:
- stores/resync.ts: polling loop with consecutive-error circuit breaker; !running without done=true throws 'job lost' instead of silent success
- MaintenanceSettings.tsx: phase progress banner, ApiLocalizedError handling
- locales/en/maintenance.json + errors.json: i18n keys for all new states