### PR TITLE
fix(sidebar): allow explorer/search hotkeys while search field is focused

### DIFF
--- a/ui/leafwiki-ui/src/components/HotKeyHandler.test.tsx
+++ b/ui/leafwiki-ui/src/components/HotKeyHandler.test.tsx
@@ -1,0 +1,91 @@
+import { TooltipProvider } from '@/components/ui/tooltip'
+import Sidebar from '@/features/sidebar/Sidebar'
+import { useDialogsStore } from '@/stores/dialogs'
+import { useHotKeysStore } from '@/stores/hotkeys'
+import { useSidebarStore } from '@/stores/sidebar'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { HotKeyHandler } from './HotKeyHandler'
+
+vi.mock('@/features/tree/TreeView', () => ({
+  default: () => <div data-testid="tree-view-stub" />,
+}))
+
+vi.mock('@/lib/api/tags', () => ({
+  fetchTags: vi.fn().mockResolvedValue([]),
+}))
+
+vi.hoisted(() => {
+  const store = new Map<string, string>()
+  const localStorage = {
+    get length() {
+      return store.size
+    },
+    clear: () => {
+      store.clear()
+    },
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, value)
+    },
+  }
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: localStorage,
+    configurable: true,
+  })
+})
+
+function renderApp() {
+  render(
+    <MemoryRouter initialEntries={['/docs/getting-started']}>
+      <TooltipProvider>
+        <HotKeyHandler />
+        <Sidebar />
+      </TooltipProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('HotKeyHandler', () => {
+  beforeEach(() => {
+    window.matchMedia = vi.fn().mockImplementation(() => ({
+      matches: false,
+      media: '(max-width: 767px)',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+
+    useSidebarStore.setState({ sidebarVisible: true, sidebarMode: 'search' })
+    useHotKeysStore.setState({ registeredHotkeys: {} })
+    useDialogsStore.setState({ dialogType: null, dialogProps: null })
+  })
+
+  it('switches to the Explorer panel on Ctrl+Shift+E while the search field is focused', async () => {
+    renderApp()
+
+    const searchInput = await screen.findByTestId('search-input')
+    searchInput.focus()
+    expect(searchInput).toHaveFocus()
+
+    fireEvent.keyDown(searchInput, {
+      key: 'e',
+      code: 'KeyE',
+      ctrlKey: true,
+      shiftKey: true,
+    })
+
+    await waitFor(() => {
+      expect(useSidebarStore.getState().sidebarMode).toBe('tree')
+    })
+  })
+})

--- a/ui/leafwiki-ui/src/features/search/Search.tsx
+++ b/ui/leafwiki-ui/src/features/search/Search.tsx
@@ -14,6 +14,7 @@ import { deferStateUpdate } from '@/lib/deferState'
 import { normalizeWikiRoutePath } from '@/lib/wikiPath'
 import { fetchTags, TagCount } from '@/lib/api/tags'
 import { useDebounce } from '@/lib/useDebounce'
+import { getShortcutDefinition } from '@/lib/shortcuts/shortcutCatalog'
 import { X } from 'lucide-react'
 import {
   startTransition,
@@ -32,6 +33,14 @@ type SearchProps = {
 
 const t = (key: string, opts?: Record<string, unknown>) =>
   i18next.t(key, { ...opts, ns: 'search' })
+
+// Sidebar panel switching must keep working while the search field is
+// focused, otherwise the shortcuts are only reachable from elsewhere on
+// the page (see HotKeyHandler's input/button focus guard).
+const SEARCH_INPUT_ALLOWED_HOTKEYS = [
+  getShortcutDefinition('sidebar.explorer.open').keyCombo,
+  getShortcutDefinition('sidebar.search.open').keyCombo,
+].join(' ')
 
 export default function Search({ active = false }: SearchProps) {
   const location = useLocation()
@@ -284,6 +293,7 @@ export default function Search({ active = false }: SearchProps) {
           placeholder={t('input.placeholder')}
           value={inputQuery}
           data-testid="search-input"
+          data-allow-hotkeys={SEARCH_INPUT_ALLOWED_HOTKEYS}
           onChange={(e) => {
             const nextQuery = e.target.value
             invalidatePendingRequests()


### PR DESCRIPTION
HotKeyHandler blocks shortcuts when a form element is focused unless it opts in via data-allow-hotkeys. The sidebar search input never opted in, so Ctrl+Shift+E (and Ctrl+Shift+F) silently did nothing while typing in search, as reported in #1287.

