### PR TITLE
fix: sidebar explorer/search shortcuts open a collapsed sidebar

### DIFF
--- a/ui/leafwiki-ui/src/features/sidebar/Sidebar.test.tsx
+++ b/ui/leafwiki-ui/src/features/sidebar/Sidebar.test.tsx
@@ -1,0 +1,102 @@
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { useHotKeysStore } from '@/stores/hotkeys'
+import { useSidebarStore } from '@/stores/sidebar'
+import { act, render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import Sidebar from './Sidebar'
+
+vi.hoisted(() => {
+  const store = new Map<string, string>()
+  const localStorage = {
+    get length() {
+      return store.size
+    },
+    clear: () => {
+      store.clear()
+    },
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, value)
+    },
+  }
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: localStorage,
+    configurable: true,
+  })
+})
+
+function renderSidebar() {
+  render(
+    <MemoryRouter initialEntries={['/docs/getting-started']}>
+      <TooltipProvider>
+        <Sidebar />
+      </TooltipProvider>
+    </MemoryRouter>,
+  )
+}
+
+function invokeHotkey(combo: string) {
+  const hotkeys = useHotKeysStore.getState().registeredHotkeys[combo]
+  const hotkey = hotkeys[hotkeys.length - 1]
+
+  expect(hotkey).toBeDefined()
+
+  act(() => {
+    hotkey?.action()
+  })
+}
+
+describe('Sidebar', () => {
+  beforeEach(() => {
+    window.matchMedia = vi.fn().mockImplementation(() => ({
+      matches: false,
+      media: '(max-width: 767px)',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+
+    useSidebarStore.setState({ sidebarVisible: false, sidebarMode: 'search' })
+    useHotKeysStore.setState({ registeredHotkeys: {} })
+  })
+
+  it('opens the collapsed sidebar when the explorer hotkey is invoked', () => {
+    renderSidebar()
+
+    invokeHotkey('Mod+Shift+KeyE')
+
+    expect(useSidebarStore.getState().sidebarVisible).toBe(true)
+    expect(useSidebarStore.getState().sidebarMode).toBe('tree')
+  })
+
+  it('opens the collapsed sidebar when the search hotkey is invoked', () => {
+    useSidebarStore.setState({ sidebarVisible: false, sidebarMode: 'tree' })
+
+    renderSidebar()
+
+    invokeHotkey('Mod+Shift+KeyF')
+
+    expect(useSidebarStore.getState().sidebarVisible).toBe(true)
+    expect(useSidebarStore.getState().sidebarMode).toBe('search')
+  })
+
+  it('keeps the sidebar open when switching panels by hotkey', () => {
+    useSidebarStore.setState({ sidebarVisible: true, sidebarMode: 'tree' })
+
+    renderSidebar()
+
+    invokeHotkey('Mod+Shift+KeyF')
+
+    expect(useSidebarStore.getState().sidebarVisible).toBe(true)
+    expect(useSidebarStore.getState().sidebarMode).toBe('search')
+  })
+})

--- a/ui/leafwiki-ui/src/features/sidebar/Sidebar.tsx
+++ b/ui/leafwiki-ui/src/features/sidebar/Sidebar.tsx
@@ -19,6 +19,7 @@ export default function Sidebar() {
   const appMode = useAppMode()
   const sidebarMode = useSidebarStore((state) => state.sidebarMode)
   const setSidebarMode = useSidebarStore((state) => state.setSidebarMode)
+  const setSidebarVisible = useSidebarStore((state) => state.setSidebarVisible)
 
   const items = useMemo(
     () =>
@@ -59,10 +60,13 @@ export default function Sidebar() {
   const actions = useMemo(() => {
     const actionMap = new Map<string, () => void>()
     items.forEach((item) => {
-      actionMap.set(item.id, () => setSidebarMode(item.id))
+      actionMap.set(item.id, () => {
+        setSidebarVisible(true)
+        setSidebarMode(item.id)
+      })
     })
     return actionMap
-  }, [items, setSidebarMode])
+  }, [items, setSidebarMode, setSidebarVisible])
 
   // Memoize hotkey definitions using the stable actions
   const hotKeyDefs = useMemo(


### PR DESCRIPTION
## Summary

The CTRL+SHIFT+E (Open explorer) and CTRL+SHIFT+F (Open search) sidebar shortcuts now open the sidebar when it is collapsed, in addition to activating the corresponding panel. When the sidebar is already open the behavior is unchanged: the shortcut just switches to that panel.

## Why this matters

Per #1265, pressing either shortcut while the sidebar is collapsed appears to do nothing. The reason is that the hotkey action in `Sidebar.tsx` only calls `setSidebarMode(item.id)`, which changes the active panel but never makes a collapsed sidebar visible. The store already exposes `setSidebarVisible` (used by `AppLayout`), so the fix wires that into the shortcut action. This matches the expected behavior described in the issue and is consistent with how editors like VS Code treat these shortcuts. The separate idea of a dedicated sidebar-toggle shortcut is left out of scope, since it is still under discussion.

The visible tab buttons keep their existing direct `onClick`, since clicking a tab already implies the sidebar is open.

## Testing

- Added `Sidebar.test.tsx` (Vitest + @testing-library/react) covering three cases: collapsed sidebar plus explorer shortcut opens it on the `tree` panel, collapsed sidebar plus search shortcut opens it on the `search` panel, and an already-open sidebar stays open and just switches panels when a shortcut is pressed.
- `eslint` and `prettier --check` pass on the changed files, and the app TypeScript project (`tsconfig.app.json`) type-checks cleanly.

Fixes #1265
