### PR TITLE
fix(ui): eliminate double-blink when closing add-page dialog

### DIFF
--- a/ui/leafwiki-ui/src/components/DialogManager.tsx
+++ b/ui/leafwiki-ui/src/components/DialogManager.tsx
@@ -30,7 +30,7 @@ export function DialogManager() {
       setRenderProps(null)
     }, 200)
     return () => clearTimeout(timeoutId)
-  }, [dialogType, dialogProps, renderType])
+  }, [dialogType, dialogProps])
 
   return (
     <Suspense fallback={null}>

--- a/ui/leafwiki-ui/src/features/page/AddPageDialog.tsx
+++ b/ui/leafwiki-ui/src/features/page/AddPageDialog.tsx
@@ -106,7 +106,6 @@ export function AddPageDialog({
       reloadTree,
       parentPath,
       navigate,
-      resetForm,
       itemLabel,
       itemLabelCapitalized,
     ],

--- a/ui/leafwiki-ui/src/features/page/AddPageDialog.tsx
+++ b/ui/leafwiki-ui/src/features/page/AddPageDialog.tsx
@@ -87,7 +87,6 @@ export function AddPageDialog({
           const fullPath = parentPath !== '' ? `${parentPath}/${slug}` : slug
           navigate(buildEditUrl(fullPath))
         }
-        resetForm()
         return true
       } catch (err: unknown) {
         console.warn(err)


### PR DESCRIPTION
resetForm() was called inside handleCreate before returning true, causing the form reset and closeDialog() to land in the same React render — the user briefly saw empty fields before the close animation. Remove the explicit resetForm(); state resets naturally on unmount.

Also remove renderType from the DialogManager useEffect dependency array — it is only ever set by the effect, never read, causing an unnecessary second effect pass on every dialog open/close.