### PR TITLE
fix(auth): stop login flash on logout, add external user-management link

### DIFF
--- a/cmd/leafwiki/main.go
+++ b/cmd/leafwiki/main.go
@@ -66,6 +66,8 @@ func writeUsage(w io.Writer) {
 	--http-remote-user-header-name  HTTP header carrying the username from a trusted proxy (default: Remote-User)
 	--trusted-proxy-ips             Comma-separated trusted proxy IPs/CIDRs (e.g. 127.0.0.1,172.18.0.0/16)
 	--http-remote-user-logout-url   URL the frontend redirects to after logout in proxy-auth mode (default: "")
+	--user-management-url           URL to an external user-management page; when set, the built-in
+	                                 User Management UI is replaced with a link to this URL (default: "")
 	--disable-request-log           Suppress per-request HTTP access log lines (default: false)
 	--git-backup                   Enable git backup to a remote repository (default: false)
 	--git-backup-author-name       Git commit author name for backups (default: LeafWiki Backup)
@@ -103,6 +105,7 @@ func writeUsage(w io.Writer) {
 	LEAFWIKI_HTTP_REMOTE_USER_HEADER_NAME
 	LEAFWIKI_TRUSTED_PROXY_IPS
 	LEAFWIKI_HTTP_REMOTE_USER_LOGOUT_URL
+	LEAFWIKI_USER_MANAGEMENT_URL
 	LEAFWIKI_DISABLE_REQUEST_LOG
 	LEAFWIKI_GIT_BACKUP
 	LEAFWIKI_GIT_BACKUP_AUTHOR_NAME
@@ -171,6 +174,7 @@ type cliFlags struct {
 	httpRemoteUserHeader    *string
 	trustedProxyIPs         *string
 	httpRemoteUserLogoutURL *string
+	userManagementURL       *string
 	disableRequestLog       *bool
 	gitBackup               *bool
 	gitBackupAuthorName     *string
@@ -209,6 +213,7 @@ func registerFlags(fs *flag.FlagSet) *cliFlags {
 		httpRemoteUserHeader:    fs.String("http-remote-user-header-name", "Remote-User", "HTTP header name carrying the username from a trusted proxy (default: Remote-User)"),
 		trustedProxyIPs:         fs.String("trusted-proxy-ips", "", "comma-separated list of trusted proxy IPs/CIDRs (e.g. 127.0.0.1,172.18.0.0/16)"),
 		httpRemoteUserLogoutURL: fs.String("http-remote-user-logout-url", "", "URL the frontend redirects to after logout when reverse-proxy auth is active (e.g. https://auth.example.com/logout)"),
+		userManagementURL:       fs.String("user-management-url", "", "URL to an external user-management page; when set, the built-in User Management UI is replaced with a link to this URL"),
 		disableRequestLog:       fs.Bool("disable-request-log", false, "suppress per-request HTTP access log lines (default: false)"),
 		gitBackup:               fs.Bool("git-backup", false, "enable git backup to a remote repository (default: false)"),
 		gitBackupAuthorName:     fs.String("git-backup-author-name", "", "git commit author name for backups (default: LeafWiki Backup)"),
@@ -271,6 +276,7 @@ func main() {
 	httpRemoteUserHeader := resolveString("http-remote-user-header-name", *flags.httpRemoteUserHeader, visited, "LEAFWIKI_HTTP_REMOTE_USER_HEADER_NAME", "Remote-User")
 	trustedProxyIPsRaw := resolveString("trusted-proxy-ips", *flags.trustedProxyIPs, visited, "LEAFWIKI_TRUSTED_PROXY_IPS", "")
 	httpRemoteUserLogoutURL := resolveString("http-remote-user-logout-url", *flags.httpRemoteUserLogoutURL, visited, "LEAFWIKI_HTTP_REMOTE_USER_LOGOUT_URL", "")
+	userManagementURL := resolveString("user-management-url", *flags.userManagementURL, visited, "LEAFWIKI_USER_MANAGEMENT_URL", "")
 	disableRequestLog := resolveBool("disable-request-log", *flags.disableRequestLog, visited, "LEAFWIKI_DISABLE_REQUEST_LOG")
 	gitBackupEnabled := resolveBool("git-backup", *flags.gitBackup, visited, "LEAFWIKI_GIT_BACKUP")
 	gitBackupAuthorName := resolveString("git-backup-author-name", *flags.gitBackupAuthorName, visited, "LEAFWIKI_GIT_BACKUP_AUTHOR_NAME", "LeafWiki Backup")
@@ -427,6 +433,7 @@ func main() {
 			LogoutURL:      httpRemoteUserLogoutURL,
 		},
 		DisableRequestLog: disableRequestLog,
+		UserManagementURL: userManagementURL,
 	})
 
 	reloadSignals := make(chan os.Signal, 1)

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -98,6 +98,7 @@ type RouterOptions struct {
 	GitBackupEnabled        bool                 // Whether git backup is enabled (surfaced to admin UI via /api/config)
 	HTTPRemoteUser          HTTPRemoteUserConfig // Reverse-proxy authentication via HTTP header
 	DisableRequestLog       bool                 // Whether to suppress per-request access log lines
+	UserManagementURL       string               // Optional URL; when set, the frontend replaces in-app user management with a link to this URL
 }
 
 // FrontendConfig carries the minimal runtime data required to serve the embedded SPA.

--- a/internal/http/router_test.go
+++ b/internal/http/router_test.go
@@ -926,6 +926,81 @@ func TestConfigEndpoint_IncludesEnableLinkRefactor(t *testing.T) {
 	}
 }
 
+func TestConfigEndpoint_IncludesUserManagementUrl(t *testing.T) {
+	w := createWikiTestInstance(t)
+	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
+
+	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
+		PublicAccess:            true,
+		InjectCodeInHeader:      "",
+		AllowInsecure:           true,
+		AccessTokenTimeout:      15 * time.Minute,
+		RefreshTokenTimeout:     7 * 24 * time.Hour,
+		HideLinkMetadataSection: false,
+		MaxAssetUploadSizeBytes: assets.DefaultMaxUploadSizeBytes,
+		UserManagementURL:       "https://control-plane.example.com/users",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected 200 OK, got %d", rec.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Invalid JSON response: %v", err)
+	}
+
+	got, ok := resp["userManagementUrl"].(string)
+	if !ok {
+		t.Fatalf("Expected userManagementUrl in config response, got %v", resp)
+	}
+
+	if got != "https://control-plane.example.com/users" {
+		t.Fatalf("Expected userManagementUrl=%q, got %q", "https://control-plane.example.com/users", got)
+	}
+}
+
+func TestConfigEndpoint_UserManagementUrlDefaultsToEmpty(t *testing.T) {
+	w := createWikiTestInstance(t)
+	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
+
+	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
+		PublicAccess:            true,
+		InjectCodeInHeader:      "",
+		AllowInsecure:           true,
+		AccessTokenTimeout:      15 * time.Minute,
+		RefreshTokenTimeout:     7 * 24 * time.Hour,
+		HideLinkMetadataSection: false,
+		MaxAssetUploadSizeBytes: assets.DefaultMaxUploadSizeBytes,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected 200 OK, got %d", rec.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Invalid JSON response: %v", err)
+	}
+
+	got, ok := resp["userManagementUrl"].(string)
+	if !ok {
+		t.Fatalf("Expected userManagementUrl in config response, got %v", resp)
+	}
+
+	if got != "" {
+		t.Fatalf("Expected userManagementUrl to default to empty string, got %q", got)
+	}
+}
+
 func TestRefactorPreviewEndpoint_UsesFrontendJSONShape(t *testing.T) {
 	w := createWikiTestInstance(t)
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)

--- a/internal/wiki/auth/routes.go
+++ b/internal/wiki/auth/routes.go
@@ -142,6 +142,7 @@ func (r *Routes) handleConfig(ctx httpinternal.RouterContext) gin.HandlerFunc {
 			"gitBackupEnabled":        opts.GitBackupEnabled,
 			"httpRemoteUserEnabled":   opts.HTTPRemoteUser.Enabled,
 			"httpRemoteUserLogoutUrl": opts.HTTPRemoteUser.LogoutURL,
+			"userManagementUrl":       opts.UserManagementURL,
 		})
 	}
 }

--- a/ui/leafwiki-ui/src/App.tsx
+++ b/ui/leafwiki-ui/src/App.tsx
@@ -19,6 +19,7 @@ function App() {
   const loadConfig = useConfigStore((s) => s.loadConfig)
   const authDisabled = useConfigStore((s) => s.authDisabled)
   const enableRevision = useConfigStore((s) => s.enableRevision)
+  const userManagementUrl = useConfigStore((s) => s.userManagementUrl)
   const loadBranding = useBrandingStore((s) => s.loadBranding)
   const lastConfigErrorRef = useRef<string | null>(null)
 
@@ -58,9 +59,10 @@ function App() {
         isReadOnlyViewer,
         authDisabled,
         enableRevision,
+        userManagementUrl,
         BASE_PATH || undefined,
       ),
-    [isReadOnlyViewer, authDisabled, enableRevision],
+    [isReadOnlyViewer, authDisabled, enableRevision, userManagementUrl],
   )
 
   return (

--- a/ui/leafwiki-ui/src/components/UserToolbar.test.tsx
+++ b/ui/leafwiki-ui/src/components/UserToolbar.test.tsx
@@ -1,13 +1,14 @@
 import { DialogManager } from '@/components/DialogManager'
 import { HotKeyHandler } from '@/components/HotKeyHandler'
 import UserToolbar from '@/components/UserToolbar'
+import * as authAPI from '@/lib/api/auth'
 import { useBackupStore } from '@/stores/backup'
 import { useConfigStore } from '@/stores/config'
 import { useDialogsStore } from '@/stores/dialogs'
 import { useSessionStore } from '@/stores/session'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('UserToolbar', () => {
@@ -26,6 +27,7 @@ describe('UserToolbar', () => {
       authDisabled: false,
       httpRemoteUserEnabled: false,
       httpRemoteUserLogoutUrl: '',
+      userManagementUrl: '',
     })
     useBackupStore.setState({ enabled: false })
     useSessionStore.setState({
@@ -143,6 +145,136 @@ describe('UserToolbar', () => {
       expect(
         screen.queryByTestId('shortcuts-help-dialog'),
       ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('logout redirect', () => {
+    const renderWithLoginRoute = () =>
+      render(
+        <MemoryRouter initialEntries={['/']}>
+          <Routes>
+            <Route path="/" element={<UserToolbar />} />
+            <Route
+              path="/login"
+              element={<div data-testid="login-form-sentinel">LOGIN</div>}
+            />
+          </Routes>
+        </MemoryRouter>,
+      )
+
+    let originalLocation: Location
+
+    beforeEach(() => {
+      originalLocation = window.location
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: { ...originalLocation, href: '' },
+      })
+    })
+
+    afterEach(() => {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: originalLocation,
+      })
+    })
+
+    it('redirects straight to the logout URL without rendering the local login screen', async () => {
+      const user = userEvent.setup()
+      const logoutSpy = vi.spyOn(authAPI, 'logout').mockResolvedValue()
+      useConfigStore.setState({
+        httpRemoteUserLogoutUrl: 'https://control-plane.example.com/logout',
+      })
+
+      renderWithLoginRoute()
+
+      const avatar = screen.getByTestId('user-toolbar-avatar')
+      await user.click(avatar.closest('button') as HTMLButtonElement)
+      await user.click(screen.getByTestId('user-toolbar-logout'))
+
+      expect(logoutSpy).toHaveBeenCalled()
+      expect(window.location.href).toBe(
+        'https://control-plane.example.com/logout',
+      )
+      expect(
+        screen.queryByTestId('login-form-sentinel'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('falls back to the local /login route when no logout URL is configured', async () => {
+      const user = userEvent.setup()
+      useConfigStore.setState({ httpRemoteUserLogoutUrl: '' })
+
+      renderWithLoginRoute()
+
+      const avatar = screen.getByTestId('user-toolbar-avatar')
+      await user.click(avatar.closest('button') as HTMLButtonElement)
+      await user.click(screen.getByTestId('user-toolbar-logout'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('login-form-sentinel')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('user management link', () => {
+    beforeEach(() => {
+      useSessionStore.setState({
+        user: {
+          id: 'admin-1',
+          username: 'admin',
+          email: 'admin@example.com',
+          role: 'admin',
+        },
+      })
+    })
+
+    it('renders User Management as an external link when userManagementUrl is set', async () => {
+      const user = userEvent.setup()
+      useConfigStore.setState({
+        userManagementUrl: 'https://control-plane.example.com/users',
+      })
+
+      render(
+        <MemoryRouter>
+          <UserToolbar />
+        </MemoryRouter>,
+      )
+
+      const avatar = screen.getByTestId('user-toolbar-avatar')
+      await user.click(avatar.closest('button') as HTMLButtonElement)
+
+      const link = screen.getByText('User Management').closest('a')
+      expect(link).toHaveAttribute(
+        'href',
+        'https://control-plane.example.com/users',
+      )
+      expect(link).toHaveAttribute('target', '_blank')
+    })
+
+    it('navigates to the local /users route when userManagementUrl is not set', async () => {
+      const user = userEvent.setup()
+      useConfigStore.setState({ userManagementUrl: '' })
+
+      render(
+        <MemoryRouter initialEntries={['/']}>
+          <Routes>
+            <Route path="/" element={<UserToolbar />} />
+            <Route
+              path="/users"
+              element={<div data-testid="users-page-sentinel">USERS</div>}
+            />
+          </Routes>
+        </MemoryRouter>,
+      )
+
+      const avatar = screen.getByTestId('user-toolbar-avatar')
+      await user.click(avatar.closest('button') as HTMLButtonElement)
+      await user.click(screen.getByText('User Management'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('users-page-sentinel')).toBeInTheDocument()
+      })
     })
   })
 })

--- a/ui/leafwiki-ui/src/components/UserToolbar.tsx
+++ b/ui/leafwiki-ui/src/components/UserToolbar.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import * as authAPI from '@/lib/api/auth'
 import i18next from '@/lib/i18n'
 import {
   DIALOG_CHANGE_OWN_PASSWORD,
@@ -53,6 +54,7 @@ export default function UserToolbar() {
   const httpRemoteUserLogoutUrl = useConfigStore(
     (s) => s.httpRemoteUserLogoutUrl,
   )
+  const userManagementUrl = useConfigStore((s) => s.userManagementUrl)
 
   useEffect(() => {
     if (!authDisabled && (!user || readOnly)) {
@@ -95,12 +97,16 @@ export default function UserToolbar() {
   }
 
   const handleLogout = async () => {
-    await logout()
     if (httpRemoteUserLogoutUrl) {
+      // Redirect immediately instead of clearing local session state first —
+      // clearing it here would flash the local login screen before the
+      // browser navigates away (see plans/logout-flash-and-external-user-management.md).
+      authAPI.logout().catch(() => {})
       window.location.href = httpRemoteUserLogoutUrl
-    } else {
-      navigate('/login')
+      return
     }
+    await logout()
+    navigate('/login')
   }
 
   return (
@@ -118,12 +124,24 @@ export default function UserToolbar() {
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
           <RoleGuard roles={['admin']}>
-            <DropdownMenuItem
-              className="cursor-pointer"
-              onClick={() => navigate('/users')}
-            >
-              User Management
-            </DropdownMenuItem>
+            {userManagementUrl ? (
+              <DropdownMenuItem asChild className="cursor-pointer">
+                <a
+                  href={userManagementUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {t('userMenu.userManagement')}
+                </a>
+              </DropdownMenuItem>
+            ) : (
+              <DropdownMenuItem
+                className="cursor-pointer"
+                onClick={() => navigate('/users')}
+              >
+                {t('userMenu.userManagement')}
+              </DropdownMenuItem>
+            )}
             <DropdownMenuItem
               className="cursor-pointer"
               onClick={() => navigate('/settings/branding')}

--- a/ui/leafwiki-ui/src/features/router/router.tsx
+++ b/ui/leafwiki-ui/src/features/router/router.tsx
@@ -19,6 +19,7 @@ export const createLeafWikiRouter = (
   isReadOnlyViewer: boolean,
   authDisabled: boolean,
   enableRevision: boolean,
+  userManagementUrl: string,
   basename?: string,
 ) =>
   createBrowserRouter(
@@ -42,7 +43,7 @@ export const createLeafWikiRouter = (
       {
         path: '/users',
         element:
-          isReadOnlyViewer || authDisabled ? (
+          isReadOnlyViewer || authDisabled || userManagementUrl ? (
             <Navigate to="/" />
           ) : (
             <AuthWrapper>

--- a/ui/leafwiki-ui/src/lib/api/config.ts
+++ b/ui/leafwiki-ui/src/lib/api/config.ts
@@ -21,6 +21,7 @@ export type Config = {
   gitBackupEnabled: boolean
   httpRemoteUserEnabled: boolean
   httpRemoteUserLogoutUrl: string
+  userManagementUrl: string
 }
 
 export async function getConfig(): Promise<Config> {

--- a/ui/leafwiki-ui/src/locales/en/auth.json
+++ b/ui/leafwiki-ui/src/locales/en/auth.json
@@ -8,5 +8,8 @@
     "errorFallback": "Login failed",
     "loginButton": "Login",
     "publicEditor": "Public editor"
+  },
+  "userMenu": {
+    "userManagement": "User Management"
   }
 }

--- a/ui/leafwiki-ui/src/stores/config.ts
+++ b/ui/leafwiki-ui/src/stores/config.ts
@@ -12,6 +12,7 @@ type ConfigStore = {
   gitBackupEnabled: boolean
   httpRemoteUserEnabled: boolean
   httpRemoteUserLogoutUrl: string
+  userManagementUrl: string
   error: string | null
   loading: boolean
   hasLoaded: boolean
@@ -28,6 +29,7 @@ export const useConfigStore = create<ConfigStore>((set) => ({
   gitBackupEnabled: false,
   httpRemoteUserEnabled: false,
   httpRemoteUserLogoutUrl: '',
+  userManagementUrl: '',
   error: null,
   loading: false,
   hasLoaded: false,
@@ -52,6 +54,7 @@ export const useConfigStore = create<ConfigStore>((set) => ({
         gitBackupEnabled: config.gitBackupEnabled ?? false,
         httpRemoteUserEnabled: config.httpRemoteUserEnabled ?? false,
         httpRemoteUserLogoutUrl: config.httpRemoteUserLogoutUrl ?? '',
+        userManagementUrl: config.userManagementUrl ?? '',
         error: null,
         hasLoaded: true,
       })


### PR DESCRIPTION
When httpRemoteUserLogoutUrl is configured, logging out cleared local session state before redirecting, which briefly flashed the local login screen before the browser navigated away. Now the redirect happens first and the server-side session is invalidated in the background.

Also add an optional userManagementUrl config: when set, the in-app User Management entry becomes an external link and the /users route is disabled, following the same pattern as the existing logout URL. The backend /api/auth/users* routes are left untouched.