### PR TITLE
feat(auth): add configurable login URL, promote logout URL to top-level option

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ Available since v0.10.0. Use when an upstream proxy authenticates users and forw
 - If the forwarded username doesn't exist in LeafWiki, the request is rejected
 - Do not enable without configuring `--trusted-proxy-ips`
 - `--login-url` and `--logout-url` are independent, optional redirect targets — set either or both to send users to an external IdP instead of the built-in login form / to redirect after logout
+- `--login-url`, `--logout-url`, and `--user-management-url` must start with `http://` or `https://`; the server refuses to start otherwise
 
 ### Unix Socket (v0.11.3)
 

--- a/README.md
+++ b/README.md
@@ -320,7 +320,8 @@ For plain HTTP: add `--allow-insecure=true` so login and CSRF cookies work.
 | `--enable-http-remote-user`      | Enable reverse-proxy auth via HTTP header                               | `false`       | v0.10.0 |
 | `--http-remote-user-header-name` | Header name carrying the username from the proxy                        | `Remote-User` | v0.10.0 |
 | `--trusted-proxy-ips`            | Trusted proxy IPs/CIDRs for remote-user header                          | `""`          | v0.10.0 |
-| `--http-remote-user-logout-url`  | Logout redirect when reverse-proxy auth is active                       | `""`          | v0.10.0 |
+| `--login-url`                    | Redirect to an external URL instead of the built-in login form          | `""`          | v0.11.5 |
+| `--logout-url`                   | Redirect to an external URL after logout                                | `""`          | v0.11.5 |
 | `--disable-request-log`          | Suppress per-request HTTP access log lines                              | `false`       | v0.10.1 |
 | `--git-backup`                   | ⚗️ Enable git backup to a remote repository                             | `false`       | v0.11.3 |
 | `--git-backup-remote`            | ⚗️ SSH remote URL for git backup (e.g. `git@github.com:user/repo.git`) | `""`          | v0.11.3 |
@@ -360,7 +361,8 @@ For plain HTTP: add `--allow-insecure=true` so login and CSRF cookies work.
 | `LEAFWIKI_ENABLE_HTTP_REMOTE_USER`      | Reverse-proxy auth via header                        | `false`       | v0.10.0 |
 | `LEAFWIKI_HTTP_REMOTE_USER_HEADER_NAME` | Username header from proxy                           | `Remote-User` | v0.10.0 |
 | `LEAFWIKI_TRUSTED_PROXY_IPS`            | Trusted proxy IPs/CIDRs                              | `""`          | v0.10.0 |
-| `LEAFWIKI_HTTP_REMOTE_USER_LOGOUT_URL`  | Logout redirect URL                                  | `""`          | v0.10.0 |
+| `LEAFWIKI_LOGIN_URL`                    | Redirect to an external URL instead of the login form | `""`          | v0.11.5 |
+| `LEAFWIKI_LOGOUT_URL`                   | Redirect to an external URL after logout             | `""`          | v0.11.5 |
 | `LEAFWIKI_DISABLE_REQUEST_LOG`          | Suppress per-request HTTP access log lines           | `false`       | v0.10.1 |
 | `LEAFWIKI_GIT_BACKUP`                   | ⚗️ Enable git backup                                | `false`       | v0.11.3 |
 | `LEAFWIKI_GIT_BACKUP_REMOTE`            | ⚗️ SSH remote URL                                   | `""`          | v0.11.3 |
@@ -399,12 +401,14 @@ Available since v0.10.0. Use when an upstream proxy authenticates users and forw
   --enable-http-remote-user=true \
   --http-remote-user-header-name=X-Forwarded-User \
   --trusted-proxy-ips=127.0.0.1,172.18.0.0/16 \
-  --http-remote-user-logout-url=https://auth.example.com/logout
+  --login-url=https://auth.example.com/login \
+  --logout-url=https://auth.example.com/logout
 ```
 
 - Only trusts the header from IPs listed in `--trusted-proxy-ips`
 - If the forwarded username doesn't exist in LeafWiki, the request is rejected
 - Do not enable without configuring `--trusted-proxy-ips`
+- `--login-url` and `--logout-url` are independent, optional redirect targets — set either or both to send users to an external IdP instead of the built-in login form / to redirect after logout
 
 ### Unix Socket (v0.11.3)
 

--- a/cmd/leafwiki/main.go
+++ b/cmd/leafwiki/main.go
@@ -306,6 +306,16 @@ func main() {
 		fail("Invalid HTTP remote user configuration", "error", err)
 	}
 
+	if err := validateRedirectURL("login-url", loginURL); err != nil {
+		fail("Invalid login URL configuration", "error", err)
+	}
+	if err := validateRedirectURL("logout-url", logoutURL); err != nil {
+		fail("Invalid logout URL configuration", "error", err)
+	}
+	if err := validateRedirectURL("user-management-url", userManagementURL); err != nil {
+		fail("Invalid user management URL configuration", "error", err)
+	}
+
 	if enableHTTPRemoteUser {
 		slog.Default().Info("Reverse-proxy authentication enabled",
 			"header", httpRemoteUserHeader,
@@ -639,6 +649,16 @@ func validateHTTPRemoteUserConfig(enabled bool, trustedProxyIPsRaw string) error
 	}
 	if !hasTrustedProxy {
 		return fmt.Errorf("--trusted-proxy-ips is required when --enable-http-remote-user is set. Set it using --trusted-proxy-ips or LEAFWIKI_TRUSTED_PROXY_IPS")
+	}
+	return nil
+}
+
+func validateRedirectURL(flagName, url string) error {
+	if url == "" {
+		return nil
+	}
+	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+		return fmt.Errorf("--%s must start with http:// or https://", flagName)
 	}
 	return nil
 }

--- a/cmd/leafwiki/main.go
+++ b/cmd/leafwiki/main.go
@@ -65,7 +65,10 @@ func writeUsage(w io.Writer) {
 	--enable-http-remote-user       Enable reverse-proxy authentication via HTTP header (default: false)
 	--http-remote-user-header-name  HTTP header carrying the username from a trusted proxy (default: Remote-User)
 	--trusted-proxy-ips             Comma-separated trusted proxy IPs/CIDRs (e.g. 127.0.0.1,172.18.0.0/16)
-	--http-remote-user-logout-url   URL the frontend redirects to after logout in proxy-auth mode (default: "")
+	--login-url                     URL the frontend redirects to instead of the built-in login form
+	                                 (e.g. an external SSO/IdP login page) (default: "")
+	--logout-url                    URL the frontend redirects to after logout
+	                                 (e.g. an external SSO/IdP logout page) (default: "")
 	--user-management-url           URL to an external user-management page; when set, the built-in
 	                                 User Management UI is replaced with a link to this URL (default: "")
 	--disable-request-log           Suppress per-request HTTP access log lines (default: false)
@@ -104,7 +107,8 @@ func writeUsage(w io.Writer) {
 	LEAFWIKI_ENABLE_HTTP_REMOTE_USER
 	LEAFWIKI_HTTP_REMOTE_USER_HEADER_NAME
 	LEAFWIKI_TRUSTED_PROXY_IPS
-	LEAFWIKI_HTTP_REMOTE_USER_LOGOUT_URL
+	LEAFWIKI_LOGIN_URL
+	LEAFWIKI_LOGOUT_URL
 	LEAFWIKI_USER_MANAGEMENT_URL
 	LEAFWIKI_DISABLE_REQUEST_LOG
 	LEAFWIKI_GIT_BACKUP
@@ -173,7 +177,8 @@ type cliFlags struct {
 	enableHTTPRemoteUser    *bool
 	httpRemoteUserHeader    *string
 	trustedProxyIPs         *string
-	httpRemoteUserLogoutURL *string
+	loginURL                *string
+	logoutURL               *string
 	userManagementURL       *string
 	disableRequestLog       *bool
 	gitBackup               *bool
@@ -212,7 +217,8 @@ func registerFlags(fs *flag.FlagSet) *cliFlags {
 		enableHTTPRemoteUser:    fs.Bool("enable-http-remote-user", false, "enable reverse-proxy authentication via HTTP header (default: false)"),
 		httpRemoteUserHeader:    fs.String("http-remote-user-header-name", "Remote-User", "HTTP header name carrying the username from a trusted proxy (default: Remote-User)"),
 		trustedProxyIPs:         fs.String("trusted-proxy-ips", "", "comma-separated list of trusted proxy IPs/CIDRs (e.g. 127.0.0.1,172.18.0.0/16)"),
-		httpRemoteUserLogoutURL: fs.String("http-remote-user-logout-url", "", "URL the frontend redirects to after logout when reverse-proxy auth is active (e.g. https://auth.example.com/logout)"),
+		loginURL:                fs.String("login-url", "", "URL the frontend redirects to instead of the built-in login form (e.g. an external SSO/IdP login page)"),
+		logoutURL:               fs.String("logout-url", "", "URL the frontend redirects to after logout (e.g. an external SSO/IdP logout page)"),
 		userManagementURL:       fs.String("user-management-url", "", "URL to an external user-management page; when set, the built-in User Management UI is replaced with a link to this URL"),
 		disableRequestLog:       fs.Bool("disable-request-log", false, "suppress per-request HTTP access log lines (default: false)"),
 		gitBackup:               fs.Bool("git-backup", false, "enable git backup to a remote repository (default: false)"),
@@ -275,7 +281,8 @@ func main() {
 	enableHTTPRemoteUser := resolveBool("enable-http-remote-user", *flags.enableHTTPRemoteUser, visited, "LEAFWIKI_ENABLE_HTTP_REMOTE_USER")
 	httpRemoteUserHeader := resolveString("http-remote-user-header-name", *flags.httpRemoteUserHeader, visited, "LEAFWIKI_HTTP_REMOTE_USER_HEADER_NAME", "Remote-User")
 	trustedProxyIPsRaw := resolveString("trusted-proxy-ips", *flags.trustedProxyIPs, visited, "LEAFWIKI_TRUSTED_PROXY_IPS", "")
-	httpRemoteUserLogoutURL := resolveString("http-remote-user-logout-url", *flags.httpRemoteUserLogoutURL, visited, "LEAFWIKI_HTTP_REMOTE_USER_LOGOUT_URL", "")
+	loginURL := resolveString("login-url", *flags.loginURL, visited, "LEAFWIKI_LOGIN_URL", "")
+	logoutURL := resolveString("logout-url", *flags.logoutURL, visited, "LEAFWIKI_LOGOUT_URL", "")
 	userManagementURL := resolveString("user-management-url", *flags.userManagementURL, visited, "LEAFWIKI_USER_MANAGEMENT_URL", "")
 	disableRequestLog := resolveBool("disable-request-log", *flags.disableRequestLog, visited, "LEAFWIKI_DISABLE_REQUEST_LOG")
 	gitBackupEnabled := resolveBool("git-backup", *flags.gitBackup, visited, "LEAFWIKI_GIT_BACKUP")
@@ -430,10 +437,11 @@ func main() {
 			HeaderName:     httpRemoteUserHeader,
 			TrustedProxies: trustedProxies,
 			UserService:    w.UserService(),
-			LogoutURL:      httpRemoteUserLogoutURL,
 		},
 		DisableRequestLog: disableRequestLog,
 		UserManagementURL: userManagementURL,
+		LoginURL:          loginURL,
+		LogoutURL:         logoutURL,
 	})
 
 	reloadSignals := make(chan os.Signal, 1)

--- a/cmd/leafwiki/main_test.go
+++ b/cmd/leafwiki/main_test.go
@@ -93,6 +93,29 @@ func TestValidateHTTPRemoteUserConfig(t *testing.T) {
 	}
 }
 
+func TestValidateRedirectURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{"empty", "", false},
+		{"http", "http://idp.example.com/login", false},
+		{"https", "https://idp.example.com/login", false},
+		{"javascript scheme", "javascript:alert(1)", true},
+		{"relative path", "/login", true},
+		{"data scheme", "data:text/html,<script>alert(1)</script>", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateRedirectURL("login-url", tc.url)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validateRedirectURL(%q) error = %v, wantErr %v", tc.url, err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestValidateListenConfig(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/hacks/proxy-auth/with-logout.yml
+++ b/hacks/proxy-auth/with-logout.yml
@@ -59,7 +59,8 @@ services:
       - "--enable-http-remote-user=true"
       - "--http-remote-user-header-name=X-Forwarded-User"
       - "--trusted-proxy-ips=172.16.0.0/12"
-      - "--http-remote-user-logout-url=http://localhost:4180/oauth2/sign_out"
+      - "--login-url=http://localhost:4180/oauth2/start"
+      - "--logout-url=http://localhost:4180/oauth2/sign_out"
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:8080/api/config"]
       interval: 2s

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -78,7 +78,6 @@ type HTTPRemoteUserConfig struct {
 	HeaderName     string
 	TrustedProxies *auth_middleware.TrustedProxies
 	UserService    *coreauth.UserService
-	LogoutURL      string // optional URL the frontend redirects to after logout
 }
 
 // RouterOptions holds global HTTP server configuration shared across all domains.
@@ -99,6 +98,8 @@ type RouterOptions struct {
 	HTTPRemoteUser          HTTPRemoteUserConfig // Reverse-proxy authentication via HTTP header
 	DisableRequestLog       bool                 // Whether to suppress per-request access log lines
 	UserManagementURL       string               // Optional URL; when set, the frontend replaces in-app user management with a link to this URL
+	LoginURL                string               // Optional URL the frontend redirects to instead of showing the built-in login form
+	LogoutURL               string               // Optional URL the frontend redirects to after logout
 }
 
 // FrontendConfig carries the minimal runtime data required to serve the embedded SPA.

--- a/internal/http/router_test.go
+++ b/internal/http/router_test.go
@@ -1001,6 +1001,96 @@ func TestConfigEndpoint_UserManagementUrlDefaultsToEmpty(t *testing.T) {
 	}
 }
 
+func TestConfigEndpoint_IncludesLoginAndLogoutUrl(t *testing.T) {
+	w := createWikiTestInstance(t)
+	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
+
+	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
+		PublicAccess:            true,
+		InjectCodeInHeader:      "",
+		AllowInsecure:           true,
+		AccessTokenTimeout:      15 * time.Minute,
+		RefreshTokenTimeout:     7 * 24 * time.Hour,
+		HideLinkMetadataSection: false,
+		MaxAssetUploadSizeBytes: assets.DefaultMaxUploadSizeBytes,
+		LoginURL:                "https://idp.example.com/login",
+		LogoutURL:               "https://idp.example.com/logout",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected 200 OK, got %d", rec.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Invalid JSON response: %v", err)
+	}
+
+	gotLogin, ok := resp["loginUrl"].(string)
+	if !ok {
+		t.Fatalf("Expected loginUrl in config response, got %v", resp)
+	}
+	if gotLogin != "https://idp.example.com/login" {
+		t.Fatalf("Expected loginUrl=%q, got %q", "https://idp.example.com/login", gotLogin)
+	}
+
+	gotLogout, ok := resp["logoutUrl"].(string)
+	if !ok {
+		t.Fatalf("Expected logoutUrl in config response, got %v", resp)
+	}
+	if gotLogout != "https://idp.example.com/logout" {
+		t.Fatalf("Expected logoutUrl=%q, got %q", "https://idp.example.com/logout", gotLogout)
+	}
+}
+
+func TestConfigEndpoint_LoginAndLogoutUrlDefaultToEmpty(t *testing.T) {
+	w := createWikiTestInstance(t)
+	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
+
+	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
+		PublicAccess:            true,
+		InjectCodeInHeader:      "",
+		AllowInsecure:           true,
+		AccessTokenTimeout:      15 * time.Minute,
+		RefreshTokenTimeout:     7 * 24 * time.Hour,
+		HideLinkMetadataSection: false,
+		MaxAssetUploadSizeBytes: assets.DefaultMaxUploadSizeBytes,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected 200 OK, got %d", rec.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Invalid JSON response: %v", err)
+	}
+
+	gotLogin, ok := resp["loginUrl"].(string)
+	if !ok {
+		t.Fatalf("Expected loginUrl in config response, got %v", resp)
+	}
+	if gotLogin != "" {
+		t.Fatalf("Expected loginUrl to default to empty string, got %q", gotLogin)
+	}
+
+	gotLogout, ok := resp["logoutUrl"].(string)
+	if !ok {
+		t.Fatalf("Expected logoutUrl in config response, got %v", resp)
+	}
+	if gotLogout != "" {
+		t.Fatalf("Expected logoutUrl to default to empty string, got %q", gotLogout)
+	}
+}
+
 func TestRefactorPreviewEndpoint_UsesFrontendJSONShape(t *testing.T) {
 	w := createWikiTestInstance(t)
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)

--- a/internal/wiki/auth/routes.go
+++ b/internal/wiki/auth/routes.go
@@ -141,7 +141,8 @@ func (r *Routes) handleConfig(ctx httpinternal.RouterContext) gin.HandlerFunc {
 			"enableLinkRefactor":      opts.EnableLinkRefactor,
 			"gitBackupEnabled":        opts.GitBackupEnabled,
 			"httpRemoteUserEnabled":   opts.HTTPRemoteUser.Enabled,
-			"httpRemoteUserLogoutUrl": opts.HTTPRemoteUser.LogoutURL,
+			"loginUrl":                opts.LoginURL,
+			"logoutUrl":               opts.LogoutURL,
 			"userManagementUrl":       opts.UserManagementURL,
 		})
 	}

--- a/ui/leafwiki-ui/src/App.tsx
+++ b/ui/leafwiki-ui/src/App.tsx
@@ -20,6 +20,7 @@ function App() {
   const authDisabled = useConfigStore((s) => s.authDisabled)
   const enableRevision = useConfigStore((s) => s.enableRevision)
   const userManagementUrl = useConfigStore((s) => s.userManagementUrl)
+  const loginUrl = useConfigStore((s) => s.loginUrl)
   const loadBranding = useBrandingStore((s) => s.loadBranding)
   const lastConfigErrorRef = useRef<string | null>(null)
 
@@ -60,9 +61,16 @@ function App() {
         authDisabled,
         enableRevision,
         userManagementUrl,
+        loginUrl,
         BASE_PATH || undefined,
       ),
-    [isReadOnlyViewer, authDisabled, enableRevision, userManagementUrl],
+    [
+      isReadOnlyViewer,
+      authDisabled,
+      enableRevision,
+      userManagementUrl,
+      loginUrl,
+    ],
   )
 
   return (

--- a/ui/leafwiki-ui/src/components/UserToolbar.test.tsx
+++ b/ui/leafwiki-ui/src/components/UserToolbar.test.tsx
@@ -26,7 +26,8 @@ describe('UserToolbar', () => {
     useConfigStore.setState({
       authDisabled: false,
       httpRemoteUserEnabled: false,
-      httpRemoteUserLogoutUrl: '',
+      loginUrl: '',
+      logoutUrl: '',
       userManagementUrl: '',
     })
     useBackupStore.setState({ enabled: false })
@@ -183,7 +184,7 @@ describe('UserToolbar', () => {
       const user = userEvent.setup()
       const logoutSpy = vi.spyOn(authAPI, 'logout').mockResolvedValue()
       useConfigStore.setState({
-        httpRemoteUserLogoutUrl: 'https://control-plane.example.com/logout',
+        logoutUrl: 'https://control-plane.example.com/logout',
       })
 
       renderWithLoginRoute()
@@ -203,7 +204,7 @@ describe('UserToolbar', () => {
 
     it('falls back to the local /login route when no logout URL is configured', async () => {
       const user = userEvent.setup()
-      useConfigStore.setState({ httpRemoteUserLogoutUrl: '' })
+      useConfigStore.setState({ logoutUrl: '' })
 
       renderWithLoginRoute()
 
@@ -214,6 +215,42 @@ describe('UserToolbar', () => {
       await waitFor(() => {
         expect(screen.getByTestId('login-form-sentinel')).toBeInTheDocument()
       })
+    })
+  })
+
+  describe('login redirect', () => {
+    let originalLocation: Location
+
+    beforeEach(() => {
+      originalLocation = window.location
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: { ...originalLocation, href: '' },
+      })
+      useSessionStore.setState({ user: null })
+    })
+
+    afterEach(() => {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: originalLocation,
+      })
+    })
+
+    it('redirects to the login URL when clicking Login and loginUrl is configured', () => {
+      useConfigStore.setState({
+        loginUrl: 'https://idp.example.com/login',
+      })
+
+      render(
+        <MemoryRouter>
+          <UserToolbar />
+        </MemoryRouter>,
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'Login' }))
+
+      expect(window.location.href).toBe('https://idp.example.com/login')
     })
   })
 

--- a/ui/leafwiki-ui/src/components/UserToolbar.tsx
+++ b/ui/leafwiki-ui/src/components/UserToolbar.tsx
@@ -51,9 +51,8 @@ export default function UserToolbar() {
   const httpRemoteUserEnabled = useConfigStore((s) => s.httpRemoteUserEnabled)
   const registerHotkey = useHotKeysStore((state) => state.registerHotkey)
   const unregisterHotkey = useHotKeysStore((state) => state.unregisterHotkey)
-  const httpRemoteUserLogoutUrl = useConfigStore(
-    (s) => s.httpRemoteUserLogoutUrl,
-  )
+  const logoutUrl = useConfigStore((s) => s.logoutUrl)
+  const loginUrl = useConfigStore((s) => s.loginUrl)
   const userManagementUrl = useConfigStore((s) => s.userManagementUrl)
 
   useEffect(() => {
@@ -79,7 +78,12 @@ export default function UserToolbar() {
   if (!user && !authDisabled) {
     return (
       <div className="user-toolbar">
-        <Button size="sm" onClick={() => navigate('/login')}>
+        <Button
+          size="sm"
+          onClick={() =>
+            loginUrl ? (window.location.href = loginUrl) : navigate('/login')
+          }
+        >
           {t('login.loginButton')}
         </Button>
       </div>
@@ -97,12 +101,12 @@ export default function UserToolbar() {
   }
 
   const handleLogout = async () => {
-    if (httpRemoteUserLogoutUrl) {
+    if (logoutUrl) {
       // Redirect immediately instead of clearing local session state first —
       // clearing it here would flash the local login screen before the
       // browser navigates away (see plans/logout-flash-and-external-user-management.md).
       authAPI.logout().catch(() => {})
-      window.location.href = httpRemoteUserLogoutUrl
+      window.location.href = logoutUrl
       return
     }
     await logout()
@@ -191,7 +195,7 @@ export default function UserToolbar() {
           >
             Change Own Password
           </DropdownMenuItem>
-          {(!httpRemoteUserEnabled || httpRemoteUserLogoutUrl) && (
+          {(!httpRemoteUserEnabled || logoutUrl) && (
             <DropdownMenuItem
               className="cursor-pointer"
               onClick={handleLogout}

--- a/ui/leafwiki-ui/src/features/auth/AuthRedirect.test.tsx
+++ b/ui/leafwiki-ui/src/features/auth/AuthRedirect.test.tsx
@@ -78,6 +78,44 @@ describe('Auth redirect flow', () => {
     )
   })
 
+  it('redirects externally instead of to /login when loginUrl is configured', async () => {
+    const originalLocation = window.location
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, href: '' },
+    })
+
+    useConfigStore.setState({
+      loginUrl: 'https://idp.example.com/login',
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/some/protected/page']}>
+        <Routes>
+          <Route path="/login" element={<LocationProbe />} />
+          <Route
+            path="*"
+            element={
+              <RequireAuth>
+                <div>Protected page</div>
+              </RequireAuth>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(window.location.href).toBe('https://idp.example.com/login')
+    })
+    expect(screen.queryByTestId('pathname')).not.toBeInTheDocument()
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    })
+  })
+
   it('returns to the requested page after successful login', async () => {
     loginMock.mockResolvedValue({
       accessTokenExpiresAt: 1234567890,

--- a/ui/leafwiki-ui/src/features/auth/AuthRedirect.test.tsx
+++ b/ui/leafwiki-ui/src/features/auth/AuthRedirect.test.tsx
@@ -85,35 +85,37 @@ describe('Auth redirect flow', () => {
       value: { ...originalLocation, href: '' },
     })
 
-    useConfigStore.setState({
-      loginUrl: 'https://idp.example.com/login',
-    })
+    try {
+      useConfigStore.setState({
+        loginUrl: 'https://idp.example.com/login',
+      })
 
-    render(
-      <MemoryRouter initialEntries={['/some/protected/page']}>
-        <Routes>
-          <Route path="/login" element={<LocationProbe />} />
-          <Route
-            path="*"
-            element={
-              <RequireAuth>
-                <div>Protected page</div>
-              </RequireAuth>
-            }
-          />
-        </Routes>
-      </MemoryRouter>,
-    )
+      render(
+        <MemoryRouter initialEntries={['/some/protected/page']}>
+          <Routes>
+            <Route path="/login" element={<LocationProbe />} />
+            <Route
+              path="*"
+              element={
+                <RequireAuth>
+                  <div>Protected page</div>
+                </RequireAuth>
+              }
+            />
+          </Routes>
+        </MemoryRouter>,
+      )
 
-    await waitFor(() => {
-      expect(window.location.href).toBe('https://idp.example.com/login')
-    })
-    expect(screen.queryByTestId('pathname')).not.toBeInTheDocument()
-
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: originalLocation,
-    })
+      await waitFor(() => {
+        expect(window.location.href).toBe('https://idp.example.com/login')
+      })
+      expect(screen.queryByTestId('pathname')).not.toBeInTheDocument()
+    } finally {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: originalLocation,
+      })
+    }
   })
 
   it('returns to the requested page after successful login', async () => {

--- a/ui/leafwiki-ui/src/features/auth/ExternalRedirect.tsx
+++ b/ui/leafwiki-ui/src/features/auth/ExternalRedirect.tsx
@@ -1,0 +1,8 @@
+import { useEffect } from 'react'
+
+export default function ExternalRedirect({ to }: { to: string }) {
+  useEffect(() => {
+    window.location.href = to
+  }, [to])
+  return null
+}

--- a/ui/leafwiki-ui/src/features/auth/RequireAuth.tsx
+++ b/ui/leafwiki-ui/src/features/auth/RequireAuth.tsx
@@ -2,6 +2,7 @@ import { useConfigStore } from '@/stores/config'
 import { useSessionStore } from '@/stores/session'
 import { ReactNode } from 'react'
 import { Navigate, useLocation } from 'react-router-dom'
+import ExternalRedirect from './ExternalRedirect'
 
 type Props = {
   children: ReactNode
@@ -11,11 +12,15 @@ export default function RequireAuth({ children }: Props) {
   const user = useSessionStore((state) => state.user)
   const isRefreshing = useSessionStore((state) => state.isRefreshing)
   const authDisabled = useConfigStore((state) => state.authDisabled)
+  const loginUrl = useConfigStore((state) => state.loginUrl)
   const location = useLocation()
 
   if (authDisabled) return <>{children}</>
 
   if (!user && !isRefreshing) {
+    if (loginUrl) {
+      return <ExternalRedirect to={loginUrl} />
+    }
     const redirectTo = `${location.pathname}${location.search}${location.hash}`
     return <Navigate to="/login" replace state={{ redirectTo }} />
   }

--- a/ui/leafwiki-ui/src/features/router/router.test.tsx
+++ b/ui/leafwiki-ui/src/features/router/router.test.tsx
@@ -1,3 +1,4 @@
+import { isValidElement } from 'react'
 import { Navigate } from 'react-router-dom'
 import { describe, expect, it } from 'vitest'
 import ExternalRedirect from '../auth/ExternalRedirect'
@@ -7,7 +8,11 @@ import { createLeafWikiRouter } from './router'
 function loginRouteElementType(authDisabled: boolean, loginUrl: string) {
   const router = createLeafWikiRouter(false, authDisabled, false, '', loginUrl)
   const loginRoute = router.routes.find((route) => route.path === '/login')
-  return loginRoute?.element?.type
+  const element = loginRoute?.element
+  if (!isValidElement(element)) {
+    throw new Error('expected /login route to render an element')
+  }
+  return element.type
 }
 
 describe('createLeafWikiRouter /login route', () => {

--- a/ui/leafwiki-ui/src/features/router/router.test.tsx
+++ b/ui/leafwiki-ui/src/features/router/router.test.tsx
@@ -1,0 +1,29 @@
+import { Navigate } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import ExternalRedirect from '../auth/ExternalRedirect'
+import { LoginForm } from './lazy-routes'
+import { createLeafWikiRouter } from './router'
+
+function loginRouteElementType(authDisabled: boolean, loginUrl: string) {
+  const router = createLeafWikiRouter(false, authDisabled, false, '', loginUrl)
+  const loginRoute = router.routes.find((route) => route.path === '/login')
+  return loginRoute?.element?.type
+}
+
+describe('createLeafWikiRouter /login route', () => {
+  it('navigates home when auth is disabled, even if loginUrl is configured', () => {
+    expect(loginRouteElementType(true, 'https://idp.example.com/login')).toBe(
+      Navigate,
+    )
+  })
+
+  it('redirects externally when loginUrl is configured and auth is enabled', () => {
+    expect(loginRouteElementType(false, 'https://idp.example.com/login')).toBe(
+      ExternalRedirect,
+    )
+  })
+
+  it('renders the local login form otherwise', () => {
+    expect(loginRouteElementType(false, '')).toBe(LoginForm)
+  })
+})

--- a/ui/leafwiki-ui/src/features/router/router.tsx
+++ b/ui/leafwiki-ui/src/features/router/router.tsx
@@ -12,6 +12,7 @@ import {
   RootRedirect,
   UserManagement,
 } from './lazy-routes'
+import ExternalRedirect from '../auth/ExternalRedirect'
 import AuthWrapper from './RouterAuthWrapper'
 import ReadOnlyWrapper from './RouterReadOnlyWrapper'
 
@@ -20,13 +21,20 @@ export const createLeafWikiRouter = (
   authDisabled: boolean,
   enableRevision: boolean,
   userManagementUrl: string,
+  loginUrl: string,
   basename?: string,
 ) =>
   createBrowserRouter(
     [
       {
         path: '/login',
-        element: authDisabled ? <Navigate to="/" replace /> : <LoginForm />,
+        element: loginUrl ? (
+          <ExternalRedirect to={loginUrl} />
+        ) : authDisabled ? (
+          <Navigate to="/" replace />
+        ) : (
+          <LoginForm />
+        ),
       },
       {
         path: '/',

--- a/ui/leafwiki-ui/src/features/router/router.tsx
+++ b/ui/leafwiki-ui/src/features/router/router.tsx
@@ -28,10 +28,10 @@ export const createLeafWikiRouter = (
     [
       {
         path: '/login',
-        element: loginUrl ? (
-          <ExternalRedirect to={loginUrl} />
-        ) : authDisabled ? (
+        element: authDisabled ? (
           <Navigate to="/" replace />
+        ) : loginUrl ? (
+          <ExternalRedirect to={loginUrl} />
         ) : (
           <LoginForm />
         ),

--- a/ui/leafwiki-ui/src/lib/api/config.ts
+++ b/ui/leafwiki-ui/src/lib/api/config.ts
@@ -20,7 +20,8 @@ export type Config = {
   enableLinkRefactor: boolean
   gitBackupEnabled: boolean
   httpRemoteUserEnabled: boolean
-  httpRemoteUserLogoutUrl: string
+  loginUrl: string
+  logoutUrl: string
   userManagementUrl: string
 }
 

--- a/ui/leafwiki-ui/src/stores/config.ts
+++ b/ui/leafwiki-ui/src/stores/config.ts
@@ -11,7 +11,8 @@ type ConfigStore = {
   enableLinkRefactor: boolean
   gitBackupEnabled: boolean
   httpRemoteUserEnabled: boolean
-  httpRemoteUserLogoutUrl: string
+  loginUrl: string
+  logoutUrl: string
   userManagementUrl: string
   error: string | null
   loading: boolean
@@ -28,7 +29,8 @@ export const useConfigStore = create<ConfigStore>((set) => ({
   enableLinkRefactor: false,
   gitBackupEnabled: false,
   httpRemoteUserEnabled: false,
-  httpRemoteUserLogoutUrl: '',
+  loginUrl: '',
+  logoutUrl: '',
   userManagementUrl: '',
   error: null,
   loading: false,
@@ -53,7 +55,8 @@ export const useConfigStore = create<ConfigStore>((set) => ({
         enableLinkRefactor: config.enableLinkRefactor ?? false,
         gitBackupEnabled: config.gitBackupEnabled ?? false,
         httpRemoteUserEnabled: config.httpRemoteUserEnabled ?? false,
-        httpRemoteUserLogoutUrl: config.httpRemoteUserLogoutUrl ?? '',
+        loginUrl: config.loginUrl ?? '',
+        logoutUrl: config.logoutUrl ?? '',
         userManagementUrl: config.userManagementUrl ?? '',
         error: null,
         hasLoaded: true,


### PR DESCRIPTION
Lets operators redirect users to an external IdP/SSO login page instead of the built-in login form, symmetric with the existing logout redirect. LogoutURL moves out of HTTPRemoteUserConfig to a standalone RouterOptions field alongside the new LoginURL, since its frontend usage was already independent of httpRemoteUserEnabled.

BREAKING CHANGE: --http-remote-user-logout-url / LEAFWIKI_HTTP_REMOTE_USER_LOGOUT_URL are renamed to --logout-url / LEAFWIKI_LOGOUT_URL.
