### PR TITLE
fix(editor): reset editor store on unmount so rename isn't blocked after closing

### DIFF
--- a/e2e/pages/TreeView.ts
+++ b/e2e/pages/TreeView.ts
@@ -43,7 +43,8 @@ export default class TreeView {
     expectedActionTestId:
       | 'tree-view-action-button-sort'
       | 'tree-view-action-button-move'
-      | 'tree-view-action-button-delete',
+      | 'tree-view-action-button-delete'
+      | 'tree-view-action-button-rename',
   ) {
     await nodeRow.waitFor({ state: 'visible' });
     await nodeRow.scrollIntoViewIfNeeded();
@@ -249,6 +250,24 @@ export default class TreeView {
     );
     await expect(moveButton).toBeVisible();
     await moveButton.click();
+  }
+
+  async openRenameDialogForPage(pageTitle: string, parentPage?: string) {
+    await this.ensureSidebarVisible();
+    await this.closeBlockingOverlayIfPresent();
+
+    if (parentPage) {
+      await this.expandNodeByTitle(parentPage);
+    }
+
+    const nodeRow = this.getNodeRowByTitle(pageTitle);
+    await this.openMoreActionsMenuForNodeRow(nodeRow, 'tree-view-action-button-rename');
+
+    const renameButton = this.page.locator(
+      '[role="menuitem"][data-testid="tree-view-action-button-rename"]',
+    );
+    await expect(renameButton).toBeVisible();
+    await renameButton.click();
   }
 
   async openDeleteDialogForPage(pageTitle: string, parentPage?: string) {

--- a/e2e/tests/editor.spec.ts
+++ b/e2e/tests/editor.spec.ts
@@ -187,8 +187,7 @@ async function expectPreviewHeadingVisible(page: Page, headingText: string) {
 
             const headings = Array.from(preview.querySelectorAll('h1, h2, h3, h4, h5, h6'));
             const heading = headings.find((element) => element.textContent?.includes(text)) as
-              | HTMLElement
-              | undefined;
+              HTMLElement | undefined;
 
             if (!heading) return false;
 
@@ -213,8 +212,7 @@ async function expectPreviewHeadingVisible(page: Page, headingText: string) {
 
       const headings = Array.from(preview.querySelectorAll('h1, h2, h3, h4, h5, h6'));
       const heading = headings.find((element) => element.textContent?.includes(text)) as
-        | HTMLElement
-        | undefined;
+        HTMLElement | undefined;
 
       if (!heading) {
         return null;

--- a/e2e/tests/editor.spec.ts
+++ b/e2e/tests/editor.spec.ts
@@ -3,7 +3,9 @@ import { join } from 'node:path';
 import test, { Page, expect } from '@playwright/test';
 import { getCsrfScript } from '../helpers/api';
 import EditPage from '../pages/EditPage';
+import EditPageMetadataDialog from '../pages/EditPageMetadataDialog';
 import LoginPage from '../pages/LoginPage';
+import TreeView from '../pages/TreeView';
 import ViewPage from '../pages/ViewPage';
 
 const user = process.env.E2E_ADMIN_USER || 'admin';
@@ -185,7 +187,8 @@ async function expectPreviewHeadingVisible(page: Page, headingText: string) {
 
             const headings = Array.from(preview.querySelectorAll('h1, h2, h3, h4, h5, h6'));
             const heading = headings.find((element) => element.textContent?.includes(text)) as
-              HTMLElement | undefined;
+              | HTMLElement
+              | undefined;
 
             if (!heading) return false;
 
@@ -210,7 +213,8 @@ async function expectPreviewHeadingVisible(page: Page, headingText: string) {
 
       const headings = Array.from(preview.querySelectorAll('h1, h2, h3, h4, h5, h6'));
       const heading = headings.find((element) => element.textContent?.includes(text)) as
-        HTMLElement | undefined;
+        | HTMLElement
+        | undefined;
 
       if (!heading) {
         return null;
@@ -759,6 +763,45 @@ test.describe('Editor', () => {
         ).toBeGreaterThan(100);
       }
     }
+  });
+
+  // ── Editor lifecycle ────────────────────────────────────────────────────────
+
+  test('rename-via-tree-is-not-blocked-after-closing-editor', async ({ page }) => {
+    const stamp = Date.now();
+    const slug = `editor-rename-after-close-${stamp}`;
+    const title = `Editor Rename After Close ${stamp}`;
+    const renamedTitle = `${title} Renamed`;
+
+    await createPageWithMetadata(page, {
+      title,
+      slug,
+      content: 'Content.',
+    });
+
+    const viewPage = new ViewPage(page);
+    await viewPage.goto(`/${slug}`);
+    await viewPage.clickEditPageButton();
+
+    const editPage = new EditPage(page);
+    await editPage.expectEditorStillOpen();
+    await editPage.closeEditor();
+
+    // Regression: the editor store used to keep `page` populated after the
+    // editor unmounted, so renaming this same page via the tree's "..." menu
+    // was permanently blocked by a stale "currently being edited" toast even
+    // though the editor was already closed.
+    const treeView = new TreeView(page);
+    await treeView.openRenameDialogForPage(title);
+
+    const metadataDialog = new EditPageMetadataDialog(page);
+    await metadataDialog.fillTitle(renamedTitle);
+    await metadataDialog.submit();
+
+    await expect(page.getByText('currently being edited')).not.toBeVisible();
+    await page.getByText('renamed successfully').waitFor({ state: 'visible' });
+    await page.waitForURL(new RegExp(`/${slug}-renamed$`));
+    await expect(page.locator('.breadcrumbs-nav__current')).toHaveText(renamedTitle);
   });
 });
 

--- a/ui/leafwiki-ui/src/features/editor/PageEditor.tsx
+++ b/ui/leafwiki-ui/src/features/editor/PageEditor.tsx
@@ -67,6 +67,17 @@ export default function PageEditor() {
     openNode(initialPage.id)
   }, [openNode, initialPage?.id])
 
+  // Reset the editor store on unmount so stale `page` data (and thus
+  // currentEditorPageId reads elsewhere) doesn't outlive the editor session.
+  // Declared after useAutoSave() so its cleanup runs after useAutoSave's own
+  // unmount cleanup, which may synchronously kick off a flush save that reads
+  // store state before it's cleared here.
+  useEffect(() => {
+    return () => {
+      usePageEditorStore.getState().resetEditorState()
+    }
+  }, [])
+
   // callbacks to save / close
   const handleSave = useCallback(() => {
     savePage()

--- a/ui/leafwiki-ui/src/features/editor/pageEditorStore.test.ts
+++ b/ui/leafwiki-ui/src/features/editor/pageEditorStore.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { Page } from '@/lib/api/pages'
+import { usePageEditorStore } from './pageEditorStore'
+
+const fakePage: Page = {
+  id: 'page-1',
+  title: 'Getting Started',
+  slug: 'getting-started',
+  path: 'docs/getting-started',
+  kind: 'page',
+  content: 'Hello world',
+  version: 'v1',
+  tags: ['guide'],
+  properties: { owner: 'alice' },
+} as Page
+
+describe('pageEditorStore.resetEditorState', () => {
+  beforeEach(() => {
+    usePageEditorStore.setState(usePageEditorStore.getInitialState())
+  })
+
+  it('clears page back to null so stale currentEditorPageId reads disappear', () => {
+    usePageEditorStore.setState({
+      page: fakePage,
+      initialPage: fakePage,
+      title: fakePage.title,
+      slug: fakePage.slug,
+      content: fakePage.content,
+      tags: fakePage.tags,
+      frontmatterFields: [{ key: 'owner', value: 'alice', type: 'text' }],
+      notFound: true,
+      error: 'stale error',
+    })
+
+    usePageEditorStore.getState().resetEditorState()
+
+    const state = usePageEditorStore.getState()
+    expect(state.page).toBeNull()
+    expect(state.initialPage).toBeNull()
+    expect(state.title).toBe('')
+    expect(state.slug).toBe('')
+    expect(state.content).toBe('')
+    expect(state.tags).toEqual([])
+    expect(state.frontmatterFields).toEqual([])
+    expect(state.notFound).toBe(false)
+    expect(state.error).toBeNull()
+  })
+
+  it('leaves the store in a clean state when nothing was ever loaded', () => {
+    usePageEditorStore.getState().resetEditorState()
+
+    expect(usePageEditorStore.getState().page).toBeNull()
+  })
+})

--- a/ui/leafwiki-ui/src/features/editor/pageEditorStore.ts
+++ b/ui/leafwiki-ui/src/features/editor/pageEditorStore.ts
@@ -45,6 +45,7 @@ export interface PageEditorState {
   savePage: (options?: { silent?: boolean }) => Promise<Page | null | undefined> // save the current page
   forceOverwrite: () => Promise<Page | null | undefined> // re-fetch server version, then save
   loadPageData: (path: string) => Promise<void> // load page data by path
+  resetEditorState: () => void // clear the store back to its pristine (no page loaded) shape
 }
 
 function tagsChanged(current: string[], original: string[]): boolean {
@@ -354,5 +355,25 @@ export const usePageEditorStore = create<PageEditorState>((set, get) => ({
         useProgressbarStore.getState().setLoading(false)
       }
     }
+  },
+  // Called when PageEditor unmounts so `page` (and thus currentEditorPageId
+  // reads elsewhere, e.g. TreeNodeActionsMenu's rename/delete guards) doesn't
+  // keep pointing at the last-edited page indefinitely after the editor closes.
+  resetEditorState: () => {
+    loadController?.abort()
+    set({
+      error: null,
+      isLoading: false,
+      notFound: false,
+      page: null,
+      title: '',
+      slug: '',
+      content: '',
+      tags: [],
+      frontmatterFields: [],
+      frontmatterUnsupported: '',
+      frontmatterErrors: {},
+      initialPage: null,
+    })
   },
 }))


### PR DESCRIPTION
usePageEditorStore never cleared `page` when PageEditor unmounted, so currentEditorPageId kept pointing at the last-edited page indefinitely. TreeNodeActionsMenu's rename check (unlike delete's) relies solely on that id without a route guard, so renaming a page via the tree's "..." menu was permanently blocked by a stale "currently being edited" toast once you'd edited it at least once, even long after closing the editor.
