### PR TITLE
feat: add date-title button to page dialogs

### DIFF
--- a/ui/leafwiki-ui/src/features/page/AddPageDialog.tsx
+++ b/ui/leafwiki-ui/src/features/page/AddPageDialog.tsx
@@ -1,10 +1,13 @@
 import BaseDialog, { BaseDialogConfirmButton } from '@/components/BaseDialog'
 import { FormInput } from '@/components/FormInput'
+import { Button } from '@/components/ui/button'
 import { createPage, NODE_KIND_PAGE } from '@/lib/api/pages'
 import { handleFieldErrors } from '@/lib/handleFieldErrors'
+import i18next from '@/lib/i18n'
 import { DIALOG_ADD_PAGE } from '@/lib/registries'
 import { buildEditUrl } from '@/lib/routePath'
 import { useTreeStore } from '@/stores/tree'
+import { CalendarDays } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
@@ -165,19 +168,35 @@ export function AddPageDialog({
       buttons={buttons}
     >
       <div className="page-dialog__fields">
-        <FormInput
-          autoFocus={true}
-          label="Title"
-          value={title}
-          onChange={(val) => {
-            handleTitleChange(val)
-            setFieldErrors((prev) => ({ ...prev, title: '' }))
-          }}
-          testid="add-page-title-input"
-          placeholder={`${itemLabelCapitalized} title`}
-          error={fieldErrors.title}
-          allowedHotkeys={DIALOG_INPUT_ALLOWED_HOTKEYS}
-        />
+        <div className="page-dialog__title-row">
+          <FormInput
+            autoFocus={true}
+            label="Title"
+            value={title}
+            onChange={(val) => {
+              handleTitleChange(val)
+              setFieldErrors((prev) => ({ ...prev, title: '' }))
+            }}
+            testid="add-page-title-input"
+            placeholder={`${itemLabelCapitalized} title`}
+            error={fieldErrors.title}
+            allowedHotkeys={DIALOG_INPUT_ALLOWED_HOTKEYS}
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="page-dialog__date-btn"
+            title={i18next.t('addPageDialog.dateTitleTooltip', {
+              ns: 'editor',
+            })}
+            onClick={() =>
+              handleTitleChange(new Date().toISOString().slice(0, 10))
+            }
+          >
+            <CalendarDays size={15} />
+          </Button>
+        </div>
         <SlugInputWithSuggestion
           title={title}
           slug={slug}

--- a/ui/leafwiki-ui/src/features/page/EditPageMetadataDialog.tsx
+++ b/ui/leafwiki-ui/src/features/page/EditPageMetadataDialog.tsx
@@ -1,9 +1,11 @@
 import { NODE_KIND_PAGE, type Page } from '@/lib/api/pages'
 import BaseDialog from '@/components/BaseDialog'
 import { FormInput } from '@/components/FormInput'
+import { Button } from '@/components/ui/button'
 import i18next from '@/lib/i18n'
 import { DIALOG_EDIT_PAGE_METADATA } from '@/lib/registries'
 import { useTreeStore } from '@/stores/tree'
+import { CalendarDays } from 'lucide-react'
 import { useCallback, useState } from 'react'
 import { SlugInputWithSuggestion } from './SlugInputWithSuggestion'
 
@@ -100,18 +102,34 @@ export function EditPageMetadataDialog({
       testidPrefix="edit-page-metadata-dialog"
     >
       <div className="page-dialog__fields">
-        <FormInput
-          autoFocus
-          label={i18next.t('editPageMetadataDialog.titleLabel', {
-            ns: 'editor',
-          })}
-          value={title}
-          onChange={handleTitleChange}
-          placeholder={`${itemLabelCapitalized} title`}
-          error={fieldErrors.title}
-          testid="edit-page-metadata-dialog-title-input"
-          allowedHotkeys={DIALOG_INPUT_ALLOWED_HOTKEYS}
-        />
+        <div className="page-dialog__title-row">
+          <FormInput
+            autoFocus
+            label={i18next.t('editPageMetadataDialog.titleLabel', {
+              ns: 'editor',
+            })}
+            value={title}
+            onChange={handleTitleChange}
+            placeholder={`${itemLabelCapitalized} title`}
+            error={fieldErrors.title}
+            testid="edit-page-metadata-dialog-title-input"
+            allowedHotkeys={DIALOG_INPUT_ALLOWED_HOTKEYS}
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="page-dialog__date-btn"
+            title={i18next.t('editPageMetadataDialog.dateTitleTooltip', {
+              ns: 'editor',
+            })}
+            onClick={() =>
+              handleTitleChange(new Date().toISOString().slice(0, 10))
+            }
+          >
+            <CalendarDays size={15} />
+          </Button>
+        </div>
 
         <SlugInputWithSuggestion
           title={title}

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -1206,6 +1206,14 @@
     @apply space-y-4;
   }
 
+  .page-dialog__title-row {
+    @apply relative;
+  }
+
+  .page-dialog__date-btn {
+    @apply text-muted absolute top-0 right-0 h-6 w-6 opacity-50 hover:opacity-100;
+  }
+
   .dialog__path {
     @apply text-muted font-mono text-xs;
   }

--- a/ui/leafwiki-ui/src/locales/en/editor.json
+++ b/ui/leafwiki-ui/src/locales/en/editor.json
@@ -8,11 +8,15 @@
     "label": "Slug",
     "placeholder": "Page slug"
   },
+  "addPageDialog": {
+    "dateTitleTooltip": "Set title to today's date"
+  },
   "editPageMetadataDialog": {
     "titleLabel": "Title",
     "pathPrefix": "Path:",
     "cancelButton": "Cancel",
-    "saveButton": "Change"
+    "saveButton": "Change",
+    "dateTitleTooltip": "Set title to today's date"
   },
   "toolbar": {
     "boldTooltip": "Bold (Ctrl+B)",


### PR DESCRIPTION
Adds a small calendar icon button next to the title input in the Add Page and Edit Metadata dialogs. Clicking it sets the title to today's date in yyyy-mm-dd format. Tooltip is i18n'd via editor.json.