### PR TITLE
fix(ui): improve syntax highlighting string color in light and dark mode

### DIFF
--- a/ui/leafwiki-ui/src/features/preview/markdownPreviewCodeTheme.css
+++ b/ui/leafwiki-ui/src/features/preview/markdownPreviewCodeTheme.css
@@ -30,7 +30,7 @@
   --hljs-keyword: #d73a49;
   --hljs-title: #6f42c1;
   --hljs-constant: #005cc5;
-  --hljs-string: #032f62;
+  --hljs-string: #b36200;
   --hljs-symbol: #e36209;
   --hljs-comment: #6a737d;
   --hljs-name: #22863a;
@@ -56,7 +56,7 @@
   --hljs-keyword: #ff7b72;
   --hljs-title: #d2a8ff;
   --hljs-constant: #79c0ff;
-  --hljs-string: #a5d6ff;
+  --hljs-string: #e6b87a;
   --hljs-symbol: #ffa657;
   --hljs-comment: #8b949e;
   --hljs-name: #7ee787;


### PR DESCRIPTION
String literals were rendered in blue shades, making them visually indistinguishable from attribute/constant tokens (also blue). Changed to warm amber in both modes so YAML values, JSON strings, etc. clearly contrast with blue keys/attrs.