### PR TITLE
fix(layout): slide sidebar via transform instead of animating width

### DIFF
--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -523,7 +523,11 @@
   }
 
   .app-layout__sidebar-container {
-    @apply relative z-30 box-border h-full overflow-auto pr-1 max-sm:fixed max-sm:h-[calc(100dvh-55px)];
+    @apply relative z-30 box-border h-full overflow-x-hidden overflow-y-auto pr-1 max-sm:fixed max-sm:h-[calc(100dvh-55px)];
+  }
+
+  .app-layout__sidebar-panel {
+    @apply h-full;
   }
 
   .app-layout__sidebar-container--flush {
@@ -531,7 +535,7 @@
   }
 
   .app-layout__sidebar-resizer {
-    @apply absolute inset-y-0 right-0 flex w-1 cursor-col-resize items-center justify-center;
+    @apply absolute inset-y-0 right-0 z-10 flex w-1 cursor-col-resize items-center justify-center;
   }
 
   .app-layout__sidebar-resize-handle {

--- a/ui/leafwiki-ui/src/layout/AppLayout.tsx
+++ b/ui/leafwiki-ui/src/layout/AppLayout.tsx
@@ -54,6 +54,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   const { siteName, logoFile, logoVersion } = useBrandingStore()
 
   const sidebarContainerRef = useRef<HTMLDivElement | null>(null)
+  const sidebarPanelRef = useRef<HTMLDivElement | null>(null)
   const liveSidebarWidthRef = useRef(sidebarWidth)
 
   const handleSidebarResize = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -80,6 +81,9 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
 
       if (sidebarContainerRef.current) {
         sidebarContainerRef.current.style.width = `${nextWidth}px`
+      }
+      if (sidebarPanelRef.current) {
+        sidebarPanelRef.current.style.width = `${nextWidth}px`
       }
     }
 
@@ -266,7 +270,22 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               />
             </div>
           )}
-          <Sidebar />
+          {/*
+            Rendered at its final width at all times and only ever moved via
+            transform. This keeps the sidebar's own content (tree labels etc.)
+            from re-wrapping through every intermediate width while the outer
+            container's width animates open/closed.
+          */}
+          <div
+            ref={sidebarPanelRef}
+            className="app-layout__sidebar-panel transition-transform duration-200"
+            style={{
+              width: isMobile ? MOBILE_SIDEBAR_WIDTH : sidebarWidth,
+              transform: sidebarVisible ? 'translateX(0)' : 'translateX(-100%)',
+            }}
+          >
+            <Sidebar />
+          </div>
         </div>
 
         {/* Overlay for mobile sidebar */}


### PR DESCRIPTION
Animating the sidebar container's width directly made its own content (tree labels etc.) re-wrap through every intermediate width during the open/close transition. The sidebar panel now renders at its final width at all times and is only ever moved via translateX, while the outer container still animates width to smoothly push the main content.

Also fixes the resize handle becoming hidden behind the sidebar panel: the panel's transform creates a stacking context that, without an explicit z-index on the handle, painted above it.