### PR TITLE
docs(contributing): clarify issue/discussion workflow and require linked PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ideas & Questions
+    url: https://github.com/perber/leafwiki/discussions
+    about: Not sure if it's a bug or a clearly scoped feature yet? Start a discussion first — see CONTRIBUTING.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Propose a clearly scoped feature or change
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Problem / use case
+
+<!-- What problem does this solve? Why is existing functionality insufficient? -->
+
+## Proposed behavior
+
+<!-- Rough idea of the expected behavior -->
+
+## Is this ready to be implemented, or does it need discussion first?
+
+<!-- If the scope or approach is still open, please open a Discussion instead:
+     https://github.com/perber/leafwiki/discussions -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Related issue
+
+<!-- Every PR must reference an existing issue. Example: Fixes #123 -->
+Fixes #
+
+## What changed
+
+<!-- Short description of the change -->
+
+## Checklist
+
+- [ ] I discussed the approach on the linked issue before starting (or this is a trivial fix: typo, docs, obvious one-liner)
+- [ ] This PR is focused on a single change
+- [ ] I ran `npm run format` in `ui/leafwiki-ui` (and in `e2e` if e2e tests changed)
+- [ ] I updated documentation if needed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,32 @@ If you're unsure whether something is worth contributing — **open an issue and
 
 ---
 
+## Issues vs. Discussions
+
+LeafWiki uses both **GitHub Issues** and **GitHub Discussions** — they serve different purposes:
+
+- **Discussions** are for anything that isn't clearly scoped yet: ideas, "what if we...", questions about usage, architecture debates, or feature proposals that need back-and-forth before they're actionable.
+- **Issues** are for concrete, actionable work: confirmed bugs, and features/changes that are clearly scoped and ready to be implemented.
+
+If you're unsure whether your idea is ready to be an issue, **start a discussion first**. A maintainer will turn it into an issue once the scope and approach are clear. This avoids issues sitting around with unresolved design questions that end up being implemented in conflicting ways.
+
+---
+
+## Picking up an issue
+
+Issues labeled **`good first issue`** or **`help wanted`** are ready to go — feel free to open a PR directly, no need to ask first.
+
+For everything else, please don't jump straight to a PR without working through it first:
+
+1. **Comment on the issue** that you'd like to work on it.
+2. If anything about the scope or approach is unclear, **ask in the issue** before writing code. Don't guess and let the PR "answer" the open question — that usually leads to rework or a rejected PR.
+3. Wait for a maintainer to confirm the issue is ready to be picked up. This also avoids two people working on the same issue at the same time.
+4. Once confirmed, open your PR and reference the issue (see [Pull request guidelines](#pull-request-guidelines)).
+
+This applies to anything beyond trivial fixes (typos, obvious one-line bugs, docs). For those, feel free to open a PR directly.
+
+---
+
 ## Project principles
 
 LeafWiki intentionally follows a small set of design principles.
@@ -87,9 +113,9 @@ If you change the e2e tests, please also run `npm run format` in the `e2e` direc
 
 To keep reviews efficient, please follow these guidelines:
 
+- **Every PR must reference an existing issue** (e.g. `Fixes #123`). PRs without a linked issue — or that weren't discussed on the issue first — may be closed and asked to go through the [issue process](#picking-up-an-issue) instead.
 - Keep pull requests **small and focused**
 - Clearly **describe the change**
-- Reference related **issues**
 - Avoid unrelated formatting changes
 - Update documentation if necessary
 


### PR DESCRIPTION
Contributors were opening PRs directly on issues without discussing scope or approach first, leading to duplicate work and rejected PRs. Adds explicit guidance on Issues vs. Discussions, an issue pickup process, a PR template requiring a linked issue, and a feature request issue template.