### PR TITLE
docs: fix git backup README inaccuracies

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,9 +396,9 @@ Use `--unix-socket` when LeafWiki should listen on a local unix domain socket in
 
 > **Experimental** — This feature is new and may change in future releases. Test it thoroughly before relying on it for critical data.
 
-Git Backup pushes wiki **content** to a remote Git repository via SSH after each change. It covers the `root/` (pages) and `assets/` directories. Database files (`.db`, `.db-wal`, etc.) and runtime files are excluded via `.gitignore`.
+Git Backup pushes wiki **content** to a remote Git repository via SSH on a configurable interval. It covers the `root/` (pages) and `assets/` directories. Database files (`.db`, `.db-wal`, etc.) and runtime files are excluded via `.gitignore`.
 
-Backups run automatically on a configurable interval and can also be triggered manually from **Settings → Backup**.
+Backups run automatically on a configurable interval and can also be triggered manually from the **Git Content Backup** page.
 
 **CLI flags (v0.11.3+):**
 
@@ -443,6 +443,7 @@ environment:
 
 - `--git-backup-remote` is required when using SSH push. The remote must be an SSH URL (`git@...` or `ssh://...`).
 - Either `--git-backup-ssh-key` or `--git-backup-ssh-key-path` is required when a remote is configured. Prefer the environment variable to avoid the key appearing in process listings.
+- `--git-backup-ssh-known-hosts` is optional but recommended. If not set, LeafWiki falls back to `~/.ssh/known_hosts`. If that file does not exist either (common in containers), SSH host key verification is **disabled** — leaving connections open to MITM attacks. Set this flag explicitly in production.
 - If the remote diverges (e.g. someone pushed directly to the backup branch), LeafWiki will stop auto-pushing and show a **Conflict — remote diverged** warning in the UI. Click **Force Push** in the UI to overwrite the remote with the current local backup history. Your wiki content is never lost — the local backup repo is always authoritative.
 - This backs up **content only** — the SQLite database is not included. For a full backup, use your data directory (`cp -r` with the app stopped).
 


### PR DESCRIPTION
- "after each change" was wrong — backup runs on a configurable interval
- "Settings → Backup" was wrong — menu item is "Git Content Backup"
- Document known_hosts fallback behaviour: without the flag, LeafWiki falls back to ~/.ssh/known_hosts and then InsecureIgnoreHostKey (MITM risk in containers)