### PR TITLE
feat(editor): add stacked preview/layout toggle

### DIFF
--- a/ui/leafwiki-ui/src/features/editor/MarkdownEditor.test.tsx
+++ b/ui/leafwiki-ui/src/features/editor/MarkdownEditor.test.tsx
@@ -101,7 +101,11 @@ describe('MarkdownEditor – breakpoint remount preserves content', () => {
     mountSpy.mockClear()
     capturedOnChange = null
     mockIsMobile = false
-    mockEditorState = { ...mockEditorState, previewVisible: false, previewStacked: false }
+    mockEditorState = {
+      ...mockEditorState,
+      previewVisible: false,
+      previewStacked: false,
+    }
   })
 
   it('passes edited content (not original initialValue) to MarkdownCodeEditor on remount', async () => {
@@ -183,7 +187,9 @@ describe('MarkdownEditor – breakpoint remount preserves content', () => {
     )
 
     const layout = container.querySelector('.markdown-editor__stacked-layout')
-    const divider = container.querySelector('.markdown-editor__divider--stacked')
+    const divider = container.querySelector(
+      '.markdown-editor__divider--stacked',
+    )
 
     expect(layout).not.toBeNull()
     expect(divider).not.toBeNull()

--- a/ui/leafwiki-ui/src/features/editor/MarkdownEditor.test.tsx
+++ b/ui/leafwiki-ui/src/features/editor/MarkdownEditor.test.tsx
@@ -7,6 +7,10 @@ import MarkdownEditor from './MarkdownEditor'
 // We use useEffect([]) so this only fires on mount, not on re-renders.
 const mountSpy = vi.fn()
 let capturedOnChange: ((val: string) => void) | null = null
+let mockEditorState = {
+  previewVisible: false,
+  previewStacked: false,
+}
 
 vi.mock('./MarkdownCodeEditor', () => ({
   default: function MockMarkdownCodeEditor({
@@ -49,8 +53,10 @@ vi.mock('@/stores/config', () => ({
 
 vi.mock('@/stores/editor', () => ({
   useEditorStore: () => ({
-    previewVisible: false,
+    previewVisible: mockEditorState.previewVisible,
     togglePreview: vi.fn(),
+    previewStacked: mockEditorState.previewStacked,
+    togglePreviewLayout: vi.fn(),
     lineWrap: true,
   }),
 }))
@@ -95,6 +101,7 @@ describe('MarkdownEditor – breakpoint remount preserves content', () => {
     mountSpy.mockClear()
     capturedOnChange = null
     mockIsMobile = false
+    mockEditorState = { ...mockEditorState, previewVisible: false, previewStacked: false }
   })
 
   it('passes edited content (not original initialValue) to MarkdownCodeEditor on remount', async () => {
@@ -158,5 +165,27 @@ describe('MarkdownEditor – breakpoint remount preserves content', () => {
 
     // MarkdownCodeEditor must not have remounted
     expect(mountSpy).not.toHaveBeenCalled()
+  })
+
+  it('renders stacked desktop layout classes when preview is stacked', () => {
+    mockEditorState = {
+      ...mockEditorState,
+      previewVisible: true,
+      previewStacked: true,
+    }
+
+    const { container } = render(
+      <MarkdownEditor
+        initialValue="original content"
+        pageId="page-1"
+        onChange={vi.fn()}
+      />,
+    )
+
+    const layout = container.querySelector('.markdown-editor__stacked-layout')
+    const divider = container.querySelector('.markdown-editor__divider--stacked')
+
+    expect(layout).not.toBeNull()
+    expect(divider).not.toBeNull()
   })
 })

--- a/ui/leafwiki-ui/src/features/editor/MarkdownEditor.tsx
+++ b/ui/leafwiki-ui/src/features/editor/MarkdownEditor.tsx
@@ -654,7 +654,9 @@ const MarkdownEditor = (
               <>
                 <div
                   className={
-                    previewStacked ? 'markdown-editor__divider--stacked' : 'markdown-editor__divider'
+                    previewStacked
+                      ? 'markdown-editor__divider--stacked'
+                      : 'markdown-editor__divider'
                   }
                   id="editor-preview-divider"
                 ></div>

--- a/ui/leafwiki-ui/src/features/editor/MarkdownEditor.tsx
+++ b/ui/leafwiki-ui/src/features/editor/MarkdownEditor.tsx
@@ -109,7 +109,9 @@ const MarkdownEditor = (
 
   const {
     previewVisible: showPreview,
+    previewStacked,
     togglePreview,
+    togglePreviewLayout,
     lineWrap,
   } = useEditorStore()
 
@@ -513,11 +515,21 @@ const MarkdownEditor = (
         editorRef={ref as React.RefObject<MarkdownEditorRef>}
         pageId={pageId}
         onTogglePreview={togglePreview}
+        onTogglePreviewLayout={togglePreviewLayout}
         previewVisible={showPreview}
+        previewStacked={previewStacked}
         onAssetVersionChange={onAssetVersionChange}
       />
     )
-  }, [onAssetVersionChange, pageId, ref, showPreview, togglePreview])
+  }, [
+    onAssetVersionChange,
+    pageId,
+    ref,
+    showPreview,
+    previewStacked,
+    togglePreview,
+    togglePreviewLayout,
+  ])
 
   const renderEditor = useCallback(
     (toolbar: boolean = true): JSX.Element => {
@@ -619,11 +631,19 @@ const MarkdownEditor = (
       {!isMobile && (
         <div className="flex h-full w-full flex-col">
           {renderToolbar()}
-          <div className="flex w-full flex-1 overflow-hidden">
+          <div
+            className={
+              previewStacked && showPreview
+                ? 'markdown-editor__stacked-layout'
+                : 'flex w-full flex-1 overflow-hidden'
+            }
+          >
             <div
               className={
                 showPreview
-                  ? 'custom-scrollbar markdown-editor__editor-pane markdown-editor__editor-pane--half'
+                  ? previewStacked
+                    ? 'custom-scrollbar markdown-editor__editor-pane markdown-editor__editor-pane--stacked'
+                    : 'custom-scrollbar markdown-editor__editor-pane markdown-editor__editor-pane--half'
                   : 'custom-scrollbar markdown-editor__editor-pane markdown-editor__editor-pane--full'
               }
             >
@@ -633,11 +653,19 @@ const MarkdownEditor = (
             {showPreview && (
               <>
                 <div
-                  className="markdown-editor__divider"
+                  className={
+                    previewStacked ? 'markdown-editor__divider--stacked' : 'markdown-editor__divider'
+                  }
                   id="editor-preview-divider"
                 ></div>
 
-                <div className="markdown-editor__preview-container">
+                <div
+                  className={
+                    previewStacked
+                      ? 'markdown-editor__preview-container markdown-editor__preview-container--stacked'
+                      : 'markdown-editor__preview-container'
+                  }
+                >
                   {renderPreview()}
                 </div>
               </>

--- a/ui/leafwiki-ui/src/features/editor/MarkdownToolbar.test.tsx
+++ b/ui/leafwiki-ui/src/features/editor/MarkdownToolbar.test.tsx
@@ -82,7 +82,9 @@ describe('MarkdownToolbar paste controls', () => {
         editorRef={editorRef}
         pageId="page-1"
         previewVisible={false}
+        previewStacked={false}
         onTogglePreview={vi.fn()}
+        onTogglePreviewLayout={vi.fn()}
       />,
     )
 
@@ -98,7 +100,9 @@ describe('MarkdownToolbar paste controls', () => {
         editorRef={editorRef}
         pageId="page-1"
         previewVisible={false}
+        previewStacked={false}
         onTogglePreview={vi.fn()}
+        onTogglePreviewLayout={vi.fn()}
       />,
     )
 

--- a/ui/leafwiki-ui/src/features/editor/MarkdownToolbar.tsx
+++ b/ui/leafwiki-ui/src/features/editor/MarkdownToolbar.tsx
@@ -18,11 +18,13 @@ import {
   ClipboardType,
   Code,
   Code2,
+  Columns2,
   Eye,
   Image,
   Italic,
   Link,
   MoreHorizontal,
+  Rows2,
   Redo,
   Strikethrough,
   Table,
@@ -39,7 +41,9 @@ type Props = {
   onAssetVersionChange?: (version: number) => void
   pageId: string
   previewVisible: boolean
+  previewStacked: boolean
   onTogglePreview: () => void
+  onTogglePreviewLayout: () => void
 }
 
 export default function MarkdownToolbar({
@@ -47,7 +51,9 @@ export default function MarkdownToolbar({
   onAssetVersionChange,
   pageId,
   previewVisible,
+  previewStacked,
   onTogglePreview,
+  onTogglePreviewLayout,
 }: Props) {
   const { t } = useTranslation('editor')
   const openDialog = useDialogsStore((state) => state.openDialog)
@@ -517,6 +523,33 @@ export default function MarkdownToolbar({
         {!isMobile && (
           <>
             <div className="markdown-toolbar__separator" />
+            <TooltipWrapper
+              label={t(
+                previewStacked
+                  ? 'toolbar.previewSplitTooltip'
+                  : 'toolbar.previewStackedTooltip',
+              )}
+              side="top"
+              align="center"
+            >
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={onTogglePreviewLayout}
+                className={cn(
+                  'markdown-toolbar__button markdown-toolbar__button--desktop-only',
+                  {
+                    'markdown-toolbar__button--active': previewStacked,
+                  },
+                )}
+              >
+                {previewStacked ? (
+                  <Columns2 className="markdown-toolbar__icon" />
+                ) : (
+                  <Rows2 className="markdown-toolbar__icon" />
+                )}
+              </Button>
+            </TooltipWrapper>
             <TooltipWrapper
               label={t(
                 previewVisible

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -918,12 +918,28 @@
     @apply w-full;
   }
 
+  .markdown-editor__editor-pane--stacked {
+    @apply h-1/2 w-full;
+  }
+
+  .markdown-editor__stacked-layout {
+    @apply flex w-full flex-1 flex-col overflow-hidden;
+  }
+
   .markdown-editor__divider {
     @apply bg-surface-border h-full w-1;
   }
 
+  .markdown-editor__divider--stacked {
+    @apply bg-surface-border h-1 w-full;
+  }
+
   .markdown-editor__preview-container {
     @apply w-1/2 max-w-none flex-1;
+  }
+
+  .markdown-editor__preview-container--stacked {
+    @apply h-1/2 w-full max-w-none;
   }
 
   /* Preview styling */

--- a/ui/leafwiki-ui/src/locales/en/editor.json
+++ b/ui/leafwiki-ui/src/locales/en/editor.json
@@ -38,6 +38,8 @@
     "lineWrapEnableTooltip": "Enable line wrap",
     "lineWrapDisableTooltip": "Disable line wrap",
     "moreOptionsAriaLabel": "More formatting options",
+    "previewSplitTooltip": "Use side-by-side preview layout",
+    "previewStackedTooltip": "Use stacked preview layout",
     "showPreviewTooltip": "Show preview",
     "hidePreviewTooltip": "Hide preview",
     "pasteRichTooltip": "Paste with formatting (Ctrl+V)",

--- a/ui/leafwiki-ui/src/stores/editor.ts
+++ b/ui/leafwiki-ui/src/stores/editor.ts
@@ -7,6 +7,8 @@ type EditorStore = {
   previewVisible: boolean
   setPreviewVisible: (visible: boolean) => void
   togglePreview: () => void
+  previewStacked: boolean
+  togglePreviewLayout: () => void
   lineWrap: boolean
   toggleLineWrap: () => void
   autoSave: boolean
@@ -21,6 +23,9 @@ export const useEditorStore = create<EditorStore>()(
       previewVisible: true,
       setPreviewVisible: (visible) => set({ previewVisible: visible }),
       togglePreview: () => set({ previewVisible: !get().previewVisible }),
+      previewStacked: false,
+      togglePreviewLayout: () =>
+        set({ previewStacked: !get().previewStacked }),
       lineWrap: true,
       toggleLineWrap: () => set({ lineWrap: !get().lineWrap }),
       autoSave: true,
@@ -32,6 +37,7 @@ export const useEditorStore = create<EditorStore>()(
       name: 'leafwiki-editor-settings',
       partialize: (state) => ({
         previewVisible: state.previewVisible,
+        previewStacked: state.previewStacked,
         lineWrap: state.lineWrap,
         autoSave: state.autoSave,
       }),

--- a/ui/leafwiki-ui/src/stores/editor.ts
+++ b/ui/leafwiki-ui/src/stores/editor.ts
@@ -24,8 +24,7 @@ export const useEditorStore = create<EditorStore>()(
       setPreviewVisible: (visible) => set({ previewVisible: visible }),
       togglePreview: () => set({ previewVisible: !get().previewVisible }),
       previewStacked: false,
-      togglePreviewLayout: () =>
-        set({ previewStacked: !get().previewStacked }),
+      togglePreviewLayout: () => set({ previewStacked: !get().previewStacked }),
       lineWrap: true,
       toggleLineWrap: () => set({ lineWrap: !get().lineWrap }),
       autoSave: true,


### PR DESCRIPTION
## Summary
- Add a desktop toggle for preview layout in editor toolbar (side-by-side vs stacked).
- Persist layout preference in local settings.
- Add classes for stacked split behavior and tests for the new layout class.

Closes #1113