### PR TITLE
feat(tree): add rename action dialog

### DIFF
--- a/ui/leafwiki-ui/src/features/page/RenamePageDialog.test.tsx
+++ b/ui/leafwiki-ui/src/features/page/RenamePageDialog.test.tsx
@@ -1,0 +1,164 @@
+import { DIALOG_RENAME_PAGE } from '@/lib/registries'
+import { useConfigStore } from '@/stores/config'
+import { useDialogsStore } from '@/stores/dialogs'
+import { useTreeStore } from '@/stores/tree'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { RenamePageDialog } from './RenamePageDialog'
+
+vi.mock('@/lib/api/pages', () => ({
+  NODE_KIND_PAGE: 'page',
+  applyPageRefactor: vi.fn(),
+  getPageByPath: vi.fn(),
+  previewPageRefactor: vi.fn(),
+  updatePage: vi.fn(),
+}))
+
+vi.mock('@/features/page/pageRefactorDialogState', () => ({
+  confirmPageRefactor: vi.fn(),
+}))
+
+vi.mock('@/features/page/pageMutationRefresh', () => ({
+  refreshAfterPageRefactor: vi.fn(),
+}))
+
+import {
+  applyPageRefactor,
+  getPageByPath,
+  previewPageRefactor,
+  updatePage,
+} from '@/lib/api/pages'
+import { confirmPageRefactor } from '@/features/page/pageRefactorDialogState'
+import { refreshAfterPageRefactor } from '@/features/page/pageMutationRefresh'
+
+const mockApplyPageRefactor = applyPageRefactor as ReturnType<typeof vi.fn>
+const mockGetPageByPath = getPageByPath as ReturnType<typeof vi.fn>
+const mockPreviewPageRefactor = previewPageRefactor as ReturnType<typeof vi.fn>
+const mockUpdatePage = updatePage as ReturnType<typeof vi.fn>
+const mockConfirmPageRefactor = confirmPageRefactor as ReturnType<typeof vi.fn>
+const mockRefreshAfterPageRefactor = refreshAfterPageRefactor as ReturnType<
+  typeof vi.fn
+>
+
+const samplePage = {
+  id: 'page-1',
+  kind: 'page' as const,
+  title: 'Original title',
+  slug: 'original-title',
+  path: '/original-title',
+  version: 'v1',
+}
+
+describe('RenamePageDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useConfigStore.setState({
+      enableLinkRefactor: false,
+    })
+    useTreeStore.setState({
+      reloadTree: vi.fn().mockResolvedValue(undefined),
+    } as never)
+    useDialogsStore.setState({
+      dialogType: DIALOG_RENAME_PAGE,
+      dialogProps: null,
+    })
+    mockGetPageByPath.mockResolvedValue({
+      content: 'hello',
+      tags: [],
+      properties: {},
+    })
+    mockUpdatePage.mockResolvedValue({ ...samplePage })
+    mockApplyPageRefactor.mockResolvedValue({ ...samplePage })
+    mockPreviewPageRefactor.mockResolvedValue({
+      kind: 'rename',
+      pageId: 'page-1',
+      oldPath: '/original-title',
+      newPath: '/renamed-title',
+      affectedPages: [],
+      counts: {
+        affectedPages: 0,
+        matchedLinks: 0,
+      },
+      warnings: [],
+    })
+    mockConfirmPageRefactor.mockResolvedValue(false)
+    mockRefreshAfterPageRefactor.mockResolvedValue(undefined)
+  })
+
+  it('updates the page title and slug directly when link refactor is disabled', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <MemoryRouter initialEntries={['/e/original-title']}>
+        <RenamePageDialog
+          page={{ ...samplePage, parentId: undefined, path: 'original-title' }}
+        />
+      </MemoryRouter>,
+    )
+
+    await user.clear(screen.getByTestId('rename-page-title-input'))
+    await user.type(screen.getByTestId('rename-page-title-input'), 'Renamed title')
+    await user.clear(screen.getByTestId('rename-page-slug-input'))
+    await user.type(screen.getByTestId('rename-page-slug-input'), 'renamed-title')
+
+    await user.click(
+      screen.getByTestId('rename-page-dialog-button-confirm'),
+    )
+
+    expect(mockGetPageByPath).toHaveBeenCalledWith('original-title')
+    expect(mockUpdatePage).toHaveBeenCalledWith(
+      'page-1',
+      'v1',
+      'Renamed title',
+      'renamed-title',
+      'hello',
+      [],
+      {},
+    )
+    expect(mockApplyPageRefactor).not.toHaveBeenCalled()
+    expect(mockRefreshAfterPageRefactor).toHaveBeenCalled()
+  })
+
+  it('uses page refactor flow when link refactor is enabled', async () => {
+    useConfigStore.setState({
+      enableLinkRefactor: true,
+    })
+    mockConfirmPageRefactor.mockResolvedValue(true)
+
+    const user = userEvent.setup()
+
+    render(
+      <MemoryRouter initialEntries={['/e/original-title']}>
+        <RenamePageDialog
+          page={{ ...samplePage, parentId: undefined, path: 'original-title' }}
+        />
+      </MemoryRouter>,
+    )
+
+    await user.clear(screen.getByTestId('rename-page-title-input'))
+    await user.type(screen.getByTestId('rename-page-title-input'), 'Renamed title')
+    await user.clear(screen.getByTestId('rename-page-slug-input'))
+    await user.type(screen.getByTestId('rename-page-slug-input'), 'renamed-title')
+
+    await user.click(
+      screen.getByTestId('rename-page-dialog-button-confirm'),
+    )
+
+    expect(mockPreviewPageRefactor).toHaveBeenCalledWith('page-1', {
+      kind: 'rename',
+      title: 'Renamed title',
+      slug: 'renamed-title',
+    })
+    expect(mockApplyPageRefactor).toHaveBeenCalledWith('page-1', {
+      kind: 'rename',
+      version: 'v1',
+      title: 'Renamed title',
+      slug: 'renamed-title',
+      content: 'hello',
+      rewriteLinks: true,
+    })
+    expect(mockUpdatePage).not.toHaveBeenCalled()
+  })
+})

--- a/ui/leafwiki-ui/src/features/page/RenamePageDialog.tsx
+++ b/ui/leafwiki-ui/src/features/page/RenamePageDialog.tsx
@@ -1,0 +1,273 @@
+import BaseDialog, { BaseDialogConfirmButton } from '@/components/BaseDialog'
+import { FormInput } from '@/components/FormInput'
+import { Button } from '@/components/ui/button'
+import { handleFieldErrors } from '@/lib/handleFieldErrors'
+import {
+  applyPageRefactor,
+  getPageByPath,
+  NODE_KIND_PAGE,
+  PageNode,
+  PageRefactorPreview,
+  previewPageRefactor,
+  updatePage,
+} from '@/lib/api/pages'
+import { DIALOG_RENAME_PAGE } from '@/lib/registries'
+import { useConfigStore } from '@/stores/config'
+import { useTreeStore } from '@/stores/tree'
+import { CalendarDays } from 'lucide-react'
+import { useCallback, useMemo, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { toast } from 'sonner'
+import { SlugInputWithSuggestion } from './SlugInputWithSuggestion'
+import { confirmPageRefactor } from './pageRefactorDialogState'
+import { refreshAfterPageRefactor } from './pageMutationRefresh'
+
+type RenamePageDialogProps = {
+  page: Pick<
+    PageNode,
+    'id' | 'title' | 'slug' | 'path' | 'version' | 'parentId' | 'kind'
+  >
+}
+
+const DIALOG_INPUT_ALLOWED_HOTKEYS = 'Enter'
+
+function getSyntheticRenamePreview({
+  page,
+  newSlug,
+  parentPath,
+}: {
+  page: RenamePageDialogProps['page']
+  newSlug: string
+  parentPath: string
+}): PageRefactorPreview {
+  const normalizedParentPath =
+    parentPath && parentPath !== '/' ? parentPath : ''
+  const normalizedNewPath = normalizedParentPath
+    ? `${normalizedParentPath}/${newSlug}`
+    : `/${newSlug}`
+
+  return {
+    kind: 'rename',
+    pageId: page.id,
+    oldPath: page.path,
+    newPath: normalizedNewPath,
+    affectedPages: [],
+    counts: {
+      affectedPages: 0,
+      matchedLinks: 0,
+    },
+    warnings: [],
+  }
+}
+
+export function RenamePageDialog({ page }: RenamePageDialogProps) {
+  const [title, setTitle] = useState(page.title)
+  const [slug, setSlug] = useState(page.slug)
+  const [loading, setLoading] = useState(false)
+  const [slugLoading, setSlugLoading] = useState(false)
+  const [slugTouched, setSlugTouched] = useState(false)
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
+
+  const reloadTree = useTreeStore((state) => state.reloadTree)
+  const parentPath = useTreeStore((state) =>
+    page.parentId ? state.getPathById(page.parentId) ?? '' : '',
+  )
+  const enableLinkRefactor = useConfigStore((state) => state.enableLinkRefactor)
+  const navigate = useNavigate()
+  const location = useLocation()
+  const itemLabel = page.kind === NODE_KIND_PAGE ? 'Page' : 'Section'
+  const itemLabelLower = page.kind === NODE_KIND_PAGE ? 'page' : 'section'
+
+  const titleChanged = title !== page.title
+  const slugChanged = slug !== page.slug
+  const isRenameDisabled =
+    !title ||
+    !slug ||
+    loading ||
+    (!slugTouched && slugLoading) ||
+    (!titleChanged && !slugChanged)
+
+  const handleTitleChange = useCallback((value: string) => {
+    setTitle(value)
+    setFieldErrors((prev) => ({ ...prev, title: '' }))
+  }, [])
+
+  const handleSlugChange = useCallback((value: string) => {
+    setSlug(value)
+    setFieldErrors((prev) => ({ ...prev, slug: '' }))
+  }, [])
+
+  const resetForm = useCallback(() => {
+    setTitle(page.title)
+    setSlug(page.slug)
+    setSlugLoading(false)
+    setSlugTouched(false)
+    setFieldErrors({})
+    setLoading(false)
+  }, [page.title, page.slug])
+
+  const buildRenamePreview = useCallback(async () => {
+    if (!enableLinkRefactor) {
+      return getSyntheticRenamePreview({
+        page,
+        newSlug: slug,
+        parentPath,
+      })
+    }
+
+    return await previewPageRefactor(page.id, {
+      kind: 'rename',
+      title,
+      slug,
+    })
+  }, [enableLinkRefactor, page, parentPath, slug, title])
+
+  const handleRename = useCallback(async (): Promise<boolean> => {
+    if (!title || !slug || isRenameDisabled) return false
+    if (slugLoading && !slugTouched) {
+      toast.warning('Please wait until the slug is fully generated.')
+      return false
+    }
+
+    setLoading(true)
+    setFieldErrors({})
+    try {
+      const preview = await buildRenamePreview()
+      const rewriteLinks = await (enableLinkRefactor
+        ? confirmPageRefactor(preview, { allowSkipRewrite: true })
+        : Promise.resolve(false))
+
+      if (enableLinkRefactor && rewriteLinks === null) return false
+
+      const fullPage = await getPageByPath(page.path)
+
+      if (enableLinkRefactor) {
+        await applyPageRefactor(page.id, {
+          kind: 'rename',
+          version: page.version,
+          title,
+          slug,
+          content: fullPage.content,
+          rewriteLinks: rewriteLinks as boolean,
+        })
+      } else {
+        await updatePage(
+          page.id,
+          page.version,
+          title,
+          slug,
+          fullPage.content,
+          fullPage.tags ?? [],
+          fullPage.properties ?? {},
+        )
+      }
+
+      await refreshAfterPageRefactor({
+        preview,
+        currentPath: location.pathname,
+        navigate,
+      })
+      await reloadTree()
+      toast.success(`${itemLabel} renamed`)
+      return true
+    } catch (err: unknown) {
+      console.warn(err)
+      handleFieldErrors(err, setFieldErrors, `Error renaming ${itemLabelLower}`)
+      return false
+    } finally {
+      setLoading(false)
+    }
+  }, [
+    title,
+    slug,
+    isRenameDisabled,
+    slugLoading,
+    slugTouched,
+    buildRenamePreview,
+    enableLinkRefactor,
+    page.id,
+    page.path,
+    page.version,
+    location.pathname,
+    navigate,
+    reloadTree,
+    itemLabel,
+    itemLabelLower,
+  ])
+
+  const buttons = useMemo<BaseDialogConfirmButton[]>(
+    () => [
+      {
+        label: loading ? 'Renaming...' : `Rename ${itemLabel}`,
+        actionType: 'confirm',
+        autoFocus: true,
+        loading,
+        disabled: isRenameDisabled,
+        variant: 'default',
+      },
+    ],
+    [itemLabel, loading, isRenameDisabled],
+  )
+
+  return (
+    <BaseDialog
+      dialogType={DIALOG_RENAME_PAGE}
+      dialogTitle={`Rename ${itemLabel}`}
+      dialogDescription={`Rename this ${itemLabelLower} and optionally update its slug`}
+      onClose={resetForm}
+      onConfirm={async () => await handleRename()}
+      testidPrefix="rename-page-dialog"
+      cancelButton={{
+        label: 'Cancel',
+        variant: 'outline',
+        autoFocus: false,
+        disabled: loading,
+      }}
+      buttons={buttons}
+    >
+      <div className="page-dialog__fields">
+        <div className="page-dialog__title-row">
+          <FormInput
+            autoFocus
+            label="Title"
+            value={title}
+            onChange={(value) => handleTitleChange(value)}
+            testid="rename-page-title-input"
+            placeholder={`${itemLabel} title`}
+            error={fieldErrors.title}
+            allowedHotkeys={DIALOG_INPUT_ALLOWED_HOTKEYS}
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="page-dialog__date-btn"
+            title="Set title to today"
+            onClick={() =>
+              handleTitleChange(new Date().toISOString().slice(0, 10))
+            }
+          >
+            <CalendarDays size={15} />
+          </Button>
+        </div>
+        <SlugInputWithSuggestion
+          title={title}
+          slug={slug}
+          testid="rename-page-slug-input"
+          parentId={page.parentId || ''}
+          currentId={page.id}
+          initialTitle={page.title}
+          onSlugChange={handleSlugChange}
+          onSlugTouchedChange={setSlugTouched}
+          onSlugLoadingChange={setSlugLoading}
+          error={fieldErrors.slug}
+          allowedHotkeys={DIALOG_INPUT_ALLOWED_HOTKEYS}
+        />
+      </div>
+      <span className="dialog__path" data-testid="rename-page-path-display">
+        Path: {parentPath !== '' && `${parentPath}/`}
+        {slug && `${slug}`}
+      </span>
+    </BaseDialog>
+  )
+}

--- a/ui/leafwiki-ui/src/features/tree/TreeNodeActionsMenu.tsx
+++ b/ui/leafwiki-ui/src/features/tree/TreeNodeActionsMenu.tsx
@@ -18,6 +18,7 @@ import {
   DIALOG_COPY_PAGE,
   DIALOG_DELETE_PAGE_CONFIRMATION,
   DIALOG_MOVE_PAGE,
+  DIALOG_RENAME_PAGE,
   DIALOG_SORT_PAGES,
 } from '@/lib/registries'
 import { stripBasePath } from '@/lib/routePath'
@@ -161,6 +162,25 @@ export default function TreeNodeActionsMenu({
           }}
         >
           <Pencil size={18} className="tree-node__action-icon" /> Edit{' '}
+          {nodeKind === NODE_KIND_PAGE ? 'Page' : 'Section'}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          className="cursor-pointer"
+          onClick={() =>
+            openDialog(DIALOG_RENAME_PAGE, {
+              page: {
+                id: nodeId,
+                kind: nodeKind,
+                title: node.title,
+                slug: node.slug,
+                path: node.path,
+                version: nodeVersion,
+                parentId: node.parentId,
+              },
+            })
+          }
+        >
+          <Pencil size={18} className="tree-node__action-icon" /> Rename{' '}
           {nodeKind === NODE_KIND_PAGE ? 'Page' : 'Section'}
         </DropdownMenuItem>
         {nodeKind === NODE_KIND_PAGE && (

--- a/ui/leafwiki-ui/src/lib/registries/index.tsx
+++ b/ui/leafwiki-ui/src/lib/registries/index.tsx
@@ -16,6 +16,7 @@ import {
   ImagePreviewDialog,
   LinkInsertDialog,
   MovePageDialog,
+  RenamePageDialog,
   PageQuickSwitcherDialog,
   PageRefactorDialog,
   PermalinkDialog,
@@ -64,6 +65,7 @@ panelItemRegistry.register({
 export const DIALOG_ADD_PAGE = 'add-page'
 export const DIALOG_SORT_PAGES = 'sort-pages'
 export const DIALOG_MOVE_PAGE = 'move-page'
+export const DIALOG_RENAME_PAGE = 'rename-page'
 export const DIALOG_CREATE_PAGE_BY_PATH = 'create-page-by-path'
 export const DIALOG_COPY_PAGE = 'copy-page'
 export const DIALOG_EDIT_PAGE_METADATA = 'edit-page-metadata'
@@ -115,6 +117,18 @@ dialogRegistry.register({
       <MovePageDialog
         key={DIALOG_MOVE_PAGE}
         {...(props as React.ComponentProps<typeof MovePageDialog>)}
+      />
+    )
+  },
+})
+
+dialogRegistry.register({
+  type: DIALOG_RENAME_PAGE,
+  render: (props) => {
+    return (
+      <RenamePageDialog
+        key={DIALOG_RENAME_PAGE}
+        {...(props as React.ComponentProps<typeof RenamePageDialog>)}
       />
     )
   },

--- a/ui/leafwiki-ui/src/lib/registries/lazy-dialogs.tsx
+++ b/ui/leafwiki-ui/src/lib/registries/lazy-dialogs.tsx
@@ -65,6 +65,11 @@ export const MovePageDialog = lazy(() =>
     default: m.MovePageDialog,
   })),
 )
+export const RenamePageDialog = lazy(() =>
+  import('@/features/page/RenamePageDialog').then((m) => ({
+    default: m.RenamePageDialog,
+  })),
+)
 export const PermalinkDialog = lazy(
   () => import('@/features/page/PermalinkDialog'),
 )


### PR DESCRIPTION
Adds a tree node rename action and dialog wired into the existing registry and action menu.