### PR TITLE
fix: split SIGUSR1/SIGHUP reload signal handling into platform files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@
 *.test
 
 # Main binary
-leafwiki
+/leafwiki
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 COPY --from=frontend-build /app/dist ./internal/http/dist
 RUN CGO_ENABLED=0 go build \
 	-ldflags="-s -w -X github.com/perber/wiki/internal/http.EmbedFrontend=true -X github.com/perber/wiki/internal/http.Environment=production -X github.com/perber/wiki/internal/wiki/auth.DisableRefreshTokenRateLimit=${DISABLE_REFRESH_TOKEN_RATE_LIMIT}" \
-	-o /out/leafwiki ./cmd/leafwiki/main.go
+	-o /out/leafwiki ./cmd/leafwiki
 
 # Step 3: Final image (small)
 FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS final

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -35,4 +35,4 @@ COPY --from=frontend /ui/dist ./internal/http/dist
 
 RUN go build \
   -ldflags="-s -w -X github.com/perber/wiki/internal/http.EmbedFrontend=true -X github.com/perber/wiki/internal/http.Environment=production" \
-  -o /out/${OUTPUT} ./cmd/leafwiki/main.go
+  -o /out/${OUTPUT} ./cmd/leafwiki

--- a/cmd/leafwiki/main.go
+++ b/cmd/leafwiki/main.go
@@ -430,7 +430,7 @@ func main() {
 	})
 
 	reloadSignals := make(chan os.Signal, 1)
-	signal.Notify(reloadSignals, syscall.SIGUSR1, syscall.SIGHUP)
+	notifyReloadSignals(reloadSignals)
 	defer signal.Stop(reloadSignals)
 
 	shutdownSignals := make(chan os.Signal, 1)

--- a/cmd/leafwiki/signals_unix.go
+++ b/cmd/leafwiki/signals_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func notifyReloadSignals(ch chan os.Signal) {
+	signal.Notify(ch, syscall.SIGUSR1, syscall.SIGHUP)
+}

--- a/cmd/leafwiki/signals_windows.go
+++ b/cmd/leafwiki/signals_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package main
+
+import "os"
+
+func notifyReloadSignals(_ chan os.Signal) {
+	// SIGUSR1 and SIGHUP do not exist on Windows; live reload via signals is unavailable.
+}


### PR DESCRIPTION
syscall.SIGUSR1 doesn't exist on Windows, breaking the windows/amd64 release binary build and leaving an empty asset that GitHub then rejected during release upload.