### PR TITLE
feat: typed properties backend with recursive MetadataValue tree

### DIFF
--- a/internal/core/tree/metadata_value.go
+++ b/internal/core/tree/metadata_value.go
@@ -1,0 +1,193 @@
+package tree
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+// MetadataValue is a typed, recursive node in the page metadata tree.
+// Scalar types use Value; list uses Items; object uses Fields.
+type MetadataValue struct {
+	Type   string                   `json:"type"`
+	Value  string                   `json:"value,omitempty"`
+	Items  []MetadataValue          `json:"items,omitempty"`
+	Fields map[string]MetadataValue `json:"fields,omitempty"`
+}
+
+// Allowed Type values for MetadataValue.
+const (
+	MetadataTypeText     = "text"
+	MetadataTypeNumber   = "number"
+	MetadataTypeBoolean  = "boolean"
+	MetadataTypeDate     = "date"
+	MetadataTypeDatetime = "datetime"
+	MetadataTypeNull     = "null"
+	MetadataTypeList     = "list"
+	MetadataTypeObject   = "object"
+)
+
+// IsValidMetadataType reports whether t is an allowed MetadataValue type.
+func IsValidMetadataType(t string) bool {
+	switch t {
+	case MetadataTypeText, MetadataTypeNumber, MetadataTypeBoolean,
+		MetadataTypeDate, MetadataTypeDatetime, MetadataTypeNull,
+		MetadataTypeList, MetadataTypeObject:
+		return true
+	}
+	return false
+}
+
+// IsScalar reports whether the value is a scalar type (not list or object).
+func (m MetadataValue) IsScalar() bool {
+	switch m.Type {
+	case MetadataTypeList, MetadataTypeObject:
+		return false
+	}
+	return true
+}
+
+// reDateOnly matches ISO date strings like 2024-01-15.
+var reDateOnly = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+
+// YamlValueToMetadataValue converts a raw value from YAML frontmatter
+// (as returned by yaml.v3 into interface{}) to a typed MetadataValue.
+func YamlValueToMetadataValue(v interface{}) (MetadataValue, error) {
+	switch val := v.(type) {
+	case nil:
+		return MetadataValue{Type: MetadataTypeNull}, nil
+
+	case bool:
+		s := "false"
+		if val {
+			s = "true"
+		}
+		return MetadataValue{Type: MetadataTypeBoolean, Value: s}, nil
+
+	case int:
+		return MetadataValue{Type: MetadataTypeNumber, Value: strconv.Itoa(val)}, nil
+
+	case int64:
+		return MetadataValue{Type: MetadataTypeNumber, Value: strconv.FormatInt(val, 10)}, nil
+
+	case float64:
+		return MetadataValue{Type: MetadataTypeNumber, Value: strconv.FormatFloat(val, 'f', -1, 64)}, nil
+
+	case string:
+		return metadataValueFromString(val), nil
+
+	case time.Time:
+		return metadataValueFromTime(val), nil
+
+	case []interface{}:
+		items := make([]MetadataValue, 0, len(val))
+		for i, item := range val {
+			child, err := YamlValueToMetadataValue(item)
+			if err != nil {
+				return MetadataValue{}, fmt.Errorf("items[%d]: %w", i, err)
+			}
+			items = append(items, child)
+		}
+		return MetadataValue{Type: MetadataTypeList, Items: items}, nil
+
+	case map[string]interface{}:
+		fields := make(map[string]MetadataValue, len(val))
+		for k, fv := range val {
+			child, err := YamlValueToMetadataValue(fv)
+			if err != nil {
+				return MetadataValue{}, fmt.Errorf("field %q: %w", k, err)
+			}
+			fields[k] = child
+		}
+		return MetadataValue{Type: MetadataTypeObject, Fields: fields}, nil
+
+	default:
+		// Fallback: stringify unknown types.
+		return MetadataValue{Type: MetadataTypeText, Value: fmt.Sprintf("%v", val)}, nil
+	}
+}
+
+func metadataValueFromString(s string) MetadataValue {
+	if _, err := time.Parse(time.RFC3339, s); err == nil {
+		return MetadataValue{Type: MetadataTypeDatetime, Value: s}
+	}
+	// Try bare date.
+	if reDateOnly.MatchString(s) {
+		if _, err := time.Parse("2006-01-02", s); err == nil {
+			return MetadataValue{Type: MetadataTypeDate, Value: s}
+		}
+	}
+	return MetadataValue{Type: MetadataTypeText, Value: s}
+}
+
+func metadataValueFromTime(ts time.Time) MetadataValue {
+	ts = ts.UTC()
+	// YAML parses bare dates (e.g. 2024-01-15) as time.Time at midnight UTC
+	// with a zero time component.
+	if ts.Hour() == 0 && ts.Minute() == 0 && ts.Second() == 0 && ts.Nanosecond() == 0 {
+		return MetadataValue{Type: MetadataTypeDate, Value: ts.Format("2006-01-02")}
+	}
+	return MetadataValue{Type: MetadataTypeDatetime, Value: ts.Format(time.RFC3339)}
+}
+
+// metadataValueToYAML converts a MetadataValue back to a Go value
+// suitable for YAML serialization via yaml.v3.
+func metadataValueToYAML(v MetadataValue) (interface{}, error) {
+	switch v.Type {
+	case MetadataTypeText:
+		return v.Value, nil
+
+	case MetadataTypeDate:
+		return v.Value, nil
+
+	case MetadataTypeDatetime:
+		return v.Value, nil
+
+	case MetadataTypeNull:
+		return nil, nil
+
+	case MetadataTypeNumber:
+		// Try integer first, then float.
+		if i, err := strconv.ParseInt(v.Value, 10, 64); err == nil {
+			return i, nil
+		}
+		f, err := strconv.ParseFloat(v.Value, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid number value %q: %w", v.Value, err)
+		}
+		return f, nil
+
+	case MetadataTypeBoolean:
+		b, err := strconv.ParseBool(v.Value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid boolean value %q: %w", v.Value, err)
+		}
+		return b, nil
+
+	case MetadataTypeList:
+		result := make([]interface{}, 0, len(v.Items))
+		for i, item := range v.Items {
+			child, err := metadataValueToYAML(item)
+			if err != nil {
+				return nil, fmt.Errorf("items[%d]: %w", i, err)
+			}
+			result = append(result, child)
+		}
+		return result, nil
+
+	case MetadataTypeObject:
+		result := make(map[string]interface{}, len(v.Fields))
+		for k, fv := range v.Fields {
+			child, err := metadataValueToYAML(fv)
+			if err != nil {
+				return nil, fmt.Errorf("field %q: %w", k, err)
+			}
+			result[k] = child
+		}
+		return result, nil
+
+	default:
+		return nil, fmt.Errorf("unknown MetadataValue type %q", v.Type)
+	}
+}

--- a/internal/core/tree/metadata_value_test.go
+++ b/internal/core/tree/metadata_value_test.go
@@ -1,0 +1,404 @@
+package tree
+
+import (
+	"testing"
+	"time"
+)
+
+// ─── YamlValueToMetadataValue ────────────────────────────────────────────────
+
+func TestYamlValueToMetadataValue_NilReturnsNull(t *testing.T) {
+	got, err := YamlValueToMetadataValue(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Type != MetadataTypeNull {
+		t.Errorf("expected type %q, got %q", MetadataTypeNull, got.Type)
+	}
+}
+
+func TestYamlValueToMetadataValue_StringReturnsText(t *testing.T) {
+	got, err := YamlValueToMetadataValue("hello world")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Type != MetadataTypeText {
+		t.Errorf("expected type %q, got %q", MetadataTypeText, got.Type)
+	}
+	if got.Value != "hello world" {
+		t.Errorf("expected value %q, got %q", "hello world", got.Value)
+	}
+}
+
+func TestYamlValueToMetadataValue_StringDatePatternReturnsDate(t *testing.T) {
+	got, err := YamlValueToMetadataValue("2024-01-15")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Type != MetadataTypeDate {
+		t.Errorf("expected type %q, got %q", MetadataTypeDate, got.Type)
+	}
+	if got.Value != "2024-01-15" {
+		t.Errorf("expected value %q, got %q", "2024-01-15", got.Value)
+	}
+}
+
+func TestYamlValueToMetadataValue_StringDatetimePatternReturnsDatetime(t *testing.T) {
+	got, err := YamlValueToMetadataValue("2024-01-15T12:30:00Z")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Type != MetadataTypeDatetime {
+		t.Errorf("expected type %q, got %q", MetadataTypeDatetime, got.Type)
+	}
+}
+
+func TestYamlValueToMetadataValue_IntReturnsNumber(t *testing.T) {
+	got, err := YamlValueToMetadataValue(42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Type != MetadataTypeNumber {
+		t.Errorf("expected type %q, got %q", MetadataTypeNumber, got.Type)
+	}
+	if got.Value != "42" {
+		t.Errorf("expected value %q, got %q", "42", got.Value)
+	}
+}
+
+func TestYamlValueToMetadataValue_Float64ReturnsNumber(t *testing.T) {
+	got, err := YamlValueToMetadataValue(3.14)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Type != MetadataTypeNumber {
+		t.Errorf("expected type %q, got %q", MetadataTypeNumber, got.Type)
+	}
+	if got.Value != "3.14" {
+		t.Errorf("expected value %q, got %q", "3.14", got.Value)
+	}
+}
+
+func TestYamlValueToMetadataValue_BoolTrueReturnsBoolean(t *testing.T) {
+	got, err := YamlValueToMetadataValue(true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Type != MetadataTypeBoolean {
+		t.Errorf("expected type %q, got %q", MetadataTypeBoolean, got.Type)
+	}
+	if got.Value != "true" {
+		t.Errorf("expected value %q, got %q", "true", got.Value)
+	}
+}
+
+func TestYamlValueToMetadataValue_BoolFalseReturnsBoolean(t *testing.T) {
+	got, err := YamlValueToMetadataValue(false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Type != MetadataTypeBoolean {
+		t.Errorf("expected type %q, got %q", MetadataTypeBoolean, got.Type)
+	}
+	if got.Value != "false" {
+		t.Errorf("expected value %q, got %q", "false", got.Value)
+	}
+}
+
+func TestYamlValueToMetadataValue_TimeDateOnlyReturnsDate(t *testing.T) {
+	// YAML parses bare dates like 2024-01-15 as time.Time at midnight UTC
+	ts := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+	got, err := YamlValueToMetadataValue(ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Type != MetadataTypeDate {
+		t.Errorf("expected type %q, got %q", MetadataTypeDate, got.Type)
+	}
+	if got.Value != "2024-01-15" {
+		t.Errorf("expected value %q, got %q", "2024-01-15", got.Value)
+	}
+}
+
+func TestYamlValueToMetadataValue_TimestampReturnsDatetime(t *testing.T) {
+	ts := time.Date(2024, 1, 15, 12, 30, 0, 0, time.UTC)
+	got, err := YamlValueToMetadataValue(ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Type != MetadataTypeDatetime {
+		t.Errorf("expected type %q, got %q", MetadataTypeDatetime, got.Type)
+	}
+}
+
+func TestYamlValueToMetadataValue_SliceReturnsList(t *testing.T) {
+	got, err := YamlValueToMetadataValue([]interface{}{"a", 1, true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Type != MetadataTypeList {
+		t.Errorf("expected type %q, got %q", MetadataTypeList, got.Type)
+	}
+	if len(got.Items) != 3 {
+		t.Errorf("expected 3 items, got %d", len(got.Items))
+	}
+	if got.Items[0].Type != MetadataTypeText || got.Items[0].Value != "a" {
+		t.Errorf("items[0] wrong: %+v", got.Items[0])
+	}
+	if got.Items[1].Type != MetadataTypeNumber || got.Items[1].Value != "1" {
+		t.Errorf("items[1] wrong: %+v", got.Items[1])
+	}
+	if got.Items[2].Type != MetadataTypeBoolean || got.Items[2].Value != "true" {
+		t.Errorf("items[2] wrong: %+v", got.Items[2])
+	}
+}
+
+func TestYamlValueToMetadataValue_MapReturnsObject(t *testing.T) {
+	m := map[string]interface{}{"author": "alice", "count": 42}
+	got, err := YamlValueToMetadataValue(m)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Type != MetadataTypeObject {
+		t.Errorf("expected type %q, got %q", MetadataTypeObject, got.Type)
+	}
+	if len(got.Fields) != 2 {
+		t.Errorf("expected 2 fields, got %d", len(got.Fields))
+	}
+	if got.Fields["author"].Type != MetadataTypeText {
+		t.Errorf("fields.author wrong type: %q", got.Fields["author"].Type)
+	}
+	if got.Fields["count"].Type != MetadataTypeNumber {
+		t.Errorf("fields.count wrong type: %q", got.Fields["count"].Type)
+	}
+}
+
+// ─── metadataValueToYAML ─────────────────────────────────────────────────────
+
+func TestMetadataValueToYAML_TextReturnsString(t *testing.T) {
+	v := MetadataValue{Type: MetadataTypeText, Value: "hello"}
+	got, err := metadataValueToYAML(v)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	s, ok := got.(string)
+	if !ok {
+		t.Fatalf("expected string, got %T", got)
+	}
+	if s != "hello" {
+		t.Errorf("expected %q, got %q", "hello", s)
+	}
+}
+
+func TestMetadataValueToYAML_NumberIntReturnsInt64(t *testing.T) {
+	v := MetadataValue{Type: MetadataTypeNumber, Value: "42"}
+	got, err := metadataValueToYAML(v)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	n, ok := got.(int64)
+	if !ok {
+		t.Fatalf("expected int64, got %T: %v", got, got)
+	}
+	if n != 42 {
+		t.Errorf("expected 42, got %d", n)
+	}
+}
+
+func TestMetadataValueToYAML_NumberFloatReturnsFloat64(t *testing.T) {
+	v := MetadataValue{Type: MetadataTypeNumber, Value: "3.14"}
+	got, err := metadataValueToYAML(v)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	f, ok := got.(float64)
+	if !ok {
+		t.Fatalf("expected float64, got %T: %v", got, got)
+	}
+	if f != 3.14 {
+		t.Errorf("expected 3.14, got %v", f)
+	}
+}
+
+func TestMetadataValueToYAML_InvalidNumberReturnsError(t *testing.T) {
+	v := MetadataValue{Type: MetadataTypeNumber, Value: "not-a-number"}
+	_, err := metadataValueToYAML(v)
+	if err == nil {
+		t.Fatal("expected error for invalid number, got nil")
+	}
+}
+
+func TestMetadataValueToYAML_BooleanTrueReturnsBool(t *testing.T) {
+	v := MetadataValue{Type: MetadataTypeBoolean, Value: "true"}
+	got, err := metadataValueToYAML(v)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	b, ok := got.(bool)
+	if !ok {
+		t.Fatalf("expected bool, got %T", got)
+	}
+	if !b {
+		t.Errorf("expected true, got false")
+	}
+}
+
+func TestMetadataValueToYAML_BooleanFalseReturnsBool(t *testing.T) {
+	v := MetadataValue{Type: MetadataTypeBoolean, Value: "false"}
+	got, err := metadataValueToYAML(v)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	b, ok := got.(bool)
+	if !ok {
+		t.Fatalf("expected bool, got %T", got)
+	}
+	if b {
+		t.Errorf("expected false, got true")
+	}
+}
+
+func TestMetadataValueToYAML_DateReturnsString(t *testing.T) {
+	v := MetadataValue{Type: MetadataTypeDate, Value: "2024-01-15"}
+	got, err := metadataValueToYAML(v)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	s, ok := got.(string)
+	if !ok {
+		t.Fatalf("expected string, got %T", got)
+	}
+	if s != "2024-01-15" {
+		t.Errorf("expected %q, got %q", "2024-01-15", s)
+	}
+}
+
+func TestMetadataValueToYAML_DatetimeReturnsString(t *testing.T) {
+	v := MetadataValue{Type: MetadataTypeDatetime, Value: "2024-01-15T12:30:00Z"}
+	got, err := metadataValueToYAML(v)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	s, ok := got.(string)
+	if !ok {
+		t.Fatalf("expected string, got %T", got)
+	}
+	if s != "2024-01-15T12:30:00Z" {
+		t.Errorf("expected RFC3339, got %q", s)
+	}
+}
+
+func TestMetadataValueToYAML_NullReturnsNil(t *testing.T) {
+	v := MetadataValue{Type: MetadataTypeNull}
+	got, err := metadataValueToYAML(v)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+func TestMetadataValueToYAML_ListReturnsSlice(t *testing.T) {
+	v := MetadataValue{
+		Type: MetadataTypeList,
+		Items: []MetadataValue{
+			{Type: MetadataTypeText, Value: "a"},
+			{Type: MetadataTypeNumber, Value: "1"},
+		},
+	}
+	got, err := metadataValueToYAML(v)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	slice, ok := got.([]interface{})
+	if !ok {
+		t.Fatalf("expected []interface{}, got %T", got)
+	}
+	if len(slice) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(slice))
+	}
+	if slice[0] != "a" {
+		t.Errorf("expected 'a', got %v", slice[0])
+	}
+	if slice[1] != int64(1) {
+		t.Errorf("expected int64(1), got %T(%v)", slice[1], slice[1])
+	}
+}
+
+func TestMetadataValueToYAML_ObjectReturnsMap(t *testing.T) {
+	v := MetadataValue{
+		Type: MetadataTypeObject,
+		Fields: map[string]MetadataValue{
+			"author": {Type: MetadataTypeText, Value: "alice"},
+		},
+	}
+	got, err := metadataValueToYAML(v)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m, ok := got.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map[string]interface{}, got %T", got)
+	}
+	if m["author"] != "alice" {
+		t.Errorf("expected author=alice, got %v", m["author"])
+	}
+}
+
+func TestMetadataValueToYAML_UnknownTypeReturnsError(t *testing.T) {
+	v := MetadataValue{Type: "unknown-type", Value: "x"}
+	_, err := metadataValueToYAML(v)
+	if err == nil {
+		t.Fatal("expected error for unknown type, got nil")
+	}
+}
+
+// ─── IsValidMetadataType ──────────────────────────────────────────────────────
+
+func TestIsValidMetadataType_KnownTypesReturnTrue(t *testing.T) {
+	known := []string{
+		MetadataTypeText, MetadataTypeNumber, MetadataTypeBoolean,
+		MetadataTypeDate, MetadataTypeDatetime, MetadataTypeNull,
+		MetadataTypeList, MetadataTypeObject,
+	}
+	for _, typ := range known {
+		if !IsValidMetadataType(typ) {
+			t.Errorf("expected %q to be valid", typ)
+		}
+	}
+}
+
+func TestIsValidMetadataType_UnknownTypeReturnsFalse(t *testing.T) {
+	if IsValidMetadataType("unknown") {
+		t.Error("expected 'unknown' to be invalid")
+	}
+	if IsValidMetadataType("") {
+		t.Error("expected empty string to be invalid")
+	}
+}
+
+// ─── IsScalar ─────────────────────────────────────────────────────────────────
+
+func TestIsScalar_ScalarTypesReturnTrue(t *testing.T) {
+	scalars := []string{
+		MetadataTypeText, MetadataTypeNumber, MetadataTypeBoolean,
+		MetadataTypeDate, MetadataTypeDatetime, MetadataTypeNull,
+	}
+	for _, typ := range scalars {
+		mv := MetadataValue{Type: typ}
+		if !mv.IsScalar() {
+			t.Errorf("expected %q to be scalar", typ)
+		}
+	}
+}
+
+func TestIsScalar_ContainerTypesReturnFalse(t *testing.T) {
+	containers := []string{MetadataTypeList, MetadataTypeObject}
+	for _, typ := range containers {
+		mv := MetadataValue{Type: typ}
+		if mv.IsScalar() {
+			t.Errorf("expected %q to not be scalar", typ)
+		}
+	}
+}

--- a/internal/core/tree/node_store.go
+++ b/internal/core/tree/node_store.go
@@ -718,25 +718,20 @@ func (f *NodeStore) UpsertContentPreservingFrontmatter(entry *PageNode, content 
 }
 
 // UpsertContentAndMetadata is the UI-edit path: it replaces the body and the
-// editor-visible frontmatter (tags and string-typed properties) while keeping
-// system-managed frontmatter (leafwiki_*) and non-string pass-through fields
-// (booleans, numbers, non-tag lists) intact.
+// editor-visible frontmatter (tags and typed properties) while keeping
+// system-managed frontmatter (leafwiki_*) intact.
 //
 // Ownership rules for ExtraFields:
-//   - String-valued keys are editor-owned: only keys present in properties
-//     survive; keys absent from properties are removed.
-//   - Non-string, non-map values (bool, int, float64, []interface{}) are
-//     always preserved — the editor cannot represent them, so it cannot
-//     intentionally delete them.
-//   - Nested maps (map[string]interface{}) are not preserved; their string
-//     leaves round-trip through the editor as dot-notation property keys.
+//   - All non-system, non-tags ExtraFields are editor-owned: only keys present
+//     in properties survive; keys absent from properties are removed.
 //   - Tags: when tags is non-nil the existing tags are replaced; when tags is
 //     nil the existing tags in the file are left unchanged.
+//   - For PreserveFrontmatter use UpsertContentPreservingFrontmatter instead.
 func (f *NodeStore) UpsertContentAndMetadata(
 	entry *PageNode,
 	body string,
 	tags []string,
-	properties map[string]string,
+	properties map[string]MetadataValue,
 ) error {
 	if entry == nil {
 		return &InvalidOpError{Op: "UpsertContentAndMetadata", Reason: "an entry is required"}
@@ -758,27 +753,16 @@ func (f *NodeStore) UpsertContentAndMetadata(
 	mdFile.SetContent(body)
 
 	existing := mdFile.GetFrontmatter().ExtraFields
-	extra := make(map[string]interface{}, len(properties)+len(existing)+1)
+	extra := make(map[string]interface{}, len(properties)+1)
 
-	// Preserve non-string, non-map ExtraFields (bool, int, float64, non-tag
-	// lists). The editor cannot represent these types and never sends them back,
-	// so they must survive an edit unchanged.
-	for k, v := range existing {
-		if k == "tags" {
-			continue // handled separately below
-		}
-		switch v.(type) {
-		case string, map[string]interface{}:
-			// string: editor-owned, replaced by incoming properties
-			// map: nested YAML — string leaves round-trip via dot-notation keys
-		default:
-			extra[k] = v
-		}
-	}
-
-	// String properties from the editor replace every editor-owned string key.
+	// Write typed properties. All editor-owned keys are replaced; keys absent
+	// from the request are dropped.
 	for k, v := range properties {
-		extra[k] = v
+		yamlVal, err := metadataValueToYAML(v)
+		if err != nil {
+			return fmt.Errorf("convert property %q: %w", k, err)
+		}
+		extra[k] = yamlVal
 	}
 
 	// Tags: replace when the caller sends an explicit list; preserve otherwise.

--- a/internal/core/tree/node_store_test.go
+++ b/internal/core/tree/node_store_test.go
@@ -592,7 +592,10 @@ func TestNodeStore_UpsertContentAndMetadata_UpdatesProperties(t *testing.T) {
 	path := filepath.Join(tmp, "root", "p.md")
 	mustWriteFile(t, path, "---\nleafwiki_id: p1\nleafwiki_title: My Page\nstatus: draft\n---\n# old\n", 0o644)
 
-	props := map[string]string{"status": "published", "author": "alice"}
+	props := map[string]MetadataValue{
+		"status": {Type: MetadataTypeText, Value: "published"},
+		"author": {Type: MetadataTypeText, Value: "alice"},
+	}
 	if err := store.UpsertContentAndMetadata(page, "# updated", nil, props); err != nil {
 		t.Fatalf("UpsertContentAndMetadata: %v", err)
 	}
@@ -623,8 +626,11 @@ func TestNodeStore_UpsertContentAndMetadata_TitleAsCustomPropertyRoundtrips(t *t
 	path := filepath.Join(tmp, "root", "p.md")
 	mustWriteFile(t, path, "---\nleafwiki_id: p1\nleafwiki_title: My Page\ntitle: My Custom Title\nstatus: draft\n---\n# old\n", 0o644)
 
-	// The editor sends title back in properties (because Phase 1 makes it visible).
-	props := map[string]string{"title": "My Custom Title", "status": "published"}
+	// The editor sends title back in properties (because it's visible as a typed value).
+	props := map[string]MetadataValue{
+		"title":  {Type: MetadataTypeText, Value: "My Custom Title"},
+		"status": {Type: MetadataTypeText, Value: "published"},
+	}
 	if err := store.UpsertContentAndMetadata(page, "# edited", nil, props); err != nil {
 		t.Fatalf("UpsertContentAndMetadata: %v", err)
 	}
@@ -654,7 +660,7 @@ func TestNodeStore_UpsertContentAndMetadata_UnsentFieldsAreDropped(t *testing.T)
 	mustWriteFile(t, path, "---\nleafwiki_id: p1\nleafwiki_title: My Page\nstatus: draft\npermalink: /my-page\n---\n# body\n", 0o644)
 
 	// User saves without "permalink" — it was deleted in the editor.
-	if err := store.UpsertContentAndMetadata(page, "# body", nil, map[string]string{"status": "draft"}); err != nil {
+	if err := store.UpsertContentAndMetadata(page, "# body", nil, map[string]MetadataValue{"status": {Type: MetadataTypeText, Value: "draft"}}); err != nil {
 		t.Fatalf("UpsertContentAndMetadata: %v", err)
 	}
 
@@ -680,7 +686,7 @@ func TestNodeStore_UpsertContentAndMetadata_RemovedPropertyDoesNotPersist(t *tes
 	mustWriteFile(t, path, "---\nleafwiki_id: p1\nleafwiki_title: My Page\nstatus: draft\nauthor: alice\n---\n# body\n", 0o644)
 
 	// User removed "author"; only "status" is sent back.
-	if err := store.UpsertContentAndMetadata(page, "# body", nil, map[string]string{"status": "draft"}); err != nil {
+	if err := store.UpsertContentAndMetadata(page, "# body", nil, map[string]MetadataValue{"status": {Type: MetadataTypeText, Value: "draft"}}); err != nil {
 		t.Fatalf("UpsertContentAndMetadata: %v", err)
 	}
 
@@ -707,7 +713,7 @@ func TestNodeStore_UpsertContentAndMetadata_NilTagsPreservesExistingTags(t *test
 	mustWriteFile(t, path, "---\nleafwiki_id: p1\nleafwiki_title: My Page\ntags:\n  - go\n  - wiki\nstatus: draft\n---\n# body\n", 0o644)
 
 	// Save with properties only — no tags field (nil means "leave unchanged").
-	if err := store.UpsertContentAndMetadata(page, "# body", nil, map[string]string{"status": "published"}); err != nil {
+	if err := store.UpsertContentAndMetadata(page, "# body", nil, map[string]MetadataValue{"status": {Type: MetadataTypeText, Value: "published"}}); err != nil {
 		t.Fatalf("UpsertContentAndMetadata: %v", err)
 	}
 
@@ -722,9 +728,9 @@ func TestNodeStore_UpsertContentAndMetadata_NilTagsPreservesExistingTags(t *test
 	}
 }
 
-func TestNodeStore_UpsertContentAndMetadata_NonStringFieldsPreserved(t *testing.T) {
-	// Regression: bool, int, and non-tag list ExtraFields must survive an edit
-	// because the editor cannot represent them and never sends them back.
+func TestNodeStore_UpsertContentAndMetadata_TypedPropertiesReplaceAll(t *testing.T) {
+	// The editor now sends ALL properties with full type info.
+	// Only the keys present in the request survive; absent keys are removed.
 	tmp := t.TempDir()
 	store := NewNodeStore(tmp)
 
@@ -732,10 +738,15 @@ func TestNodeStore_UpsertContentAndMetadata_NonStringFieldsPreserved(t *testing.
 	page := &PageNode{ID: "p1", Slug: "p", Title: "My Page", Kind: NodeKindPage, Parent: root}
 
 	path := filepath.Join(tmp, "root", "p.md")
-	mustWriteFile(t, path, "---\nleafwiki_id: p1\nleafwiki_title: My Page\npublished: true\npriority: 42\naliases:\n  - /old-path\nstatus: draft\n---\n# body\n", 0o644)
+	mustWriteFile(t, path, "---\nleafwiki_id: p1\nleafwiki_title: My Page\npublished: true\npriority: 42\nstatus: draft\n---\n# body\n", 0o644)
 
-	// Editor only sends back the string property; non-string fields are absent.
-	if err := store.UpsertContentAndMetadata(page, "# body", nil, map[string]string{"status": "published"}); err != nil {
+	// Editor sends back all properties it wants to keep, with types.
+	props := map[string]MetadataValue{
+		"published": {Type: MetadataTypeBoolean, Value: "true"},
+		"priority":  {Type: MetadataTypeNumber, Value: "42"},
+		"status":    {Type: MetadataTypeText, Value: "published"},
+	}
+	if err := store.UpsertContentAndMetadata(page, "# body", nil, props); err != nil {
 		t.Fatalf("UpsertContentAndMetadata: %v", err)
 	}
 
@@ -745,17 +756,10 @@ func TestNodeStore_UpsertContentAndMetadata_NonStringFieldsPreserved(t *testing.
 		t.Fatalf("ParseFrontmatter: %v", err)
 	}
 	if fm.ExtraFields["published"] != true {
-		t.Fatalf("bool field published must be preserved, got %v", fm.ExtraFields["published"])
-	}
-	if fm.ExtraFields["priority"] != 42 {
-		t.Fatalf("int field priority must be preserved, got %v", fm.ExtraFields["priority"])
-	}
-	aliases, _ := fm.ExtraFields["aliases"].([]interface{})
-	if len(aliases) != 1 {
-		t.Fatalf("list field aliases must be preserved, got %v", fm.ExtraFields["aliases"])
+		t.Fatalf("bool published must round-trip, got %v", fm.ExtraFields["published"])
 	}
 	if fm.ExtraFields["status"] != "published" {
-		t.Fatalf("string property must be updated, got %v", fm.ExtraFields["status"])
+		t.Fatalf("string status must be updated, got %v", fm.ExtraFields["status"])
 	}
 }
 
@@ -1612,4 +1616,259 @@ func mustRead(t *testing.T, path string) []byte {
 		t.Fatalf("read %s: %v", path, err)
 	}
 	return b
+}
+
+// ─── UpsertContentAndMetadata: typed MetadataValue properties ────────────────
+
+func newPageFixture(t *testing.T, tmp string) (*NodeStore, *PageNode, string) {
+	t.Helper()
+	store := NewNodeStore(tmp)
+	root := &PageNode{ID: "root", Slug: "root", Title: "root", Kind: NodeKindSection}
+	page := &PageNode{ID: "p1", Slug: "p", Title: "My Page", Kind: NodeKindPage, Parent: root}
+	path := filepath.Join(tmp, "root", "p.md")
+	mustWriteFile(t, path, "---\nleafwiki_id: p1\nleafwiki_title: My Page\n---\n# old\n", 0o644)
+	return store, page, path
+}
+
+func TestNodeStore_UpsertContentAndMetadata_WritesNumberProperty(t *testing.T) {
+	tmp := t.TempDir()
+	store, page, path := newPageFixture(t, tmp)
+
+	props := map[string]MetadataValue{
+		"count": {Type: MetadataTypeNumber, Value: "42"},
+	}
+	if err := store.UpsertContentAndMetadata(page, "# body", nil, props); err != nil {
+		t.Fatalf("UpsertContentAndMetadata: %v", err)
+	}
+
+	raw := string(mustRead(t, path))
+	fm, _, _, err := markdown.ParseFrontmatter(raw)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	// YAML round-trip: numbers are stored as int (not int64 from yaml.v3)
+	v, ok := fm.ExtraFields["count"]
+	if !ok {
+		t.Fatal("expected count in frontmatter")
+	}
+	switch n := v.(type) {
+	case int:
+		if n != 42 {
+			t.Errorf("expected 42, got %d", n)
+		}
+	case int64:
+		if n != 42 {
+			t.Errorf("expected 42, got %d", n)
+		}
+	default:
+		t.Errorf("expected numeric type, got %T(%v)", v, v)
+	}
+}
+
+func TestNodeStore_UpsertContentAndMetadata_WritesBooleanProperty(t *testing.T) {
+	tmp := t.TempDir()
+	store, page, path := newPageFixture(t, tmp)
+
+	props := map[string]MetadataValue{
+		"active": {Type: MetadataTypeBoolean, Value: "true"},
+	}
+	if err := store.UpsertContentAndMetadata(page, "# body", nil, props); err != nil {
+		t.Fatalf("UpsertContentAndMetadata: %v", err)
+	}
+
+	raw := string(mustRead(t, path))
+	fm, _, _, err := markdown.ParseFrontmatter(raw)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	if fm.ExtraFields["active"] != true {
+		t.Errorf("expected active=true, got %v (%T)", fm.ExtraFields["active"], fm.ExtraFields["active"])
+	}
+}
+
+func TestNodeStore_UpsertContentAndMetadata_WritesDateProperty(t *testing.T) {
+	tmp := t.TempDir()
+	store, page, path := newPageFixture(t, tmp)
+
+	props := map[string]MetadataValue{
+		"created": {Type: MetadataTypeDate, Value: "2024-01-15"},
+	}
+	if err := store.UpsertContentAndMetadata(page, "# body", nil, props); err != nil {
+		t.Fatalf("UpsertContentAndMetadata: %v", err)
+	}
+
+	raw := string(mustRead(t, path))
+	fm, _, _, err := markdown.ParseFrontmatter(raw)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	// After YAML round-trip, a quoted date string stays a string.
+	// The stored value must contain the date.
+	v := fm.ExtraFields["created"]
+	if v == nil {
+		t.Fatal("expected created in frontmatter")
+	}
+	// Verify round-trip: convert back to MetadataValue and check type.
+	mv, err := YamlValueToMetadataValue(v)
+	if err != nil {
+		t.Fatalf("YamlValueToMetadataValue: %v", err)
+	}
+	if mv.Type != MetadataTypeDate && mv.Type != MetadataTypeDatetime {
+		t.Errorf("expected date or datetime type after round-trip, got %q", mv.Type)
+	}
+}
+
+func TestNodeStore_UpsertContentAndMetadata_WritesDateTimeProperty(t *testing.T) {
+	tmp := t.TempDir()
+	store, page, path := newPageFixture(t, tmp)
+
+	props := map[string]MetadataValue{
+		"updated": {Type: MetadataTypeDatetime, Value: "2024-01-15T12:30:00Z"},
+	}
+	if err := store.UpsertContentAndMetadata(page, "# body", nil, props); err != nil {
+		t.Fatalf("UpsertContentAndMetadata: %v", err)
+	}
+
+	raw := string(mustRead(t, path))
+	fm, _, _, err := markdown.ParseFrontmatter(raw)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	v := fm.ExtraFields["updated"]
+	if v == nil {
+		t.Fatal("expected updated in frontmatter")
+	}
+	mv, err := YamlValueToMetadataValue(v)
+	if err != nil {
+		t.Fatalf("YamlValueToMetadataValue: %v", err)
+	}
+	if mv.Type != MetadataTypeDatetime {
+		t.Errorf("expected datetime type after round-trip, got %q", mv.Type)
+	}
+}
+
+func TestNodeStore_UpsertContentAndMetadata_WritesNullProperty(t *testing.T) {
+	tmp := t.TempDir()
+	store, page, path := newPageFixture(t, tmp)
+
+	props := map[string]MetadataValue{
+		"archivedAt": {Type: MetadataTypeNull},
+	}
+	if err := store.UpsertContentAndMetadata(page, "# body", nil, props); err != nil {
+		t.Fatalf("UpsertContentAndMetadata: %v", err)
+	}
+
+	raw := string(mustRead(t, path))
+	fm, _, _, err := markdown.ParseFrontmatter(raw)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	if v, ok := fm.ExtraFields["archivedAt"]; !ok || v != nil {
+		t.Errorf("expected archivedAt=null, got %v (exists=%v)", v, ok)
+	}
+}
+
+func TestNodeStore_UpsertContentAndMetadata_WritesNestedObject(t *testing.T) {
+	tmp := t.TempDir()
+	store, page, path := newPageFixture(t, tmp)
+
+	props := map[string]MetadataValue{
+		"meta": {
+			Type: MetadataTypeObject,
+			Fields: map[string]MetadataValue{
+				"author": {Type: MetadataTypeText, Value: "alice"},
+			},
+		},
+	}
+	if err := store.UpsertContentAndMetadata(page, "# body", nil, props); err != nil {
+		t.Fatalf("UpsertContentAndMetadata: %v", err)
+	}
+
+	raw := string(mustRead(t, path))
+	fm, _, _, err := markdown.ParseFrontmatter(raw)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	meta, ok := fm.ExtraFields["meta"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected meta to be map, got %T: %v", fm.ExtraFields["meta"], fm.ExtraFields["meta"])
+	}
+	if meta["author"] != "alice" {
+		t.Errorf("expected meta.author=alice, got %v", meta["author"])
+	}
+}
+
+func TestNodeStore_UpsertContentAndMetadata_WritesNestedMixedList(t *testing.T) {
+	tmp := t.TempDir()
+	store, page, path := newPageFixture(t, tmp)
+
+	props := map[string]MetadataValue{
+		"items": {
+			Type: MetadataTypeList,
+			Items: []MetadataValue{
+				{Type: MetadataTypeText, Value: "hello"},
+				{Type: MetadataTypeNumber, Value: "7"},
+				{Type: MetadataTypeObject, Fields: map[string]MetadataValue{
+					"k": {Type: MetadataTypeText, Value: "v"},
+				}},
+			},
+		},
+	}
+	if err := store.UpsertContentAndMetadata(page, "# body", nil, props); err != nil {
+		t.Fatalf("UpsertContentAndMetadata: %v", err)
+	}
+
+	raw := string(mustRead(t, path))
+	fm, _, _, err := markdown.ParseFrontmatter(raw)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	list, ok := fm.ExtraFields["items"].([]interface{})
+	if !ok {
+		t.Fatalf("expected items to be list, got %T: %v", fm.ExtraFields["items"], fm.ExtraFields["items"])
+	}
+	if len(list) != 3 {
+		t.Errorf("expected 3 items, got %d", len(list))
+	}
+}
+
+func TestNodeStore_UpsertContentAndMetadata_RemovesUnsentEditorOwnedTree(t *testing.T) {
+	tmp := t.TempDir()
+	store, page, path := newPageFixture(t, tmp)
+
+	// File initially has a meta subtree.
+	mustWriteFile(t, path, "---\nleafwiki_id: p1\nleafwiki_title: My Page\nmeta:\n  author: alice\nstatus: draft\n---\n# old\n", 0o644)
+
+	// Properties request omits meta — it must be removed.
+	props := map[string]MetadataValue{
+		"status": {Type: MetadataTypeText, Value: "published"},
+	}
+	if err := store.UpsertContentAndMetadata(page, "# body", nil, props); err != nil {
+		t.Fatalf("UpsertContentAndMetadata: %v", err)
+	}
+
+	raw := string(mustRead(t, path))
+	fm, _, _, err := markdown.ParseFrontmatter(raw)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	if _, ok := fm.ExtraFields["meta"]; ok {
+		t.Error("meta subtree must be removed when not present in properties request")
+	}
+	if fm.ExtraFields["status"] != "published" {
+		t.Errorf("expected status=published, got %v", fm.ExtraFields["status"])
+	}
+}
+
+func TestNodeStore_UpsertContentAndMetadata_InvalidNumberReturnsError(t *testing.T) {
+	tmp := t.TempDir()
+	store, page, _ := newPageFixture(t, tmp)
+
+	props := map[string]MetadataValue{
+		"count": {Type: MetadataTypeNumber, Value: "not-a-number"},
+	}
+	err := store.UpsertContentAndMetadata(page, "# body", nil, props)
+	if err == nil {
+		t.Fatal("expected error for invalid number, got nil")
+	}
 }

--- a/internal/core/tree/page.go
+++ b/internal/core/tree/page.go
@@ -2,8 +2,10 @@ package tree
 
 type Page struct {
 	*PageNode
-	Content    string `json:"content"`
-	RawContent string `json:"-"` // full file including frontmatter; never serialised
+	Content    string                   `json:"content"`
+	RawContent string                   `json:"-"`
+	Tags       []string                 `json:"-"`
+	Properties map[string]MetadataValue `json:"-"`
 }
 
 type PermalinkTarget struct {

--- a/internal/core/tree/page_metadata.go
+++ b/internal/core/tree/page_metadata.go
@@ -1,0 +1,67 @@
+package tree
+
+import (
+	"log/slog"
+	"strings"
+
+	"github.com/perber/wiki/internal/core/markdown"
+)
+
+// ParseFrontmatterMetadata extracts tags and typed properties from raw markdown content.
+func ParseFrontmatterMetadata(rawContent string) ([]string, map[string]MetadataValue) {
+	fm, _, has, err := markdown.ParseFrontmatter(rawContent)
+	if err != nil || !has || len(fm.ExtraFields) == 0 {
+		return []string{}, map[string]MetadataValue{}
+	}
+	return ParseFrontmatterFields(fm.ExtraFields)
+}
+
+// ParseFrontmatterFields extracts tags and typed properties from parsed frontmatter ExtraFields.
+func ParseFrontmatterFields(fields map[string]interface{}) ([]string, map[string]MetadataValue) {
+	tags := []string{}
+	properties := map[string]MetadataValue{}
+
+	for rawKey, value := range fields {
+		key := strings.TrimSpace(rawKey)
+		if strings.ToLower(key) == "tags" {
+			tags = normalizeFrontmatterTags(value)
+			continue
+		}
+		if markdown.IsSystemKey(key) {
+			continue
+		}
+		mv, err := YamlValueToMetadataValue(value)
+		if err != nil {
+			slog.Warn("skipping metadata field with unconvertible value", "key", key, "error", err)
+			continue
+		}
+		properties[key] = mv
+	}
+
+	return tags, properties
+}
+
+func normalizeFrontmatterTags(value interface{}) []string {
+	list, ok := value.([]interface{})
+	if !ok {
+		return []string{}
+	}
+	seen := make(map[string]struct{}, len(list))
+	result := make([]string, 0, len(list))
+	for _, item := range list {
+		tag, ok := item.(string)
+		if !ok {
+			continue
+		}
+		normalized := strings.ToLower(strings.TrimSpace(tag))
+		if normalized == "" {
+			continue
+		}
+		if _, exists := seen[normalized]; exists {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		result = append(result, normalized)
+	}
+	return result
+}

--- a/internal/core/tree/tree_service.go
+++ b/internal/core/tree/tree_service.go
@@ -658,7 +658,7 @@ func (t *TreeService) DeleteNode(userID string, id string, recursive bool, expec
 // When preserveFrontmatter is true the content is treated as raw markdown with
 // embedded frontmatter (UpsertContentPreservingFrontmatter).
 // When both are absent, content is a plain body update (UpsertContent).
-func (t *TreeService) UpdateNode(userID string, id string, title string, slug string, content *string, expectedVersion string, tags []string, properties map[string]string, preserveFrontmatter bool) error {
+func (t *TreeService) UpdateNode(userID string, id string, title string, slug string, content *string, expectedVersion string, tags []string, properties map[string]MetadataValue, preserveFrontmatter bool) error {
 	return t.withLockedTree(func() error {
 		if t.tree == nil {
 			return ErrTreeNotLoaded
@@ -964,7 +964,8 @@ func (t *TreeService) GetPages(ids []string) ([]*Page, []error) {
 			if err != nil {
 				errs[tk.index] = fmt.Errorf("could not get page content: %w", err)
 			} else {
-				pages[tk.index] = &Page{PageNode: tk.node, Content: content, RawContent: raw}
+				tags, props := ParseFrontmatterMetadata(raw)
+				pages[tk.index] = &Page{PageNode: tk.node, Content: content, RawContent: raw, Tags: tags, Properties: props}
 			}
 			mu.Unlock()
 		}(tk)
@@ -994,10 +995,13 @@ func (t *TreeService) GetPage(id string) (*Page, error) {
 		return nil, fmt.Errorf("could not get page content: %w", err)
 	}
 
+	tags, props := ParseFrontmatterMetadata(raw)
 	return &Page{
 		PageNode:   page,
 		Content:    content,
 		RawContent: raw,
+		Tags:       tags,
+		Properties: props,
 	}, nil
 }
 

--- a/internal/http/dto/page.go
+++ b/internal/http/dto/page.go
@@ -38,32 +38,39 @@ type Node struct {
 // Page is the HTTP representation of a full page (node + content).
 type Page struct {
 	*Node
-	Content    string            `json:"content"`
-	Path       string            `json:"path"`
-	Tags       []string          `json:"tags"`
-	Properties map[string]string `json:"properties"`
+	Content    string                        `json:"content"`
+	Tags       []string                      `json:"tags"`
+	Properties map[string]tree.MetadataValue `json:"properties"`
 }
 
 // ToAPIPage converts a tree.Page to its HTTP representation.
 func ToAPIPage(p *tree.Page, userResolver *auth.UserResolver) *Page {
-	return &Page{
-		Node:       ToAPINode(p.PageNode, "", userResolver),
-		Content:    p.Content,
-		Path:       BuildPathFromNode(p.PageNode),
-		Tags:       []string{},
-		Properties: map[string]string{},
+	node := ToAPINode(p.PageNode, "", userResolver)
+	node.Path = BuildPathFromNode(p.PageNode)
+	tags := p.Tags
+	if tags == nil {
+		tags = []string{}
 	}
+	props := p.Properties
+	if props == nil {
+		props = map[string]tree.MetadataValue{}
+	}
+	return &Page{Node: node, Content: p.Content, Tags: tags, Properties: props}
 }
 
 // ToAPIPageWithDepth converts a tree.Page with a depth-limited node tree.
 func ToAPIPageWithDepth(p *tree.Page, userResolver *auth.UserResolver, depth int) *Page {
-	return &Page{
-		Node:       ToAPINodeWithDepth(p.PageNode, "", userResolver, depth),
-		Content:    p.Content,
-		Path:       BuildPathFromNode(p.PageNode),
-		Tags:       []string{},
-		Properties: map[string]string{},
+	node := ToAPINodeWithDepth(p.PageNode, "", userResolver, depth)
+	node.Path = BuildPathFromNode(p.PageNode)
+	tags := p.Tags
+	if tags == nil {
+		tags = []string{}
 	}
+	props := p.Properties
+	if props == nil {
+		props = map[string]tree.MetadataValue{}
+	}
+	return &Page{Node: node, Content: p.Content, Tags: tags, Properties: props}
 }
 
 // BuildPathFromNode builds the slash-separated path string from a node.

--- a/internal/http/router_test.go
+++ b/internal/http/router_test.go
@@ -1719,9 +1719,9 @@ func TestUpdatePageEndpoint_WritesTagsAndStringProperties(t *testing.T) {
 		"slug":    "updated-title",
 		"content": "# Updated Content",
 		"tags":    []string{"React", "TypeScript"},
-		"properties": map[string]string{
-			"status": "published",
-			"author": "alice",
+		"properties": map[string]interface{}{
+			"status": map[string]interface{}{"type": "text", "value": "published"},
+			"author": map[string]interface{}{"type": "text", "value": "alice"},
 		},
 	}
 	body, _ := json.Marshal(payload)
@@ -1747,11 +1747,13 @@ func TestUpdatePageEndpoint_WritesTagsAndStringProperties(t *testing.T) {
 	if fetched.Tags[0] != "react" || fetched.Tags[1] != "typescript" {
 		t.Fatalf("expected lowercase normalized tags, got %#v", fetched.Tags)
 	}
-	if fetched.Properties["status"] != "published" {
-		t.Fatalf("expected status=published, got %#v", fetched.Properties)
+	statusMV, _ := fetched.Properties["status"].(map[string]interface{})
+	if statusMV["value"] != "published" {
+		t.Fatalf("expected status.value=published, got %#v", fetched.Properties["status"])
 	}
-	if fetched.Properties["author"] != "alice" {
-		t.Fatalf("expected author=alice, got %#v", fetched.Properties)
+	authorMV, _ := fetched.Properties["author"].(map[string]interface{})
+	if authorMV["value"] != "alice" {
+		t.Fatalf("expected author.value=alice, got %#v", fetched.Properties["author"])
 	}
 }
 
@@ -2423,8 +2425,8 @@ func TestUpdatePage_InvalidProperties(t *testing.T) {
 		"title":   "Updated Title",
 		"slug":    "updated-title",
 		"content": "Updated content",
-		"properties": map[string]string{
-			"leafwiki_hidden": "forbidden",
+		"properties": map[string]interface{}{
+			"leafwiki_hidden": map[string]interface{}{"type": "text", "value": "forbidden"},
 		},
 	}
 	body, _ := json.Marshal(payload)
@@ -2511,19 +2513,26 @@ Body
 		t.Fatalf("Expected tags in response, got %#v", resp["tags"])
 	}
 
-	// Only string scalar properties are returned; numbers, booleans, and lists are excluded.
+	// All typed properties are returned, including numbers, booleans, and lists.
 	propertiesValue, ok := resp["properties"].(map[string]interface{})
 	if !ok {
 		t.Fatalf("Expected properties map in response, got %#v", resp["properties"])
 	}
-	if _, exists := propertiesValue["priority"]; exists {
-		t.Fatalf("Numeric property must not be returned, got %#v", propertiesValue)
+	priorityMV, _ := propertiesValue["priority"].(map[string]interface{})
+	if priorityMV["type"] != "number" || priorityMV["value"] != "2" {
+		t.Fatalf("Expected priority={type:number,value:2}, got %#v", propertiesValue["priority"])
 	}
-	if _, exists := propertiesValue["published"]; exists {
-		t.Fatalf("Boolean property must not be returned, got %#v", propertiesValue)
+	publishedMV, _ := propertiesValue["published"].(map[string]interface{})
+	if publishedMV["type"] != "boolean" || publishedMV["value"] != "true" {
+		t.Fatalf("Expected published={type:boolean,value:true}, got %#v", propertiesValue["published"])
 	}
-	if _, exists := propertiesValue["owners"]; exists {
-		t.Fatalf("List property must not be returned, got %#v", propertiesValue)
+	ownersMV, _ := propertiesValue["owners"].(map[string]interface{})
+	if ownersMV["type"] != "list" {
+		t.Fatalf("Expected owners to have type=list, got %#v", propertiesValue["owners"])
+	}
+	ownerItems, _ := ownersMV["items"].([]interface{})
+	if len(ownerItems) != 2 {
+		t.Fatalf("Expected 2 owners items, got %#v", ownersMV["items"])
 	}
 }
 

--- a/internal/importer/importer_integration_test.go
+++ b/internal/importer/importer_integration_test.go
@@ -205,8 +205,9 @@ func TestImporterService_ExecuteCurrentPlan_IndexesTagsAndPropertiesImmediately(
 	if err != nil {
 		t.Fatalf("GetAllPropertyKeys err: %v", err)
 	}
-	if len(keys) != 2 {
-		t.Fatalf("expected 2 indexed string properties, got %#v", keys)
+	// Indexed keys: status, owner, priority (number), owners.0 (list element)
+	if len(keys) != 4 {
+		t.Fatalf("expected 4 indexed properties, got %#v", keys)
 	}
 
 	statusPageIDs, err := propsStore.GetPageIDsByProperty("status", "published")
@@ -225,12 +226,13 @@ func TestImporterService_ExecuteCurrentPlan_IndexesTagsAndPropertiesImmediately(
 		t.Fatalf("expected owner property to be indexed for one page, got %v", ownerPageIDs)
 	}
 
+	// Numeric properties are now indexed too.
 	priorityPageIDs, err := propsStore.GetPageIDsByProperty("priority", "3")
 	if err != nil {
 		t.Fatalf("GetPageIDsByProperty(priority) err: %v", err)
 	}
-	if len(priorityPageIDs) != 0 {
-		t.Fatalf("expected numeric property to be skipped, got %v", priorityPageIDs)
+	if len(priorityPageIDs) != 1 {
+		t.Fatalf("expected numeric priority property to be indexed, got %v", priorityPageIDs)
 	}
 }
 

--- a/internal/properties/properties_service.go
+++ b/internal/properties/properties_service.go
@@ -1,7 +1,10 @@
 package properties
 
 import (
+	"fmt"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/perber/wiki/internal/core/markdown"
 )
@@ -84,10 +87,32 @@ func extractFlatEntryDepth(prefix string, value interface{}, result map[string]P
 	switch v := value.(type) {
 	case string:
 		if _, exists := result[prefix]; !exists {
-			entry, ok := toPropertyEntry(v)
-			if ok {
+			if entry, ok := scalarToPropertyEntry(v); ok {
 				result[prefix] = entry
 			}
+		}
+	case int:
+		result[prefix] = PropertyEntry{Value: strconv.Itoa(v), Type: "number"}
+	case int64:
+		result[prefix] = PropertyEntry{Value: strconv.FormatInt(v, 10), Type: "number"}
+	case float64:
+		result[prefix] = PropertyEntry{Value: strconv.FormatFloat(v, 'f', -1, 64), Type: "number"}
+	case bool:
+		val := "false"
+		if v {
+			val = "true"
+		}
+		result[prefix] = PropertyEntry{Value: val, Type: "boolean"}
+	case time.Time:
+		v = v.UTC()
+		if v.Hour() == 0 && v.Minute() == 0 && v.Second() == 0 && v.Nanosecond() == 0 {
+			result[prefix] = PropertyEntry{Value: v.Format("2006-01-02"), Type: "date"}
+		} else {
+			result[prefix] = PropertyEntry{Value: v.Format(time.RFC3339), Type: "datetime"}
+		}
+	case []interface{}:
+		for i, item := range v {
+			extractFlatEntryDepth(fmt.Sprintf("%s.%d", prefix, i), item, result, depth+1)
 		}
 	case map[string]interface{}:
 		for childKey, childValue := range v {
@@ -95,8 +120,6 @@ func extractFlatEntryDepth(prefix string, value interface{}, result map[string]P
 			if childKey == "" {
 				continue
 			}
-			// Skip child segments that use the system-reserved prefix so that
-			// e.g. {"meta": {"leafwiki_id": "x"}} cannot pollute the index.
 			if strings.HasPrefix(strings.ToLower(childKey), "leafwiki_") {
 				continue
 			}
@@ -105,12 +128,7 @@ func extractFlatEntryDepth(prefix string, value interface{}, result map[string]P
 	}
 }
 
-
-func toPropertyEntry(value interface{}) (PropertyEntry, bool) {
-	s, ok := value.(string)
-	if !ok {
-		return PropertyEntry{}, false
-	}
+func scalarToPropertyEntry(s string) (PropertyEntry, bool) {
 	s = strings.TrimSpace(s)
 	if s == "" || strings.ContainsRune(s, '\n') {
 		return PropertyEntry{}, false

--- a/internal/properties/properties_service_test.go
+++ b/internal/properties/properties_service_test.go
@@ -29,27 +29,19 @@ func TestExtractPropertiesFromContent_MultipleStringValues(t *testing.T) {
 	assertEntry(t, got, "environment", PropertyEntry{Value: "staging", Type: "text"})
 }
 
-func TestExtractPropertiesFromContent_SkipsNumberValues(t *testing.T) {
+func TestExtractPropertiesFromContent_IndexesNumberValues(t *testing.T) {
 	content := "---\nscore: 42\nrating: 4.5\nstatus: draft\n---\n"
 	got := ExtractPropertiesFromContent(content)
-	if _, ok := got["score"]; ok {
-		t.Error("integer value must not be stored as a property")
-	}
-	if _, ok := got["rating"]; ok {
-		t.Error("float value must not be stored as a property")
-	}
+	assertEntry(t, got, "score", PropertyEntry{Value: "42", Type: "number"})
+	assertEntry(t, got, "rating", PropertyEntry{Value: "4.5", Type: "number"})
 	assertEntry(t, got, "status", PropertyEntry{Value: "draft", Type: "text"})
 }
 
-func TestExtractPropertiesFromContent_SkipsBooleanValues(t *testing.T) {
+func TestExtractPropertiesFromContent_IndexesBooleanValues(t *testing.T) {
 	content := "---\nfeatured: true\narchived: false\nstatus: draft\n---\n"
 	got := ExtractPropertiesFromContent(content)
-	if _, ok := got["featured"]; ok {
-		t.Error("boolean true must not be stored as a property")
-	}
-	if _, ok := got["archived"]; ok {
-		t.Error("boolean false must not be stored as a property")
-	}
+	assertEntry(t, got, "featured", PropertyEntry{Value: "true", Type: "boolean"})
+	assertEntry(t, got, "archived", PropertyEntry{Value: "false", Type: "boolean"})
 	assertEntry(t, got, "status", PropertyEntry{Value: "draft", Type: "text"})
 }
 
@@ -211,12 +203,12 @@ func TestExtractPropertiesFromContent_OnlyReservedKeysReturnsNil(t *testing.T) {
 	}
 }
 
-func TestExtractPropertiesFromContent_OnlyNonStringValuesReturnsNil(t *testing.T) {
+func TestExtractPropertiesFromContent_IndexesNonStringScalars(t *testing.T) {
 	content := "---\nscore: 42\nfeatured: true\nrating: 4.5\n---\n"
 	got := ExtractPropertiesFromContent(content)
-	if got != nil {
-		t.Errorf("expected nil when all values are non-string, got %v", got)
-	}
+	assertEntry(t, got, "score", PropertyEntry{Value: "42", Type: "number"})
+	assertEntry(t, got, "featured", PropertyEntry{Value: "true", Type: "boolean"})
+	assertEntry(t, got, "rating", PropertyEntry{Value: "4.5", Type: "number"})
 }
 
 // ─── Nested map (dot-notation) extraction ────────────────────────────────────
@@ -256,12 +248,10 @@ func TestExtractPropertiesFromContent_MixedFlatAndNestedKeys(t *testing.T) {
 	assertEntry(t, got, "a.b", PropertyEntry{Value: "nested", Type: "text"})
 }
 
-func TestExtractPropertiesFromContent_NestedMapSkipsNonStringLeaves(t *testing.T) {
+func TestExtractPropertiesFromContent_NestedMapIndexesNonStringLeaves(t *testing.T) {
 	content := "---\na:\n  b: 42\n  c: value\n---\n"
 	got := ExtractPropertiesFromContent(content)
-	if _, ok := got["a.b"]; ok {
-		t.Error("nested integer value must not be stored as a property")
-	}
+	assertEntry(t, got, "a.b", PropertyEntry{Value: "42", Type: "number"})
 	assertEntry(t, got, "a.c", PropertyEntry{Value: "value", Type: "text"})
 }
 
@@ -558,6 +548,83 @@ func TestPropertiesService_IndexPageContent_UpdatesExistingEntry(t *testing.T) {
 	if len(old) != 0 {
 		t.Errorf("old value 'draft' should be gone, got %v", old)
 	}
+}
+
+// ─── Typed leaf indexing (number, boolean, date, datetime) ───────────────────
+
+func TestExtractPropertiesFromContent_IndexesNumberLeaf(t *testing.T) {
+	content := "---\ncount: 42\n---\n"
+	got := ExtractPropertiesFromContent(content)
+	assertEntry(t, got, "count", PropertyEntry{Value: "42", Type: "number"})
+}
+
+func TestExtractPropertiesFromContent_IndexesFloatLeaf(t *testing.T) {
+	content := "---\nrating: 4.5\n---\n"
+	got := ExtractPropertiesFromContent(content)
+	assertEntry(t, got, "rating", PropertyEntry{Value: "4.5", Type: "number"})
+}
+
+func TestExtractPropertiesFromContent_IndexesBooleanLeaf(t *testing.T) {
+	content := "---\nfeatured: true\n---\n"
+	got := ExtractPropertiesFromContent(content)
+	assertEntry(t, got, "featured", PropertyEntry{Value: "true", Type: "boolean"})
+}
+
+func TestExtractPropertiesFromContent_IndexesBooleanFalseLeaf(t *testing.T) {
+	content := "---\narchived: false\n---\n"
+	got := ExtractPropertiesFromContent(content)
+	assertEntry(t, got, "archived", PropertyEntry{Value: "false", Type: "boolean"})
+}
+
+func TestExtractPropertiesFromContent_IndexesDateLeaf(t *testing.T) {
+	// Dates in YAML are parsed as time.Time by yaml.v3
+	content := "---\ncreated: 2024-01-15\n---\n"
+	got := ExtractPropertiesFromContent(content)
+	if e, ok := got["created"]; !ok {
+		t.Fatal("expected 'created' in index")
+	} else if e.Type != "date" {
+		t.Errorf("expected type 'date', got %q", e.Type)
+	}
+}
+
+func TestExtractPropertiesFromContent_IndexesDateTimeLeaf(t *testing.T) {
+	content := "---\nupdated: 2024-01-15T12:30:00Z\n---\n"
+	got := ExtractPropertiesFromContent(content)
+	if e, ok := got["updated"]; !ok {
+		t.Fatal("expected 'updated' in index")
+	} else if e.Type != "datetime" {
+		t.Errorf("expected type 'datetime', got %q", e.Type)
+	}
+}
+
+func TestExtractPropertiesFromContent_IndexesNestedObjectLeaf(t *testing.T) {
+	content := "---\nmeta:\n  author: alice\n  count: 5\n---\n"
+	got := ExtractPropertiesFromContent(content)
+	assertEntry(t, got, "meta.author", PropertyEntry{Value: "alice", Type: "text"})
+	assertEntry(t, got, "meta.count", PropertyEntry{Value: "5", Type: "number"})
+}
+
+func TestExtractPropertiesFromContent_IndexesScalarArrayEntries(t *testing.T) {
+	content := "---\nscores:\n  - 10\n  - 20\n---\n"
+	got := ExtractPropertiesFromContent(content)
+	assertEntry(t, got, "scores.0", PropertyEntry{Value: "10", Type: "number"})
+	assertEntry(t, got, "scores.1", PropertyEntry{Value: "20", Type: "number"})
+}
+
+func TestExtractPropertiesFromContent_IndexesNestedArrayObjectLeaves(t *testing.T) {
+	content := "---\nauthors:\n  - name: alice\n    role: editor\n---\n"
+	got := ExtractPropertiesFromContent(content)
+	assertEntry(t, got, "authors.0.name", PropertyEntry{Value: "alice", Type: "text"})
+	assertEntry(t, got, "authors.0.role", PropertyEntry{Value: "editor", Type: "text"})
+}
+
+func TestExtractPropertiesFromContent_SkipsSystemKeysInsideObjects(t *testing.T) {
+	content := "---\nmeta:\n  leafwiki_id: spoofed\n  status: active\n---\n"
+	got := ExtractPropertiesFromContent(content)
+	if _, ok := got["meta.leafwiki_id"]; ok {
+		t.Error("nested leafwiki_ key must not be indexed")
+	}
+	assertEntry(t, got, "meta.status", PropertyEntry{Value: "active", Type: "text"})
 }
 
 // ─── helpers ─────────────────────────────────────────────────────────────────

--- a/internal/properties/properties_store.go
+++ b/internal/properties/properties_store.go
@@ -16,7 +16,7 @@ import (
 // PropertyEntry is a single property value with its type.
 type PropertyEntry struct {
 	Value string
-	Type  string // currently always "text"
+	Type  string
 }
 
 // PropertyKeyCount carries a property key and the number of pages that have it.

--- a/internal/wiki/pages/routes.go
+++ b/internal/wiki/pages/routes.go
@@ -257,12 +257,12 @@ func (r *Routes) handleCreate(c *gin.Context) {
 func (r *Routes) handleUpdate(c *gin.Context) {
 	id := strings.TrimSpace(c.Param("id"))
 	var req struct {
-		Version    string            `json:"version" binding:"required"`
-		Title      string            `json:"title" binding:"required"`
-		Slug       string            `json:"slug" binding:"required"`
-		Content    *string           `json:"content"`
-		Tags       []string          `json:"tags"`
-		Properties map[string]string `json:"properties"`
+		Version    string                       `json:"version" binding:"required"`
+		Title      string                       `json:"title" binding:"required"`
+		Slug       string                       `json:"slug" binding:"required"`
+		Content    *string                      `json:"content"`
+		Tags       []string                     `json:"tags"`
+		Properties map[string]tree.MetadataValue `json:"properties"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		respondWithPageStatusError(c, http.StatusBadRequest, ErrCodePageInvalidRequest, "Invalid request", "invalid request")
@@ -494,112 +494,15 @@ func (r *Routes) handleRefactorApply(c *gin.Context) {
 }
 
 func (r *Routes) respondPage(c *gin.Context, status int, page *tree.Page) {
-	apiPage := dto.ToAPIPage(page, r.userResolver)
-	r.enrichPageMetadata(apiPage)
-	c.JSON(status, apiPage)
+	c.JSON(status, dto.ToAPIPage(page, r.userResolver))
 }
 
 func (r *Routes) respondPageWithDepth(c *gin.Context, status int, page *tree.Page, depth int) {
-	apiPage := dto.ToAPIPageWithDepth(page, r.userResolver, depth)
-	r.enrichPageMetadata(apiPage)
-	c.JSON(status, apiPage)
+	c.JSON(status, dto.ToAPIPageWithDepth(page, r.userResolver, depth))
 }
 
-func (r *Routes) enrichPageMetadata(page *dto.Page) {
-	if page == nil {
-		return
-	}
-
-	page.Tags = []string{}
-	page.Properties = map[string]string{}
-
-	raw, err := r.treeService.ReadPageRaw(page.ID)
-	if err != nil {
-		return
-	}
-
-	fm, _, has, err := markdown.ParseFrontmatter(raw)
-	if err != nil || !has || len(fm.ExtraFields) == 0 {
-		return
-	}
-
-	tags, properties := extractPageMetadata(fm.ExtraFields)
-	page.Tags = tags
-	page.Properties = properties
-}
-
-func extractPageMetadata(fields map[string]interface{}) ([]string, map[string]string) {
-	tags := []string{}
-	properties := map[string]string{}
-
-	for rawKey, value := range fields {
-		key := strings.TrimSpace(rawKey)
-		lower := strings.ToLower(key)
-
-		if lower == "tags" {
-			tags = normalizeMetadataTags(value)
-			continue
-		}
-		if markdown.IsSystemKey(key) {
-			continue
-		}
-
-		flattenMetadataEntry(key, value, properties)
-	}
-
-	return tags, properties
-}
-
-// flattenMetadataEntry recursively flattens nested YAML maps into dot-notation
-// keys (e.g. {"a": {"b": "v"}} → properties["a.b"] = "v").
-func flattenMetadataEntry(prefix string, value interface{}, properties map[string]string) {
-	flattenMetadataEntryDepth(prefix, value, properties, 0)
-}
-
-func flattenMetadataEntryDepth(prefix string, value interface{}, properties map[string]string, depth int) {
-	if depth >= maxFlattenDepth {
-		return
-	}
-	switch v := value.(type) {
-	case string:
-		s := strings.TrimSpace(v)
-		if s != "" && !strings.ContainsRune(s, '\n') {
-			if _, exists := properties[prefix]; !exists {
-				properties[prefix] = s
-			}
-		}
-	case map[string]interface{}:
-		for childKey, childValue := range v {
-			childKey = strings.TrimSpace(childKey)
-			if childKey == "" {
-				continue
-			}
-			if strings.HasPrefix(strings.ToLower(childKey), "leafwiki_") {
-				continue
-			}
-			flattenMetadataEntryDepth(prefix+"."+childKey, childValue, properties, depth+1)
-		}
-	}
-}
-
-const maxFlattenDepth = 20
-
-func normalizeMetadataTags(value interface{}) []string {
-	list, ok := value.([]interface{})
-	if !ok {
-		return []string{}
-	}
-
-	rawTags := make([]string, 0, len(list))
-	for _, item := range list {
-		tag, ok := item.(string)
-		if !ok {
-			continue
-		}
-		rawTags = append(rawTags, tag)
-	}
-
-	return normalizeTagInputs(rawTags)
+func extractPageMetadata(fields map[string]interface{}) ([]string, map[string]tree.MetadataValue) {
+	return tree.ParseFrontmatterFields(fields)
 }
 
 func normalizeTagInputs(tags []string) []string {
@@ -621,7 +524,7 @@ func normalizeTagInputs(tags []string) []string {
 	return result
 }
 
-func validatePageMetadataInput(tags []string, properties map[string]string) error {
+func validatePageMetadataInput(tags []string, properties map[string]tree.MetadataValue) error {
 	ve := sharederrors.NewValidationErrors()
 	seenTags := map[string]struct{}{}
 
@@ -644,17 +547,24 @@ func validatePageMetadataInput(tags []string, properties map[string]string) erro
 		seenTags[key] = struct{}{}
 	}
 
-	for rawKey := range properties {
+	for rawKey, value := range properties {
 		key := strings.TrimSpace(rawKey)
 		field := "properties." + rawKey
 		switch {
 		case key == "":
 			ve.Add(field, "Property key must not be empty")
+			continue
 		case key != rawKey:
 			ve.Add(field, "Property key must not contain leading or trailing whitespace")
+			continue
+		case strings.ToLower(key) == "tags":
+			ve.Add(field, "Property key is reserved")
+			continue
 		case markdown.IsSystemKey(key):
 			ve.Add(field, "Property key is reserved")
+			continue
 		}
+		validateMetadataValue(field, value, ve)
 	}
 
 	if ve.HasErrors() {
@@ -662,6 +572,62 @@ func validatePageMetadataInput(tags []string, properties map[string]string) erro
 	}
 
 	return nil
+}
+
+func validateMetadataValue(field string, v tree.MetadataValue, ve *sharederrors.ValidationErrors) {
+	if !tree.IsValidMetadataType(v.Type) {
+		ve.Add(field, "Invalid property type: "+v.Type)
+		return
+	}
+
+	hasValue := v.Value != ""
+	hasItems := len(v.Items) > 0
+	hasFields := len(v.Fields) > 0
+
+	switch v.Type {
+	case tree.MetadataTypeList:
+		if v.Items == nil {
+			ve.Add(field, "List property must have items")
+			return
+		}
+		if hasFields {
+			ve.Add(field, "List property must not have fields")
+			return
+		}
+		if hasValue {
+			ve.Add(field, "List property must not have a scalar value")
+			return
+		}
+		for i, item := range v.Items {
+			validateMetadataValue(field+"["+strconv.Itoa(i)+"]", item, ve)
+		}
+
+	case tree.MetadataTypeObject:
+		if v.Fields == nil {
+			ve.Add(field, "Object property must have fields")
+			return
+		}
+		if hasItems {
+			ve.Add(field, "Object property must not have items")
+			return
+		}
+		if hasValue {
+			ve.Add(field, "Object property must not have a scalar value")
+			return
+		}
+		for k, fv := range v.Fields {
+			validateMetadataValue(field+"."+k, fv, ve)
+		}
+
+	default:
+		// Scalar types: must not mix with items or fields.
+		if hasItems {
+			ve.Add(field, "Scalar property must not have items")
+		}
+		if hasFields {
+			ve.Add(field, "Scalar property must not have fields")
+		}
+	}
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────

--- a/internal/wiki/pages/routes_flatten_test.go
+++ b/internal/wiki/pages/routes_flatten_test.go
@@ -2,144 +2,180 @@ package pages
 
 import (
 	"testing"
+
+	"github.com/perber/wiki/internal/core/tree"
 )
-
-func TestFlattenMetadataEntry_FlatString(t *testing.T) {
-	result := map[string]string{}
-	flattenMetadataEntry("key", "value", result)
-	if result["key"] != "value" {
-		t.Errorf("expected result[key] = value, got %q", result["key"])
-	}
-}
-
-func TestFlattenMetadataEntry_NestedOneLevel(t *testing.T) {
-	result := map[string]string{}
-	flattenMetadataEntry("a", map[string]interface{}{"b": "val"}, result)
-	if result["a.b"] != "val" {
-		t.Errorf("expected result[a.b] = val, got %q", result["a.b"])
-	}
-}
-
-func TestFlattenMetadataEntry_NestedTwoLevels(t *testing.T) {
-	result := map[string]string{}
-	flattenMetadataEntry("a", map[string]interface{}{
-		"b": map[string]interface{}{"c": "deep"},
-	}, result)
-	if result["a.b.c"] != "deep" {
-		t.Errorf("expected result[a.b.c] = deep, got %q", result["a.b.c"])
-	}
-}
-
-func TestFlattenMetadataEntry_SkipsEmptyStringValue(t *testing.T) {
-	result := map[string]string{}
-	flattenMetadataEntry("key", "", result)
-	if _, ok := result["key"]; ok {
-		t.Error("expected empty string to be skipped")
-	}
-}
-
-func TestFlattenMetadataEntry_SkipsWhitespaceOnlyValue(t *testing.T) {
-	result := map[string]string{}
-	flattenMetadataEntry("key", "   ", result)
-	if _, ok := result["key"]; ok {
-		t.Error("expected whitespace-only string to be skipped")
-	}
-}
-
-func TestFlattenMetadataEntry_SkipsValueWithNewline(t *testing.T) {
-	result := map[string]string{}
-	flattenMetadataEntry("key", "line1\nline2", result)
-	if _, ok := result["key"]; ok {
-		t.Error("expected multiline string to be skipped")
-	}
-}
-
-func TestFlattenMetadataEntry_SkipsNonStringLeaf(t *testing.T) {
-	result := map[string]string{}
-	flattenMetadataEntry("key", 42, result)
-	if _, ok := result["key"]; ok {
-		t.Error("expected non-string leaf to be skipped")
-	}
-}
-
-func TestFlattenMetadataEntry_SkipsLeafwikiChildSegment(t *testing.T) {
-	result := map[string]string{}
-	flattenMetadataEntry("meta", map[string]interface{}{
-		"leafwiki_id": "secret",
-		"visible":     "yes",
-	}, result)
-	if _, ok := result["meta.leafwiki_id"]; ok {
-		t.Error("expected leafwiki_ child segment to be skipped")
-	}
-	if result["meta.visible"] != "yes" {
-		t.Errorf("expected meta.visible = yes, got %q", result["meta.visible"])
-	}
-}
-
-func TestFlattenMetadataEntry_SkipsEmptyChildKey(t *testing.T) {
-	result := map[string]string{}
-	flattenMetadataEntry("a", map[string]interface{}{
-		"":  "empty-key-value",
-		"b": "ok",
-	}, result)
-	if _, ok := result["a."]; ok {
-		t.Error("expected empty child key to be skipped")
-	}
-	if result["a.b"] != "ok" {
-		t.Errorf("expected a.b = ok, got %q", result["a.b"])
-	}
-}
 
 // ─── extractPageMetadata ─────────────────────────────────────────────────────
 
-func TestExtractPageMetadata_SkipsTagsAlways(t *testing.T) {
+func TestExtractPageMetadata_ReturnsTypedScalarProperties(t *testing.T) {
 	fields := map[string]interface{}{
-		"tags":   []interface{}{"go", "react"},
 		"status": "draft",
+		"count":  42,
+		"active": true,
+	}
+	_, props := extractPageMetadata(fields)
+
+	if props["status"].Type != tree.MetadataTypeText || props["status"].Value != "draft" {
+		t.Errorf("status wrong: %+v", props["status"])
+	}
+	if props["count"].Type != tree.MetadataTypeNumber || props["count"].Value != "42" {
+		t.Errorf("count wrong: %+v", props["count"])
+	}
+	if props["active"].Type != tree.MetadataTypeBoolean || props["active"].Value != "true" {
+		t.Errorf("active wrong: %+v", props["active"])
+	}
+}
+
+func TestExtractPageMetadata_ReturnsNestedObjectTree(t *testing.T) {
+	fields := map[string]interface{}{
+		"meta": map[string]interface{}{
+			"author": "alice",
+		},
+	}
+	_, props := extractPageMetadata(fields)
+
+	mv, ok := props["meta"]
+	if !ok {
+		t.Fatal("expected 'meta' in properties")
+	}
+	if mv.Type != tree.MetadataTypeObject {
+		t.Errorf("expected object type, got %q", mv.Type)
+	}
+	if mv.Fields["author"].Value != "alice" {
+		t.Errorf("expected author=alice, got %+v", mv.Fields["author"])
+	}
+}
+
+func TestExtractPageMetadata_ReturnsMixedListTree(t *testing.T) {
+	fields := map[string]interface{}{
+		"items": []interface{}{"a", 1},
+	}
+	_, props := extractPageMetadata(fields)
+
+	mv, ok := props["items"]
+	if !ok {
+		t.Fatal("expected 'items' in properties")
+	}
+	if mv.Type != tree.MetadataTypeList {
+		t.Errorf("expected list type, got %q", mv.Type)
+	}
+	if len(mv.Items) != 2 {
+		t.Errorf("expected 2 items, got %d", len(mv.Items))
+	}
+}
+
+func TestExtractPageMetadata_SkipsTagsAndSystemKeys(t *testing.T) {
+	fields := map[string]interface{}{
+		"tags":        []interface{}{"go", "react"},
+		"leafwiki_id": "abc",
+		"status":      "draft",
 	}
 	tags, props := extractPageMetadata(fields)
+
 	if len(tags) != 2 {
 		t.Errorf("expected 2 tags, got %v", tags)
 	}
 	if _, ok := props["tags"]; ok {
 		t.Error("tags must not appear in properties")
 	}
-	if props["status"] != "draft" {
-		t.Errorf("expected status=draft, got %q", props["status"])
+	if _, ok := props["leafwiki_id"]; ok {
+		t.Error("leafwiki_ key must not appear in properties")
+	}
+	if props["status"].Value != "draft" {
+		t.Errorf("expected status=draft, got %+v", props["status"])
 	}
 }
 
-func TestExtractPageMetadata_TitleInExtraFieldsIsAlwaysCustomProperty(t *testing.T) {
-	// "title" always lands in ExtraFields and is always treated as a custom
-	// property by extractPageMetadata.
+func TestExtractPageMetadata_TitleInExtraFieldsIsCustomProperty(t *testing.T) {
 	fields := map[string]interface{}{
 		"title":  "My Custom Title",
 		"status": "draft",
 	}
 	_, props := extractPageMetadata(fields)
-	if props["title"] != "My Custom Title" {
-		t.Errorf("title in ExtraFields must appear in properties, got %q", props["title"])
+	if props["title"].Value != "My Custom Title" {
+		t.Errorf("title must appear in properties, got %+v", props["title"])
 	}
 }
 
-func TestExtractPageMetadata_SkipsLeafwikiPrefixAlways(t *testing.T) {
-	fields := map[string]interface{}{
-		"leafwiki_id": "abc",
-		"status":      "draft",
+// ─── validatePageMetadataInput ───────────────────────────────────────────────
+
+func TestValidatePageMetadataInput_RejectsReservedRootKey(t *testing.T) {
+	props := map[string]tree.MetadataValue{
+		"tags": {Type: tree.MetadataTypeText, Value: "x"},
 	}
-	_, props := extractPageMetadata(fields)
-	if _, ok := props["leafwiki_id"]; ok {
-		t.Error("leafwiki_ keys must never appear in properties")
+	err := validatePageMetadataInput(nil, props)
+	if err == nil {
+		t.Fatal("expected validation error for reserved key 'tags'")
 	}
 }
 
-func TestFlattenMetadataEntry_DepthLimitDoesNotPanic(t *testing.T) {
-	// Build a map nested maxFlattenDepth+5 levels deep
-	inner := map[string]interface{}{"leaf": "value"}
-	for i := 0; i < maxFlattenDepth+5; i++ {
-		inner = map[string]interface{}{"child": inner}
+func TestValidatePageMetadataInput_RejectsLeafwikiKey(t *testing.T) {
+	props := map[string]tree.MetadataValue{
+		"leafwiki_id": {Type: tree.MetadataTypeText, Value: "x"},
 	}
-	result := map[string]string{}
-	// Must not panic; depth guard terminates recursion before stack overflow
-	flattenMetadataEntry("root", inner, result)
+	err := validatePageMetadataInput(nil, props)
+	if err == nil {
+		t.Fatal("expected validation error for leafwiki_ key")
+	}
+}
+
+func TestValidatePageMetadataInput_RejectsUnknownType(t *testing.T) {
+	props := map[string]tree.MetadataValue{
+		"status": {Type: "unknown-type", Value: "x"},
+	}
+	err := validatePageMetadataInput(nil, props)
+	if err == nil {
+		t.Fatal("expected validation error for unknown type")
+	}
+}
+
+func TestValidatePageMetadataInput_RejectsListWithoutItems(t *testing.T) {
+	props := map[string]tree.MetadataValue{
+		"items": {Type: tree.MetadataTypeList, Items: nil},
+	}
+	err := validatePageMetadataInput(nil, props)
+	if err == nil {
+		t.Fatal("expected validation error for list without items")
+	}
+}
+
+func TestValidatePageMetadataInput_RejectsObjectWithoutFields(t *testing.T) {
+	props := map[string]tree.MetadataValue{
+		"meta": {Type: tree.MetadataTypeObject, Fields: nil},
+	}
+	err := validatePageMetadataInput(nil, props)
+	if err == nil {
+		t.Fatal("expected validation error for object without fields")
+	}
+}
+
+func TestValidatePageMetadataInput_RejectsScalarWithItems(t *testing.T) {
+	props := map[string]tree.MetadataValue{
+		"x": {
+			Type:  tree.MetadataTypeText,
+			Value: "hi",
+			Items: []tree.MetadataValue{{Type: tree.MetadataTypeText, Value: "a"}},
+		},
+	}
+	err := validatePageMetadataInput(nil, props)
+	if err == nil {
+		t.Fatal("expected validation error for scalar with items")
+	}
+}
+
+func TestValidatePageMetadataInput_AcceptsValidTypedProperties(t *testing.T) {
+	props := map[string]tree.MetadataValue{
+		"text":   {Type: tree.MetadataTypeText, Value: "hello"},
+		"num":    {Type: tree.MetadataTypeNumber, Value: "42"},
+		"flag":   {Type: tree.MetadataTypeBoolean, Value: "true"},
+		"dt":     {Type: tree.MetadataTypeDate, Value: "2024-01-15"},
+		"ts":     {Type: tree.MetadataTypeDatetime, Value: "2024-01-15T12:00:00Z"},
+		"nil":    {Type: tree.MetadataTypeNull},
+		"list":   {Type: tree.MetadataTypeList, Items: []tree.MetadataValue{{Type: tree.MetadataTypeText, Value: "a"}}},
+		"object": {Type: tree.MetadataTypeObject, Fields: map[string]tree.MetadataValue{"k": {Type: tree.MetadataTypeText, Value: "v"}}},
+	}
+	if err := validatePageMetadataInput(nil, props); err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
 }

--- a/internal/wiki/pages/update_page.go
+++ b/internal/wiki/pages/update_page.go
@@ -19,7 +19,7 @@ type UpdatePageInput struct {
 	Content             *string
 	Kind                *tree.NodeKind
 	Tags                []string
-	Properties          map[string]string
+	Properties          map[string]tree.MetadataValue
 	PreserveFrontmatter bool
 }
 

--- a/plans/nested-property-search.md
+++ b/plans/nested-property-search.md
@@ -1,0 +1,103 @@
+# Plan: Nested / Range Property Search
+
+## Status: Bereit zur Umsetzung (post v0.11.0)
+
+## Problem-Analyse
+
+Drei Lücken mit unterschiedlichen Lösungsansätzen:
+
+| Use Case          | Beispiel                    | Status              |
+|-------------------|-----------------------------|---------------------|
+| Scalar Exact-Match | `status = published`       | ✅ vorhanden        |
+| List-Containment  | `owners enthält alice`      | ❌ fehlt            |
+| Range-Query       | `priority > 5`              | ❌ fehlt            |
+| Object-Field      | `meta.author = alice`       | ✅ via Dot-Notation |
+
+## Schritt 1 — Schema-Erweiterung: `list_key`-Spalte
+
+Beim Indexieren von Listen wird ein zusätzlicher Eintrag ohne Index-Suffix geschrieben.
+PRIMARY KEY bleibt auf `(page_id, key)`, kein Konflikt. `list_key` ist nullable.
+
+```
+key=owners.0, value=alice, type=text, list_key=owners
+key=owners.1, value=bob,   type=text, list_key=owners
+```
+
+Migration: `ALTER TABLE page_properties ADD COLUMN list_key TEXT`
+Index: `CREATE INDEX idx_page_properties_list_key_value ON page_properties(list_key, value)`
+
+Query für Containment:
+```sql
+SELECT DISTINCT page_id FROM page_properties
+WHERE list_key = ? AND value = ?
+```
+
+## Schritt 2 — Schema-Erweiterung: `numeric_value`-Spalte
+
+Für Range-Queries wird der numerische Wert in einer eigenen REAL-Spalte gespeichert.
+
+```
+key=priority, value="42", type=number, numeric_value=42.0
+```
+
+Migration: `ALTER TABLE page_properties ADD COLUMN numeric_value REAL`
+Index: `CREATE INDEX idx_page_properties_key_numeric ON page_properties(key, numeric_value)`
+
+Query für Range:
+```sql
+SELECT page_id FROM page_properties
+WHERE key = ? AND numeric_value > ?
+```
+
+## Schritt 3 — Neue Store-Methoden
+
+```go
+// List-Containment: "owners enthält alice"
+GetPageIDsByPropertyContains(listKey, value string) ([]string, error)
+
+// Range: "priority > 5"  — op: "gt", "gte", "lt", "lte", "eq"
+GetPageIDsByPropertyRange(key string, op string, threshold float64) ([]string, error)
+```
+
+## Schritt 4 — Service-Layer: PropertyFilter
+
+```go
+type PropertyFilter struct {
+    Key      string
+    Operator string  // "eq", "contains", "gt", "gte", "lt", "lte"
+    Value    string
+}
+
+func (s *PropertiesService) FilterPages(filters []PropertyFilter) ([]string, error)
+```
+
+Mehrere Filter werden per INTERSECT oder in Go verknüpft (AND-Semantik).
+
+## Schritt 5 — Index-Schreiblogik anpassen
+
+In `extractFlatEntryDepth` (properties_service.go):
+- Bei `[]interface{}`: `list_key = parent-prefix` in PropertyEntry setzen
+- Bei `float64`/`int`: `numeric_value` in PropertyEntry füllen
+- `PropertyEntry.Type`-Kommentar `// currently always "text"` entfernen
+
+`PropertyEntry` wird um zwei optionale Felder erweitert:
+```go
+type PropertyEntry struct {
+    Value        string
+    Type         string
+    ListKey      string   // gesetzt wenn dieser Eintrag ein Listen-Element ist
+    NumericValue *float64 // gesetzt für type=number
+}
+```
+
+## Schritt 6 — HTTP-API (separater Schritt, nach Bedarf)
+
+```
+GET /api/pages?filter[owners][contains]=alice&filter[priority][gt]=5
+```
+
+## Nicht im Scope
+
+- Object-Containment (`meta` enthält irgendwo Wert `alice`) — kein realer Use Case, weglassen.
+- Full-Text-Search auf Property-Values — dafür gibt es den Search-Index.
+- OR-Verknüpfung mehrerer Filter — erstmal nur AND.


### PR DESCRIPTION
Replaces the flat map[string]string properties with a recursive MetadataValue type (text, number, boolean, date, datetime, null, list, object) that round-trips through YAML frontmatter without data loss.

- New MetadataValue struct with YAML↔typed conversion in core/tree
- UpsertContentAndMetadata and UpdateNode accept map[string]MetadataValue; the editor now owns all non-system properties (absent keys are dropped)
- Properties index now indexes numbers, booleans, dates and list elements (dot notation: owners.0, owners.1) for richer filter/search
- Tags and Properties promoted to first-class fields on tree.Page, populated at load time — eliminates the extra ReadPageRaw call per GET
- enrichPageMetadata removed; dto mapping reads directly from page fields
- Path shadowing in dto.Page fixed; RFC3339 dead-code loop removed
- Plan for nested/range property search added to plans/