### PR TITLE
feat(editor): make preview split resizable

### DIFF
--- a/ui/leafwiki-ui/src/features/editor/MarkdownEditor.test.tsx
+++ b/ui/leafwiki-ui/src/features/editor/MarkdownEditor.test.tsx
@@ -232,7 +232,7 @@ describe('MarkdownEditor – breakpoint remount preserves content', () => {
     expect(divider).toHaveAttribute('aria-valuenow', '60')
   })
 
-  it('does not resize panes in stacked desktop preview mode', () => {
+  it('resizes stacked desktop panes when dragging the divider vertically', () => {
     mockEditorState = {
       ...mockEditorState,
       previewVisible: true,
@@ -248,16 +248,24 @@ describe('MarkdownEditor – breakpoint remount preserves content', () => {
     )
 
     const divider = getByTestId('editor-preview-resize-handle')
+    const layout = divider.parentElement as HTMLDivElement
+    layout.getBoundingClientRect = vi.fn(
+      () =>
+        ({
+          height: 1000,
+        }) as DOMRect,
+    )
 
-    fireEvent.mouseDown(divider, { clientX: 500 })
-    fireEvent.mouseMove(document, { clientX: 600 })
+    fireEvent.mouseDown(divider, { clientY: 500 })
+    fireEvent.mouseMove(document, { clientY: 600 })
     fireEvent.mouseUp(document)
 
     const editorPane = container.querySelector(
       '.markdown-editor__editor-pane--stacked',
     ) as HTMLDivElement
 
-    expect(editorPane.style.flex).toBe('')
-    expect(divider).not.toHaveAttribute('aria-valuenow')
+    expect(editorPane.style.flex).toBe('0 0 60%')
+    expect(divider).toHaveAttribute('aria-valuenow', '60')
+    expect(divider).toHaveAttribute('aria-orientation', 'horizontal')
   })
 })

--- a/ui/leafwiki-ui/src/features/editor/MarkdownEditor.test.tsx
+++ b/ui/leafwiki-ui/src/features/editor/MarkdownEditor.test.tsx
@@ -1,4 +1,4 @@
-import { act, render } from '@testing-library/react'
+import { act, fireEvent, render } from '@testing-library/react'
 import { useEffect, useRef } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import MarkdownEditor from './MarkdownEditor'
@@ -100,6 +100,7 @@ describe('MarkdownEditor – breakpoint remount preserves content', () => {
   beforeEach(() => {
     mountSpy.mockClear()
     capturedOnChange = null
+    window.localStorage.clear()
     mockIsMobile = false
     mockEditorState = {
       ...mockEditorState,
@@ -193,5 +194,70 @@ describe('MarkdownEditor – breakpoint remount preserves content', () => {
 
     expect(layout).not.toBeNull()
     expect(divider).not.toBeNull()
+  })
+
+  it('resizes side-by-side desktop panes when dragging the divider', () => {
+    mockEditorState = {
+      ...mockEditorState,
+      previewVisible: true,
+      previewStacked: false,
+    }
+
+    const { getByTestId, container } = render(
+      <MarkdownEditor
+        initialValue="original content"
+        pageId="page-1"
+        onChange={vi.fn()}
+      />,
+    )
+
+    const divider = getByTestId('editor-preview-resize-handle')
+    const layout = divider.parentElement as HTMLDivElement
+    layout.getBoundingClientRect = vi.fn(
+      () =>
+        ({
+          width: 1000,
+        }) as DOMRect,
+    )
+
+    fireEvent.mouseDown(divider, { clientX: 500 })
+    fireEvent.mouseMove(document, { clientX: 600 })
+    fireEvent.mouseUp(document)
+
+    const editorPane = container.querySelector(
+      '.markdown-editor__editor-pane--half',
+    ) as HTMLDivElement
+
+    expect(editorPane.style.flex).toBe('0 0 60%')
+    expect(divider).toHaveAttribute('aria-valuenow', '60')
+  })
+
+  it('does not resize panes in stacked desktop preview mode', () => {
+    mockEditorState = {
+      ...mockEditorState,
+      previewVisible: true,
+      previewStacked: true,
+    }
+
+    const { getByTestId, container } = render(
+      <MarkdownEditor
+        initialValue="original content"
+        pageId="page-1"
+        onChange={vi.fn()}
+      />,
+    )
+
+    const divider = getByTestId('editor-preview-resize-handle')
+
+    fireEvent.mouseDown(divider, { clientX: 500 })
+    fireEvent.mouseMove(document, { clientX: 600 })
+    fireEvent.mouseUp(document)
+
+    const editorPane = container.querySelector(
+      '.markdown-editor__editor-pane--stacked',
+    ) as HTMLDivElement
+
+    expect(editorPane.style.flex).toBe('')
+    expect(divider).not.toHaveAttribute('aria-valuenow')
   })
 })

--- a/ui/leafwiki-ui/src/features/editor/MarkdownEditor.tsx
+++ b/ui/leafwiki-ui/src/features/editor/MarkdownEditor.tsx
@@ -577,21 +577,25 @@ const MarkdownEditor = (
   )
 
   const handleSplitResize = (event: ReactMouseEvent<HTMLDivElement>) => {
-    if (isMobile || previewStacked || !showPreview) return
+    if (isMobile || !showPreview) return
 
     event.preventDefault()
     event.stopPropagation()
 
-    const startX = event.clientX
+    const startPosition = previewStacked ? event.clientY : event.clientX
     const startWidth = editorPaneWidth
-    const splitWidth =
-      desktopSplitRef.current?.getBoundingClientRect().width ||
-      window.innerWidth
+    const splitRect = desktopSplitRef.current?.getBoundingClientRect()
+    const splitSize =
+      (previewStacked ? splitRect?.height : splitRect?.width) ||
+      (previewStacked ? window.innerHeight : window.innerWidth)
 
     const onMouseMove = (moveEvent: MouseEvent) => {
-      const delta = moveEvent.clientX - startX
+      const currentPosition = previewStacked
+        ? moveEvent.clientY
+        : moveEvent.clientX
+      const delta = currentPosition - startPosition
       const nextWidth = clampEditorPaneWidth(
-        startWidth + (delta / splitWidth) * 100,
+        startWidth + (delta / splitSize) * 100,
       )
 
       liveEditorPaneWidthRef.current = nextWidth
@@ -747,9 +751,7 @@ const MarkdownEditor = (
                   : 'custom-scrollbar markdown-editor__editor-pane markdown-editor__editor-pane--full'
               }
               style={
-                showPreview && !previewStacked
-                  ? { flex: `0 0 ${editorPaneWidth}%` }
-                  : undefined
+                showPreview ? { flex: `0 0 ${editorPaneWidth}%` } : undefined
               }
             >
               {renderEditor(false)}
@@ -760,7 +762,11 @@ const MarkdownEditor = (
                 <div
                   className={
                     previewStacked
-                      ? 'markdown-editor__divider--stacked'
+                      ? `markdown-editor__divider markdown-editor__divider--stacked ${
+                          isResizingSplit
+                            ? 'markdown-editor__divider--active'
+                            : ''
+                        }`
                       : `markdown-editor__divider ${
                           isResizingSplit
                             ? 'markdown-editor__divider--active'
@@ -774,9 +780,7 @@ const MarkdownEditor = (
                   aria-label="Resize editor and preview panes"
                   aria-valuemin={MIN_EDITOR_PANE_WIDTH}
                   aria-valuemax={MAX_EDITOR_PANE_WIDTH}
-                  aria-valuenow={
-                    previewStacked ? undefined : Math.round(editorPaneWidth)
-                  }
+                  aria-valuenow={Math.round(editorPaneWidth)}
                   data-testid="editor-preview-resize-handle"
                 />
 
@@ -787,7 +791,9 @@ const MarkdownEditor = (
                       : 'markdown-editor__preview-container'
                   }
                   style={
-                    previewStacked ? undefined : { flex: '1 1 0', minWidth: 0 }
+                    previewStacked
+                      ? { flex: '1 1 0', minHeight: 0 }
+                      : { flex: '1 1 0', minWidth: 0 }
                   }
                 >
                   {renderPreview()}

--- a/ui/leafwiki-ui/src/features/editor/MarkdownEditor.tsx
+++ b/ui/leafwiki-ui/src/features/editor/MarkdownEditor.tsx
@@ -7,6 +7,7 @@ import {
   ClipboardEvent,
   forwardRef,
   JSX,
+  MouseEvent as ReactMouseEvent,
   useCallback,
   useEffect,
   useImperativeHandle,
@@ -57,6 +58,26 @@ type Props = {
   pageId: string
 }
 
+const DEFAULT_EDITOR_PANE_WIDTH = 50
+const MIN_EDITOR_PANE_WIDTH = 25
+const MAX_EDITOR_PANE_WIDTH = 75
+const EDITOR_PANE_WIDTH_STORAGE_KEY = 'leafwiki-editor-pane-width'
+
+function clampEditorPaneWidth(value: number) {
+  return Math.min(MAX_EDITOR_PANE_WIDTH, Math.max(MIN_EDITOR_PANE_WIDTH, value))
+}
+
+function getInitialEditorPaneWidth() {
+  if (typeof window === 'undefined') return DEFAULT_EDITOR_PANE_WIDTH
+
+  const storedValue = window.localStorage.getItem(EDITOR_PANE_WIDTH_STORAGE_KEY)
+  const parsed = Number.parseFloat(storedValue ?? '')
+
+  if (Number.isNaN(parsed)) return DEFAULT_EDITOR_PANE_WIDTH
+
+  return clampEditorPaneWidth(parsed)
+}
+
 const MarkdownEditor = (
   { initialValue = '', onChange, pageId }: Props,
   ref: React.ForwardedRef<MarkdownEditorRef>,
@@ -88,6 +109,7 @@ const MarkdownEditor = (
 
   const { t } = useTranslation('editor')
   const previewRef = useRef<HTMLDivElement | null>(null)
+  const desktopSplitRef = useRef<HTMLDivElement | null>(null)
 
   const setPreviewRef = useCallback((node: HTMLDivElement | null) => {
     if (node) {
@@ -98,9 +120,18 @@ const MarkdownEditor = (
   const editorViewRef = useRef<EditorView | null>(null)
   const rafRef = useRef<number | null>(null)
   const currentCursorLineRef = useRef<number | null>(null)
+  const liveEditorPaneWidthRef = useRef(DEFAULT_EDITOR_PANE_WIDTH)
+  const resizeHandlersRef = useRef<{
+    onMouseMove: (event: MouseEvent) => void
+    onMouseUp: () => void
+  } | null>(null)
   const [assetVersion, setAssetVersion] = useState(() => Date.now()) // Initial version based on current timestamp
 
   const [markdown, setMarkdown] = useState(initialValue)
+  const [editorPaneWidth, setEditorPaneWidth] = useState(
+    getInitialEditorPaneWidth,
+  )
+  const [isResizingSplit, setIsResizingSplit] = useState(false)
   const debouncedPreview = useDebounce(markdown, 100)
   const isMobile = useIsMobile()
   const maxAssetUploadSizeBytes = useConfigStore(
@@ -116,6 +147,18 @@ const MarkdownEditor = (
   } = useEditorStore()
 
   const [activeTab, setActiveTab] = useState<'editor' | 'preview'>('editor')
+
+  useEffect(() => {
+    liveEditorPaneWidthRef.current = editorPaneWidth
+  }, [editorPaneWidth])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    window.localStorage.setItem(
+      EDITOR_PANE_WIDTH_STORAGE_KEY,
+      String(editorPaneWidth),
+    )
+  }, [editorPaneWidth])
 
   // Handles paste requests.
   // This allows to paste images from clipboard directly into the editor.
@@ -509,6 +552,62 @@ const MarkdownEditor = (
     }
   }, [assetVersion, debouncedPreview, scrollPreviewToLine, showPreview])
 
+  useEffect(() => {
+    if (!isResizingSplit || !resizeHandlersRef.current) return
+
+    const { onMouseMove, onMouseUp } = resizeHandlersRef.current
+    document.addEventListener('mousemove', onMouseMove)
+    document.addEventListener('mouseup', onMouseUp)
+
+    return () => {
+      document.removeEventListener('mousemove', onMouseMove)
+      document.removeEventListener('mouseup', onMouseUp)
+    }
+  }, [isResizingSplit])
+
+  useEffect(
+    () => () => {
+      if (!resizeHandlersRef.current) return
+
+      const { onMouseMove, onMouseUp } = resizeHandlersRef.current
+      document.removeEventListener('mousemove', onMouseMove)
+      document.removeEventListener('mouseup', onMouseUp)
+    },
+    [],
+  )
+
+  const handleSplitResize = (event: ReactMouseEvent<HTMLDivElement>) => {
+    if (isMobile || previewStacked || !showPreview) return
+
+    event.preventDefault()
+    event.stopPropagation()
+
+    const startX = event.clientX
+    const startWidth = editorPaneWidth
+    const splitWidth =
+      desktopSplitRef.current?.getBoundingClientRect().width ||
+      window.innerWidth
+
+    const onMouseMove = (moveEvent: MouseEvent) => {
+      const delta = moveEvent.clientX - startX
+      const nextWidth = clampEditorPaneWidth(
+        startWidth + (delta / splitWidth) * 100,
+      )
+
+      liveEditorPaneWidthRef.current = nextWidth
+      setEditorPaneWidth(nextWidth)
+    }
+
+    const onMouseUp = () => {
+      setEditorPaneWidth(liveEditorPaneWidthRef.current)
+      setIsResizingSplit(false)
+      resizeHandlersRef.current = null
+    }
+
+    resizeHandlersRef.current = { onMouseMove, onMouseUp }
+    setIsResizingSplit(true)
+  }
+
   const renderToolbar = useCallback((): JSX.Element => {
     return (
       <MarkdownToolbar
@@ -632,6 +731,7 @@ const MarkdownEditor = (
         <div className="flex h-full w-full flex-col">
           {renderToolbar()}
           <div
+            ref={desktopSplitRef}
             className={
               previewStacked && showPreview
                 ? 'markdown-editor__stacked-layout'
@@ -646,6 +746,11 @@ const MarkdownEditor = (
                     : 'custom-scrollbar markdown-editor__editor-pane markdown-editor__editor-pane--half'
                   : 'custom-scrollbar markdown-editor__editor-pane markdown-editor__editor-pane--full'
               }
+              style={
+                showPreview && !previewStacked
+                  ? { flex: `0 0 ${editorPaneWidth}%` }
+                  : undefined
+              }
             >
               {renderEditor(false)}
             </div>
@@ -656,16 +761,33 @@ const MarkdownEditor = (
                   className={
                     previewStacked
                       ? 'markdown-editor__divider--stacked'
-                      : 'markdown-editor__divider'
+                      : `markdown-editor__divider ${
+                          isResizingSplit
+                            ? 'markdown-editor__divider--active'
+                            : ''
+                        }`
                   }
                   id="editor-preview-divider"
-                ></div>
+                  onMouseDown={handleSplitResize}
+                  role="separator"
+                  aria-orientation={previewStacked ? 'horizontal' : 'vertical'}
+                  aria-label="Resize editor and preview panes"
+                  aria-valuemin={MIN_EDITOR_PANE_WIDTH}
+                  aria-valuemax={MAX_EDITOR_PANE_WIDTH}
+                  aria-valuenow={
+                    previewStacked ? undefined : Math.round(editorPaneWidth)
+                  }
+                  data-testid="editor-preview-resize-handle"
+                />
 
                 <div
                   className={
                     previewStacked
                       ? 'markdown-editor__preview-container markdown-editor__preview-container--stacked'
                       : 'markdown-editor__preview-container'
+                  }
+                  style={
+                    previewStacked ? undefined : { flex: '1 1 0', minWidth: 0 }
                   }
                 >
                   {renderPreview()}

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -927,7 +927,12 @@
   }
 
   .markdown-editor__divider {
-    @apply bg-surface-border h-full w-1;
+    @apply bg-surface-border h-full w-1 shrink-0 cursor-col-resize transition-colors duration-200;
+  }
+
+  .markdown-editor__divider:hover,
+  .markdown-editor__divider--active {
+    @apply bg-brand-light;
   }
 
   .markdown-editor__divider--stacked {

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -936,7 +936,7 @@
   }
 
   .markdown-editor__divider--stacked {
-    @apply bg-surface-border h-1 w-full;
+    @apply h-1 w-full cursor-row-resize;
   }
 
   .markdown-editor__preview-container {

--- a/ui/leafwiki-ui/src/test-setup.ts
+++ b/ui/leafwiki-ui/src/test-setup.ts
@@ -1,1 +1,17 @@
 import '@testing-library/jest-dom'
+
+if (typeof window !== 'undefined' && !window.localStorage) {
+  const storage = new Map<string, string>()
+
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      clear: () => storage.clear(),
+      getItem: (key: string) => storage.get(key) ?? null,
+      removeItem: (key: string) => storage.delete(key),
+      setItem: (key: string, value: string) => {
+        storage.set(key, value)
+      },
+    },
+    configurable: true,
+  })
+}


### PR DESCRIPTION
## Related issue

Fixes #1114

## What changed

Added a draggable divider for the desktop editor/preview split and kept the existing stacked/mobile layouts unchanged.

## Checklist

- [x] This is for an issue labeled `good first issue` / `help wanted`
- [x] This PR is focused on a single change
- [x] I ran `npm run format` in `ui/leafwiki-ui`
- [x] I updated documentation if needed
