### PR TITLE
fix(tree): rename page/section without requiring link-refactor flag

### DIFF
--- a/ui/leafwiki-ui/src/features/tree/TreeNodeActionsMenu.test.tsx
+++ b/ui/leafwiki-ui/src/features/tree/TreeNodeActionsMenu.test.tsx
@@ -1,8 +1,15 @@
 import { useDialogsStore } from '@/stores/dialogs'
+import { useConfigStore } from '@/stores/config'
 import { usePageEditorStore } from '@/features/editor/pageEditorStore'
 import { DIALOG_EDIT_PAGE_METADATA } from '@/lib/registries'
-import type { PageNode } from '@/lib/api/pages'
-import { fireEvent, render, screen } from '@testing-library/react'
+import {
+  applyPageRefactor,
+  getPageByPath,
+  previewPageRefactor,
+  updatePage,
+} from '@/lib/api/pages'
+import type { Page, PageNode } from '@/lib/api/pages'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -80,6 +87,7 @@ describe('TreeNodeActionsMenu', () => {
     useDialogsStore.setState({ dialogType: null, dialogProps: null })
     usePageEditorStore.setState({ page: null })
     useTreeNodeActionsMenusStore.setState({ openMenuNodeId: node.id })
+    useConfigStore.setState({ enableLinkRefactor: false })
   })
 
   it('opens the metadata dialog for renaming a tree node', () => {
@@ -102,5 +110,55 @@ describe('TreeNodeActionsMenu', () => {
       slug: node.slug,
     })
     expect(dialogState.dialogProps?.onChange).toEqual(expect.any(Function))
+  })
+
+  it('renames via plain page update instead of the refactor endpoints when link refactor is disabled', async () => {
+    useConfigStore.setState({ enableLinkRefactor: false })
+
+    const fetchedPage: Page = {
+      id: node.id,
+      slug: node.slug,
+      path: node.path,
+      title: node.title,
+      content: 'some content',
+      tags: [],
+      properties: {},
+      version: node.version,
+      kind: node.kind,
+    }
+    vi.mocked(getPageByPath).mockResolvedValue(fetchedPage)
+    vi.mocked(updatePage).mockResolvedValue({
+      ...fetchedPage,
+      title: 'Renamed',
+      slug: 'renamed',
+    })
+
+    render(
+      <MemoryRouter>
+        <TreeNodeActionsMenu node={node} />
+      </MemoryRouter>,
+    )
+
+    fireEvent.click(screen.getByTestId('tree-view-action-button-rename'))
+
+    const onChange = useDialogsStore.getState().dialogProps?.onChange as (
+      title: string,
+      slug: string,
+    ) => Promise<void>
+    await onChange('Renamed', 'renamed')
+
+    await waitFor(() => {
+      expect(updatePage).toHaveBeenCalledWith(
+        node.id,
+        node.version,
+        'Renamed',
+        'renamed',
+        'some content',
+        [],
+        {},
+      )
+    })
+    expect(previewPageRefactor).not.toHaveBeenCalled()
+    expect(applyPageRefactor).not.toHaveBeenCalled()
   })
 })

--- a/ui/leafwiki-ui/src/features/tree/TreeNodeActionsMenu.tsx
+++ b/ui/leafwiki-ui/src/features/tree/TreeNodeActionsMenu.tsx
@@ -13,6 +13,7 @@ import {
   NODE_KIND_SECTION,
   pinPage,
   previewPageRefactor,
+  updatePage,
 } from '@/lib/api/pages'
 import type { Page, PageNode } from '@/lib/api/pages'
 import { asApiLocalizedError, mapApiError } from '@/lib/api/errors'
@@ -26,6 +27,7 @@ import {
 } from '@/lib/registries'
 import { stripBasePath } from '@/lib/routePath'
 import { getDeleteRedirectRoutePath } from '@/lib/wikiPath'
+import { useConfigStore } from '@/stores/config'
 import { useDialogsStore } from '@/stores/dialogs'
 import { useViewerStore } from '@/features/viewer/viewer'
 import { useTreeStore } from '@/stores/tree'
@@ -61,6 +63,7 @@ export default function TreeNodeActionsMenu({
   const { t } = useTranslation('viewer')
   const { id: nodeId, kind: nodeKind, children, version: nodeVersion } = node
   const currentEditorPageId = usePageEditorStore((state) => state.page?.id)
+  const enableLinkRefactor = useConfigStore((s) => s.enableLinkRefactor)
   const openDialog = useDialogsStore((state) => state.openDialog)
   const reloadTree = useTreeStore((state) => state.reloadTree)
   const hasChildren = children && children.length > 0
@@ -140,27 +143,41 @@ export default function TreeNodeActionsMenu({
           return
         }
 
-        const preview = await previewPageRefactor(page.id, {
-          kind: 'rename',
-          title,
-          slug,
-        })
-        const rewriteLinks = await confirmPageRefactor(preview, {
-          allowSkipRewrite: true,
-        })
+        let updatedPage: Page | null
 
-        if (rewriteLinks === null) {
-          return
+        if (slugChanged && enableLinkRefactor) {
+          const preview = await previewPageRefactor(page.id, {
+            kind: 'rename',
+            title,
+            slug,
+          })
+          const rewriteLinks = await confirmPageRefactor(preview, {
+            allowSkipRewrite: true,
+          })
+
+          if (rewriteLinks === null) {
+            return
+          }
+
+          updatedPage = await applyPageRefactor(page.id, {
+            kind: 'rename',
+            version: page.version,
+            title,
+            slug,
+            content: page.content,
+            rewriteLinks,
+          })
+        } else {
+          updatedPage = await updatePage(
+            page.id,
+            page.version,
+            title,
+            slug,
+            page.content,
+            page.tags ?? [],
+            page.properties ?? {},
+          )
         }
-
-        const updatedPage: Page | null = await applyPageRefactor(page.id, {
-          kind: 'rename',
-          version: page.version,
-          title,
-          slug,
-          content: page.content,
-          rewriteLinks,
-        })
 
         await reloadTree()
 
@@ -204,6 +221,7 @@ export default function TreeNodeActionsMenu({
     },
     [
       currentEditorPageId,
+      enableLinkRefactor,
       getCurrentRoutePath,
       navigate,
       node.path,


### PR DESCRIPTION
Tree-view rename always went through the /refactor/preview and /refactor/apply endpoints, which are only registered when LEAFWIKI_ENABLE_LINK_REFACTOR is enabled (default: off). With the flag disabled, renaming from the tree context menu hit a 404 and surfaced as "Page not found". The editor title bar and the move dialog already guarded this correctly by falling back to a plain page update when the flag is off or the slug didn't change; the tree rename handler now does the same.
