### PR TITLE
fix(ui): stop long asset filenames from overflowing the Asset Manager…

### DIFF
--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -700,7 +700,7 @@
 
   /* AssetManager Component */
   .asset-manager {
-    @apply text-interface-text space-y-3 text-sm;
+    @apply text-interface-text min-w-0 space-y-3 text-sm;
   }
 
   .asset-manager__title {


### PR DESCRIPTION
… dialog

The Asset Manager card is a direct child of the Dialog's CSS grid container. Without an explicit min-width, a long unbreakable filename forced the grid track's automatic minimum size to the text's full max-content width, pushing the dialog content (and action buttons) past the visible edge of the modal instead of truncating.