### PR TITLE
fix(auth): restore deep link after login

### DIFF
--- a/ui/leafwiki-ui/src/features/auth/AuthRedirect.test.tsx
+++ b/ui/leafwiki-ui/src/features/auth/AuthRedirect.test.tsx
@@ -1,0 +1,124 @@
+import '@/lib/i18n'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import LoginForm from './LoginForm'
+import RequireAuth from './RequireAuth'
+import { useConfigStore } from '@/stores/config'
+import { useSessionStore } from '@/stores/session'
+
+const loginMock = vi.fn()
+
+vi.mock('@/lib/api/auth', () => ({
+  login: (...args: unknown[]) => loginMock(...args),
+}))
+
+function LocationProbe() {
+  const location = useLocation()
+  const redirectTo =
+    typeof location.state === 'object' &&
+    location.state !== null &&
+    'redirectTo' in location.state
+      ? String((location.state as { redirectTo?: unknown }).redirectTo ?? '')
+      : ''
+
+  return (
+    <>
+      <div data-testid="pathname">{location.pathname}</div>
+      <div data-testid="redirect-to">{redirectTo}</div>
+    </>
+  )
+}
+
+describe('Auth redirect flow', () => {
+  beforeEach(() => {
+    loginMock.mockReset()
+    useConfigStore.setState({
+      authDisabled: false,
+      httpRemoteUserEnabled: false,
+    })
+    useSessionStore.setState({
+      user: null,
+      isRefreshing: false,
+      accessTokenExpiresAt: null,
+    })
+  })
+
+  it('preserves the requested path when redirecting to login', async () => {
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: '/home-lab/services-ip-addresses',
+            search: '?tab=ports',
+            hash: '#ssh',
+          },
+        ]}
+      >
+        <Routes>
+          <Route path="/login" element={<LocationProbe />} />
+          <Route
+            path="*"
+            element={
+              <RequireAuth>
+                <div>Protected page</div>
+              </RequireAuth>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pathname')).toHaveTextContent('/login')
+    })
+    expect(screen.getByTestId('redirect-to')).toHaveTextContent(
+      '/home-lab/services-ip-addresses?tab=ports#ssh',
+    )
+  })
+
+  it('returns to the requested page after successful login', async () => {
+    loginMock.mockResolvedValue({
+      accessTokenExpiresAt: 1234567890,
+      message: 'ok',
+      user: {
+        id: 'user-1',
+        username: 'admin',
+        email: 'admin@example.com',
+        role: 'admin',
+      },
+    })
+
+    const user = userEvent.setup()
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: '/login',
+            state: {
+              redirectTo: '/home-lab/services-ip-addresses?tab=ports#ssh',
+            },
+          },
+        ]}
+      >
+        <Routes>
+          <Route path="/login" element={<LoginForm />} />
+          <Route path="/" element={<div>Home page</div>} />
+          <Route
+            path="/home-lab/services-ip-addresses"
+            element={<div>Requested page</div>}
+          />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await user.type(screen.getByTestId('login-identifier'), 'admin')
+    await user.type(screen.getByTestId('login-password'), 'admin')
+    await user.click(screen.getByTestId('login-submit'))
+
+    await screen.findByText('Requested page')
+    expect(loginMock).toHaveBeenCalledWith('admin', 'admin')
+  })
+})

--- a/ui/leafwiki-ui/src/features/auth/LoginForm.tsx
+++ b/ui/leafwiki-ui/src/features/auth/LoginForm.tsx
@@ -7,8 +7,29 @@ import { useBrandingStore } from '@/stores/branding'
 import { useSessionStore } from '@/stores/session'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Navigate, useNavigate } from 'react-router-dom'
+import { Navigate, useLocation, useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
+
+function getRedirectTo(state: unknown): string | null {
+  if (!state || typeof state !== 'object') {
+    return null
+  }
+
+  const redirectTo = (state as { redirectTo?: unknown }).redirectTo
+  if (typeof redirectTo !== 'string' || !redirectTo.startsWith('/')) {
+    return null
+  }
+
+  if (
+    redirectTo === '/login' ||
+    redirectTo.startsWith('/login?') ||
+    redirectTo.startsWith('/login#')
+  ) {
+    return null
+  }
+
+  return redirectTo
+}
 
 export default function LoginForm() {
   const { t } = useTranslation('auth')
@@ -16,13 +37,15 @@ export default function LoginForm() {
   const [password, setPassword] = useState('')
   const [loading, setLoading] = useState(false)
 
+  const location = useLocation()
   const navigate = useNavigate()
   const user = useSessionStore((s) => s.user)
   const { siteName, logoFile, logoVersion } = useBrandingStore()
+  const redirectTo = getRedirectTo(location.state)
 
   // If already logged in, redirect to home
   if (user) {
-    return <Navigate to="/" replace />
+    return <Navigate to={redirectTo || '/'} replace />
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -32,8 +55,8 @@ export default function LoginForm() {
     try {
       // user already set in the store by the login function
       await login(identifier, password)
-      // Redirect to home page after successful login
-      navigate('/')
+      // Restore the originally requested page after successful login.
+      navigate(redirectTo || '/', { replace: true })
     } catch (err) {
       const mapped = mapApiError(err, t('login.errorFallback'))
       toast.error(mapped.message)

--- a/ui/leafwiki-ui/src/features/auth/RequireAuth.tsx
+++ b/ui/leafwiki-ui/src/features/auth/RequireAuth.tsx
@@ -1,7 +1,7 @@
 import { useConfigStore } from '@/stores/config'
 import { useSessionStore } from '@/stores/session'
 import { ReactNode } from 'react'
-import { Navigate } from 'react-router-dom'
+import { Navigate, useLocation } from 'react-router-dom'
 
 type Props = {
   children: ReactNode
@@ -11,11 +11,13 @@ export default function RequireAuth({ children }: Props) {
   const user = useSessionStore((state) => state.user)
   const isRefreshing = useSessionStore((state) => state.isRefreshing)
   const authDisabled = useConfigStore((state) => state.authDisabled)
+  const location = useLocation()
 
   if (authDisabled) return <>{children}</>
 
   if (!user && !isRefreshing) {
-    return <Navigate to="/login" replace />
+    const redirectTo = `${location.pathname}${location.search}${location.hash}`
+    return <Navigate to="/login" replace state={{ redirectTo }} />
   }
 
   if (!user && isRefreshing) {


### PR DESCRIPTION
Preserve the originally requested route when redirecting unauthenticated users to the login page so bookmarked wiki pages open after a successful sign-in.

Add focused auth redirect tests to cover carrying the route into the login flow and returning to it after login.