### PR TITLE
fix(editor): update alt text on asset rename to fix stale Lightbox title

### DIFF
--- a/ui/leafwiki-ui/src/features/editor/MarkdownEditor.tsx
+++ b/ui/leafwiki-ui/src/features/editor/MarkdownEditor.tsx
@@ -16,7 +16,11 @@ import {
 import MarkdownPreview from '../preview/MarkdownPreview'
 import MarkdownCodeEditor from './MarkdownCodeEditor'
 import MarkdownToolbar from './MarkdownToolbar'
-import { insertHeadingAtStart, insertWrappedText } from './editorCommands'
+import {
+  insertHeadingAtStart,
+  insertWrappedText,
+  replaceFilenameInText,
+} from './editorCommands'
 
 import { uploadAsset, UploadAssetResponse } from '@/lib/api/assets'
 import { mapApiError } from '@/lib/api/errors'
@@ -246,12 +250,7 @@ const MarkdownEditor = (
       if (!view) return
       const docText = view.state.doc.toString()
 
-      // Just replace the filename.
-      // The path remains unchanged, but the filename has to start with '/'
-      const regex = new RegExp(`(!?\\[.*?\\]\\(.*?/?)/${before}(\\))`, 'g')
-
-      const newFilename = after.startsWith('/') ? after.slice(1) : after
-      const updatedText = docText.replace(regex, `$1/${newFilename}$2`)
+      const updatedText = replaceFilenameInText(docText, before, after)
 
       // Replace the entire document content
       view.dispatch({

--- a/ui/leafwiki-ui/src/features/editor/editorCommands.test.ts
+++ b/ui/leafwiki-ui/src/features/editor/editorCommands.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { replaceFilenameInText } from './editorCommands'
+
+describe('replaceFilenameInText', () => {
+  it('updates both the src filename and the alt text when the alt text matches the old filename', () => {
+    const doc = '![old-name.png](/assets/old-name.png)'
+    const result = replaceFilenameInText(doc, 'old-name.png', 'new-name.png')
+    expect(result).toBe('![new-name.png](/assets/new-name.png)')
+  })
+
+  it('updates the src filename but preserves custom alt text that does not match the old filename', () => {
+    const doc = '![a nice photo](/assets/old-name.png)'
+    const result = replaceFilenameInText(doc, 'old-name.png', 'new-name.png')
+    expect(result).toBe('![a nice photo](/assets/new-name.png)')
+  })
+
+  it('updates plain (non-image) markdown links the same way', () => {
+    const doc = '[old-name.pdf](/assets/old-name.pdf)'
+    const result = replaceFilenameInText(doc, 'old-name.pdf', 'new-name.pdf')
+    expect(result).toBe('[new-name.pdf](/assets/new-name.pdf)')
+  })
+
+  it('handles filenames containing regex-special characters', () => {
+    const doc = '![old (1).png](/assets/old (1).png)'
+    const result = replaceFilenameInText(doc, 'old (1).png', 'new.png')
+    expect(result).toBe('![new.png](/assets/new.png)')
+  })
+
+  it('replaces every occurrence in the document', () => {
+    const doc = [
+      '![old-name.png](/assets/old-name.png)',
+      'See also [old-name.png](/assets/old-name.png) below.',
+    ].join('\n')
+    const result = replaceFilenameInText(doc, 'old-name.png', 'new-name.png')
+    expect(result).toBe(
+      [
+        '![new-name.png](/assets/new-name.png)',
+        'See also [new-name.png](/assets/new-name.png) below.',
+      ].join('\n'),
+    )
+  })
+})

--- a/ui/leafwiki-ui/src/features/editor/editorCommands.test.ts
+++ b/ui/leafwiki-ui/src/features/editor/editorCommands.test.ts
@@ -39,4 +39,13 @@ describe('replaceFilenameInText', () => {
       ].join('\n'),
     )
   })
+
+  it('does not match across multiple links on the same line', () => {
+    const doc =
+      '![foo.png](/assets/foo.png) and ![old-name.png](/assets/old-name.png)'
+    const result = replaceFilenameInText(doc, 'old-name.png', 'new-name.png')
+    expect(result).toBe(
+      '![foo.png](/assets/foo.png) and ![new-name.png](/assets/new-name.png)',
+    )
+  })
 })

--- a/ui/leafwiki-ui/src/features/editor/editorCommands.ts
+++ b/ui/leafwiki-ui/src/features/editor/editorCommands.ts
@@ -79,7 +79,7 @@ export function replaceFilenameInText(
 ) {
   const newFilename = after.startsWith('/') ? after.slice(1) : after
   const regex = new RegExp(
-    `(!?\\[)(.*?)(\\]\\(.*?\\/?)\\/${escapeRegExp(before)}(\\))`,
+    `(!?\\[)([^\\]]*?)(\\]\\((?:(?!\\]\\().)*?\\/?)\\/${escapeRegExp(before)}(\\))`,
     'g',
   )
 

--- a/ui/leafwiki-ui/src/features/editor/editorCommands.ts
+++ b/ui/leafwiki-ui/src/features/editor/editorCommands.ts
@@ -65,6 +65,33 @@ export function insertWrappedText(
   view.focus()
 }
 
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+// Replaces a filename in markdown link/image targets (`[text](.../old)` -> `[text](.../new)`).
+// Also updates the link/alt text itself when it exactly matches the old filename, since
+// inserted assets default to using the filename as their alt/link text.
+export function replaceFilenameInText(
+  docText: string,
+  before: string,
+  after: string,
+) {
+  const newFilename = after.startsWith('/') ? after.slice(1) : after
+  const regex = new RegExp(
+    `(!?\\[)(.*?)(\\]\\(.*?\\/?)\\/${escapeRegExp(before)}(\\))`,
+    'g',
+  )
+
+  return docText.replace(
+    regex,
+    (_match, bracket, altText, pathPrefix, closeParen) => {
+      const newAltText = altText === before ? newFilename : altText
+      return `${bracket}${newAltText}${pathPrefix}/${newFilename}${closeParen}`
+    },
+  )
+}
+
 // Inserts a heading of the specified level (1, 2, or 3) at the current line at the start position
 export function insertHeadingAtStart(view: EditorView, level: 1 | 2 | 3) {
   const { from } = view.state.selection.main


### PR DESCRIPTION
Renaming an asset only rewrote the image src path in markdown, leaving the alt text (which defaults to the filename on insert) untouched. The Lightbox displays alt text verbatim, so it kept showing the old name after rename + save, even after a maintenance resync.

Fixes #1251