### PR TITLE
feat(cli): allow configuring initial admin username and email

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ Start the backend (in another terminal):
 
 ``` bash
 cd cmd/leafwiki
-go run main.go --jwt-secret=dev --admin-password=dev --public-access=true --allow-insecure=true
+go run . --jwt-secret=dev --admin-password=dev --public-access=true --allow-insecure=true
 ```
 
 The frontend dev server usually runs at:

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ npm run dev
 **Terminal 2 — Backend:**
 ```bash
 cd cmd/leafwiki
-go run main.go --jwt-secret=yoursecret --allow-insecure=true --admin-password=yourpassword
+go run . --jwt-secret=yoursecret --allow-insecure=true --admin-password=yourpassword
 ```
 
 Vite starts on `http://localhost:5173`. The backend binds to `127.0.0.1` by default.
@@ -294,6 +294,13 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 | `--jwt-secret` | Secret for signing JWTs. Keep it secure. |
 | `--admin-password` | Initial admin password (only applied if no admin exists yet). |
 
+### Optional admin identity
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--admin-username` | Initial admin username (only applied if no admin exists yet). | `admin` |
+| `--admin-email` | Initial admin email (only applied if no admin exists yet). | `admin@localhost` |
+
 For plain HTTP: add `--allow-insecure=true` so login and CSRF cookies work.
 
 ### CLI Flags
@@ -304,6 +311,8 @@ For plain HTTP: add `--allow-insecure=true` so login and CSRF cookies work.
 | `--port`                         | Port the server listens on                                              | `8080`        | –       |
 | `--unix-socket`                  | Unix domain socket path; overrides `--host` and `--port`                | `""`          | v0.11.3 |
 | `--data-dir`                     | Directory where data is stored                                          | `./data`      | –       |
+| `--admin-username`               | Initial admin username (only applied if no admin exists yet)            | `admin`       | unreleased |
+| `--admin-email`                  | Initial admin email (only applied if no admin exists yet)               | `admin@localhost` | unreleased |
 | `--public-access`                | Allow public read-only access                                           | `false`       | –       |
 | `--base-path`                    | URL prefix for reverse proxy setups (e.g. `/wiki`)                      | `""`          | v0.8.2  |
 | `--allow-insecure`               | ⚠️ Enables HTTP for auth cookies (required for plain HTTP)              | `false`       | v0.7.0  |
@@ -344,6 +353,8 @@ For plain HTTP: add `--allow-insecure=true` so login and CSRF cookies work.
 | `LEAFWIKI_UNIX_SOCKET`                  | Unix domain socket path; overrides host/port         | `""`          | v0.11.3 |
 | `LEAFWIKI_DATA_DIR`                     | Data directory path                                  | `./data`      | –       |
 | `LEAFWIKI_ADMIN_PASSWORD`               | Initial admin password *(required)*                  | –             | –       |
+| `LEAFWIKI_ADMIN_USERNAME`               | Initial admin username (only applied if no admin exists yet) | `admin`       | unreleased |
+| `LEAFWIKI_ADMIN_EMAIL`                  | Initial admin email (only applied if no admin exists yet) | `admin@localhost` | unreleased |
 | `LEAFWIKI_JWT_SECRET`                   | JWT signing secret *(required)*                      | –             | –       |
 | `LEAFWIKI_PUBLIC_ACCESS`                | Allow public read-only access                        | `false`       | –       |
 | `LEAFWIKI_BASE_PATH`                    | URL prefix for reverse proxy                         | `""`          | v0.8.2  |

--- a/README.md
+++ b/README.md
@@ -311,8 +311,8 @@ For plain HTTP: add `--allow-insecure=true` so login and CSRF cookies work.
 | `--port`                         | Port the server listens on                                              | `8080`        | –       |
 | `--unix-socket`                  | Unix domain socket path; overrides `--host` and `--port`                | `""`          | v0.11.3 |
 | `--data-dir`                     | Directory where data is stored                                          | `./data`      | –       |
-| `--admin-username`               | Initial admin username (only applied if no admin exists yet)            | `admin`       | unreleased |
-| `--admin-email`                  | Initial admin email (only applied if no admin exists yet)               | `admin@localhost` | unreleased |
+| `--admin-username`               | Initial admin username (only applied if no admin exists yet)            | `admin`       | v0.12.0 |
+| `--admin-email`                  | Initial admin email (only applied if no admin exists yet)               | `admin@localhost` | v0.12.0 |
 | `--public-access`                | Allow public read-only access                                           | `false`       | –       |
 | `--base-path`                    | URL prefix for reverse proxy setups (e.g. `/wiki`)                      | `""`          | v0.8.2  |
 | `--allow-insecure`               | ⚠️ Enables HTTP for auth cookies (required for plain HTTP)              | `false`       | v0.7.0  |
@@ -329,8 +329,9 @@ For plain HTTP: add `--allow-insecure=true` so login and CSRF cookies work.
 | `--enable-http-remote-user`      | Enable reverse-proxy auth via HTTP header                               | `false`       | v0.10.0 |
 | `--http-remote-user-header-name` | Header name carrying the username from the proxy                        | `Remote-User` | v0.10.0 |
 | `--trusted-proxy-ips`            | Trusted proxy IPs/CIDRs for remote-user header                          | `""`          | v0.10.0 |
-| `--login-url`                    | Redirect to an external URL instead of the built-in login form          | `""`          | v0.11.5 |
-| `--logout-url`                   | Redirect to an external URL after logout                                | `""`          | v0.11.5 |
+| `--login-url`                    | Redirect to an external URL instead of the built-in login form          | `""`          | v0.12.0 |
+| `--logout-url`                   | Redirect to an external URL after logout                                | `""`          | v0.12.0 |
+| `--http-remote-user-logout-url`  | ⚠️ Deprecated, use `--logout-url` instead                               | `""`          | v0.10.0 |
 | `--disable-request-log`          | Suppress per-request HTTP access log lines                              | `false`       | v0.10.1 |
 | `--git-backup`                   | ⚗️ Enable git backup to a remote repository                             | `false`       | v0.11.3 |
 | `--git-backup-remote`            | ⚗️ SSH remote URL for git backup (e.g. `git@github.com:user/repo.git`) | `""`          | v0.11.3 |
@@ -353,8 +354,8 @@ For plain HTTP: add `--allow-insecure=true` so login and CSRF cookies work.
 | `LEAFWIKI_UNIX_SOCKET`                  | Unix domain socket path; overrides host/port         | `""`          | v0.11.3 |
 | `LEAFWIKI_DATA_DIR`                     | Data directory path                                  | `./data`      | –       |
 | `LEAFWIKI_ADMIN_PASSWORD`               | Initial admin password *(required)*                  | –             | –       |
-| `LEAFWIKI_ADMIN_USERNAME`               | Initial admin username (only applied if no admin exists yet) | `admin`       | unreleased |
-| `LEAFWIKI_ADMIN_EMAIL`                  | Initial admin email (only applied if no admin exists yet) | `admin@localhost` | unreleased |
+| `LEAFWIKI_ADMIN_USERNAME`               | Initial admin username (only applied if no admin exists yet) | `admin`       | v0.12.0 |
+| `LEAFWIKI_ADMIN_EMAIL`                  | Initial admin email (only applied if no admin exists yet) | `admin@localhost` | v0.12.0 |
 | `LEAFWIKI_JWT_SECRET`                   | JWT signing secret *(required)*                      | –             | –       |
 | `LEAFWIKI_PUBLIC_ACCESS`                | Allow public read-only access                        | `false`       | –       |
 | `LEAFWIKI_BASE_PATH`                    | URL prefix for reverse proxy                         | `""`          | v0.8.2  |
@@ -372,8 +373,9 @@ For plain HTTP: add `--allow-insecure=true` so login and CSRF cookies work.
 | `LEAFWIKI_ENABLE_HTTP_REMOTE_USER`      | Reverse-proxy auth via header                        | `false`       | v0.10.0 |
 | `LEAFWIKI_HTTP_REMOTE_USER_HEADER_NAME` | Username header from proxy                           | `Remote-User` | v0.10.0 |
 | `LEAFWIKI_TRUSTED_PROXY_IPS`            | Trusted proxy IPs/CIDRs                              | `""`          | v0.10.0 |
-| `LEAFWIKI_LOGIN_URL`                    | Redirect to an external URL instead of the login form | `""`          | v0.11.5 |
-| `LEAFWIKI_LOGOUT_URL`                   | Redirect to an external URL after logout             | `""`          | v0.11.5 |
+| `LEAFWIKI_LOGIN_URL`                    | Redirect to an external URL instead of the login form | `""`          | v0.12.0 |
+| `LEAFWIKI_LOGOUT_URL`                   | Redirect to an external URL after logout             | `""`          | v0.12.0 |
+| `LEAFWIKI_HTTP_REMOTE_USER_LOGOUT_URL`  | ⚠️ Deprecated, use `LEAFWIKI_LOGOUT_URL` instead     | `""`          | v0.10.0 |
 | `LEAFWIKI_DISABLE_REQUEST_LOG`          | Suppress per-request HTTP access log lines           | `false`       | v0.10.1 |
 | `LEAFWIKI_GIT_BACKUP`                   | ⚗️ Enable git backup                                | `false`       | v0.11.3 |
 | `LEAFWIKI_GIT_BACKUP_REMOTE`            | ⚗️ SSH remote URL                                   | `""`          | v0.11.3 |
@@ -420,7 +422,9 @@ Available since v0.10.0. Use when an upstream proxy authenticates users and forw
 - If the forwarded username doesn't exist in LeafWiki, the request is rejected
 - Do not enable without configuring `--trusted-proxy-ips`
 - `--login-url` and `--logout-url` are independent, optional redirect targets — set either or both to send users to an external IdP instead of the built-in login form / to redirect after logout
-- `--login-url`, `--logout-url`, and `--user-management-url` must start with `http://` or `https://`; the server refuses to start otherwise
+- `--login-url` and `--logout-url` must start with `http://` or `https://`; the server refuses to start otherwise. `--user-management-url` has no such restriction — it's only used as a link, so relative paths work too
+- ⚠️ `--login-url` takes effect regardless of `--enable-http-remote-user` and has no in-app bypass: once set, *every* unauthenticated visit (including `/login` itself) redirects to it immediately. Double-check the URL before setting it — a wrong or unreachable value locks all users, including admins, out of the built-in login form
+- `--http-remote-user-logout-url` (v0.10.0) is deprecated; use `--logout-url` instead. It still works as a fallback when `--logout-url`/`LEAFWIKI_LOGOUT_URL` isn't set, but a deprecation warning is logged
 
 ### Unix Socket (v0.11.3)
 

--- a/cmd/leafwiki/main.go
+++ b/cmd/leafwiki/main.go
@@ -80,6 +80,7 @@ func writeUsage(w io.Writer) {
 	                                 (e.g. an external SSO/IdP login page) (default: "")
 	--logout-url                    URL the frontend redirects to after logout
 	                                 (e.g. an external SSO/IdP logout page) (default: "")
+	--http-remote-user-logout-url   Deprecated: use --logout-url instead
 	--user-management-url           URL to an external user-management page; when set, the built-in
 	                                 User Management UI is replaced with a link to this URL (default: "")
 	--disable-request-log           Suppress per-request HTTP access log lines (default: false)
@@ -125,6 +126,7 @@ func writeUsage(w io.Writer) {
 	LEAFWIKI_TRUSTED_PROXY_IPS
 	LEAFWIKI_LOGIN_URL
 	LEAFWIKI_LOGOUT_URL
+	LEAFWIKI_HTTP_REMOTE_USER_LOGOUT_URL  (deprecated: use LEAFWIKI_LOGOUT_URL instead)
 	LEAFWIKI_USER_MANAGEMENT_URL
 	LEAFWIKI_DISABLE_REQUEST_LOG
 	LEAFWIKI_GIT_BACKUP
@@ -200,6 +202,7 @@ type cliFlags struct {
 	trustedProxyIPs         *string
 	loginURL                *string
 	logoutURL               *string
+	httpRemoteUserLogoutURL *string
 	userManagementURL       *string
 	disableRequestLog       *bool
 	gitBackup               *bool
@@ -245,6 +248,7 @@ func registerFlags(fs *flag.FlagSet) *cliFlags {
 		trustedProxyIPs:         fs.String("trusted-proxy-ips", "", "comma-separated list of trusted proxy IPs/CIDRs (e.g. 127.0.0.1,172.18.0.0/16)"),
 		loginURL:                fs.String("login-url", "", "URL the frontend redirects to instead of the built-in login form (e.g. an external SSO/IdP login page)"),
 		logoutURL:               fs.String("logout-url", "", "URL the frontend redirects to after logout (e.g. an external SSO/IdP logout page)"),
+		httpRemoteUserLogoutURL: fs.String("http-remote-user-logout-url", "", "deprecated: use --logout-url instead"),
 		userManagementURL:       fs.String("user-management-url", "", "URL to an external user-management page; when set, the built-in User Management UI is replaced with a link to this URL"),
 		disableRequestLog:       fs.Bool("disable-request-log", false, "suppress per-request HTTP access log lines (default: false)"),
 		gitBackup:               fs.Bool("git-backup", false, "enable git backup to a remote repository (default: false)"),
@@ -285,8 +289,10 @@ func main() {
 	unixSocket := resolveString("unix-socket", *flags.unixSocket, visited, "LEAFWIKI_UNIX_SOCKET", "")
 	dataDir := resolveString("data-dir", *flags.dataDir, visited, "LEAFWIKI_DATA_DIR", "./data")
 	adminPassword := resolveString("admin-password", *flags.adminPassword, visited, "LEAFWIKI_ADMIN_PASSWORD", "")
-	adminUsername := resolveString("admin-username", *flags.adminUsername, visited, "LEAFWIKI_ADMIN_USERNAME", "admin")
-	adminEmail := resolveString("admin-email", *flags.adminEmail, visited, "LEAFWIKI_ADMIN_EMAIL", "admin@localhost")
+	// Empty stays empty here; auth.UserService applies the "admin"/"admin@localhost"
+	// fallback itself, so that default lives in exactly one place.
+	adminUsername := resolveString("admin-username", *flags.adminUsername, visited, "LEAFWIKI_ADMIN_USERNAME", "")
+	adminEmail := resolveString("admin-email", *flags.adminEmail, visited, "LEAFWIKI_ADMIN_EMAIL", "")
 	jwtSecret := resolveString("jwt-secret", *flags.jwtSecret, visited, "LEAFWIKI_JWT_SECRET", "")
 	injectCodeInHeader := resolveString("inject-code-in-header", *flags.injectCodeInHeader, visited, "LEAFWIKI_INJECT_CODE_IN_HEADER", "")
 	customStylesheet := resolveString("custom-stylesheet", *flags.customStylesheet, visited, "LEAFWIKI_CUSTOM_STYLESHEET", "")
@@ -314,6 +320,10 @@ func main() {
 	trustedProxyIPsRaw := resolveString("trusted-proxy-ips", *flags.trustedProxyIPs, visited, "LEAFWIKI_TRUSTED_PROXY_IPS", "")
 	loginURL := resolveString("login-url", *flags.loginURL, visited, "LEAFWIKI_LOGIN_URL", "")
 	logoutURL := resolveString("logout-url", *flags.logoutURL, visited, "LEAFWIKI_LOGOUT_URL", "")
+	if resolved, usedDeprecated := resolveLogoutURL(logoutURL, *flags.httpRemoteUserLogoutURL, visited, "LEAFWIKI_HTTP_REMOTE_USER_LOGOUT_URL"); usedDeprecated {
+		slog.Default().Warn("--http-remote-user-logout-url/LEAFWIKI_HTTP_REMOTE_USER_LOGOUT_URL is deprecated, use --logout-url/LEAFWIKI_LOGOUT_URL instead")
+		logoutURL = resolved
+	}
 	userManagementURL := resolveString("user-management-url", *flags.userManagementURL, visited, "LEAFWIKI_USER_MANAGEMENT_URL", "")
 	disableRequestLog := resolveBool("disable-request-log", *flags.disableRequestLog, visited, "LEAFWIKI_DISABLE_REQUEST_LOG")
 	gitBackupEnabled := resolveBool("git-backup", *flags.gitBackup, visited, "LEAFWIKI_GIT_BACKUP")
@@ -343,9 +353,9 @@ func main() {
 	if err := validateRedirectURL("logout-url", logoutURL); err != nil {
 		fail("Invalid logout URL configuration", "error", err)
 	}
-	if err := validateRedirectURL("user-management-url", userManagementURL); err != nil {
-		fail("Invalid user management URL configuration", "error", err)
-	}
+	// --user-management-url is only ever used as a plain <a href> in the frontend
+	// (relative paths and other schemes work fine there), so it isn't restricted
+	// to http(s) like --login-url/--logout-url, which the browser navigates to directly.
 
 	if enableHTTPRemoteUser {
 		slog.Default().Info("Reverse-proxy authentication enabled",
@@ -370,7 +380,7 @@ func main() {
 	if len(args) > 0 {
 		switch args[0] {
 		case "reset-admin-password":
-			user, err := tools.ResetAdminPassword(dataDir)
+			user, err := tools.ResetAdminPassword(dataDir, adminUsername, adminEmail)
 			if err != nil {
 				fail("Password reset failed", "error", err)
 			}
@@ -645,7 +655,7 @@ func removeStaleUnixSocket(socketPath string) error {
 func resolveString(flagName, flagVal string, visited map[string]bool, envVar string, def string) string {
 	// If flag was explicitly set, it takes precedence
 	if visited[flagName] {
-		return flagVal
+		return strings.TrimSpace(flagVal)
 	}
 	// Next, check environment variable
 	if env := strings.TrimSpace(os.Getenv(envVar)); env != "" {
@@ -749,11 +759,27 @@ func validateHTTPRemoteUserConfig(enabled bool, trustedProxyIPsRaw string) error
 	return nil
 }
 
+// resolveLogoutURL resolves --logout-url/LEAFWIKI_LOGOUT_URL, falling back to
+// the deprecated --http-remote-user-logout-url/LEAFWIKI_HTTP_REMOTE_USER_LOGOUT_URL
+// when the new option isn't set. usedDeprecated tells the caller whether to log
+// a deprecation warning.
+func resolveLogoutURL(logoutURL, deprecatedFlagVal string, visited map[string]bool, deprecatedEnvVar string) (resolved string, usedDeprecated bool) {
+	if logoutURL != "" {
+		return logoutURL, false
+	}
+	deprecated := resolveString("http-remote-user-logout-url", deprecatedFlagVal, visited, deprecatedEnvVar, "")
+	if deprecated == "" {
+		return "", false
+	}
+	return deprecated, true
+}
+
 func validateRedirectURL(flagName, url string) error {
 	if url == "" {
 		return nil
 	}
-	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+	lower := strings.ToLower(url)
+	if !strings.HasPrefix(lower, "http://") && !strings.HasPrefix(lower, "https://") {
 		return fmt.Errorf("--%s must start with http:// or https://", flagName)
 	}
 	return nil

--- a/cmd/leafwiki/main.go
+++ b/cmd/leafwiki/main.go
@@ -51,6 +51,8 @@ func writeUsage(w io.Writer) {
 	--unix-socket      Path to a unix domain socket to listen on (overrides --host and --port)
 	--data-dir         Path to data directory (default: ./data)
 	--admin-password   Initial admin password (used only if no admin exists)
+	--admin-username   Initial admin username (used only if no admin exists) (default: admin)
+	--admin-email      Initial admin email (used only if no admin exists) (default: admin@localhost)
 	--jwt-secret       Secret for signing auth tokens (JWT) (required)
 	--public-access    Allow public access to the wiki only with read access (default: false)
 	--allow-insecure   Allow insecure HTTP connections (default: false)                      
@@ -99,6 +101,8 @@ func writeUsage(w io.Writer) {
 	LEAFWIKI_JWT_SECRET
 	LEAFWIKI_LOG_LEVEL
 	LEAFWIKI_ADMIN_PASSWORD
+	LEAFWIKI_ADMIN_USERNAME
+	LEAFWIKI_ADMIN_EMAIL
 	LEAFWIKI_PUBLIC_ACCESS
 	LEAFWIKI_ALLOW_INSECURE
 	LEAFWIKI_INJECT_CODE_IN_HEADER
@@ -171,6 +175,8 @@ type cliFlags struct {
 	port                    *string
 	unixSocket              *string
 	dataDir                 *string
+	adminUsername           *string
+	adminEmail              *string
 	adminPassword           *string
 	jwtSecret               *string
 	publicAccess            *bool
@@ -214,6 +220,8 @@ func registerFlags(fs *flag.FlagSet) *cliFlags {
 		port:                    fs.String("port", "", "port to run the server on"),
 		unixSocket:              fs.String("unix-socket", "", "path to a unix domain socket to listen on; overrides --host and --port"),
 		dataDir:                 fs.String("data-dir", "", "path to data directory"),
+		adminUsername:           fs.String("admin-username", "", "initial admin username (used only if no admin exists) (default: admin)"),
+		adminEmail:              fs.String("admin-email", "", "initial admin email (used only if no admin exists) (default: admin@localhost)"),
 		adminPassword:           fs.String("admin-password", "", "initial admin password"),
 		jwtSecret:               fs.String("jwt-secret", "", "JWT secret for authentication"),
 		publicAccess:            fs.Bool("public-access", false, "allow public access to the wiki with read access (default: false)"),
@@ -277,6 +285,8 @@ func main() {
 	unixSocket := resolveString("unix-socket", *flags.unixSocket, visited, "LEAFWIKI_UNIX_SOCKET", "")
 	dataDir := resolveString("data-dir", *flags.dataDir, visited, "LEAFWIKI_DATA_DIR", "./data")
 	adminPassword := resolveString("admin-password", *flags.adminPassword, visited, "LEAFWIKI_ADMIN_PASSWORD", "")
+	adminUsername := resolveString("admin-username", *flags.adminUsername, visited, "LEAFWIKI_ADMIN_USERNAME", "admin")
+	adminEmail := resolveString("admin-email", *flags.adminEmail, visited, "LEAFWIKI_ADMIN_EMAIL", "admin@localhost")
 	jwtSecret := resolveString("jwt-secret", *flags.jwtSecret, visited, "LEAFWIKI_JWT_SECRET", "")
 	injectCodeInHeader := resolveString("inject-code-in-header", *flags.injectCodeInHeader, visited, "LEAFWIKI_INJECT_CODE_IN_HEADER", "")
 	customStylesheet := resolveString("custom-stylesheet", *flags.customStylesheet, visited, "LEAFWIKI_CUSTOM_STYLESHEET", "")
@@ -412,6 +422,8 @@ func main() {
 
 	w, err := wiki.NewWiki(&wiki.WikiOptions{
 		StorageDir:             dataDir,
+		AdminUsername:          adminUsername,
+		AdminEmail:             adminEmail,
 		AdminPassword:          adminPassword,
 		JWTSecret:              jwtSecret,
 		AccessTokenTimeout:     accessTokenTimeout,

--- a/cmd/leafwiki/main_test.go
+++ b/cmd/leafwiki/main_test.go
@@ -28,6 +28,8 @@ func TestWriteUsage_UsesLongFlags(t *testing.T) {
 	for _, expected := range []string{
 		"--jwt-secret",
 		"--admin-password",
+		"--admin-username",
+		"--admin-email",
 		"--allow-insecure",
 		"--enable-metrics",
 		"--metrics-host",
@@ -35,6 +37,8 @@ func TestWriteUsage_UsesLongFlags(t *testing.T) {
 		"--data-dir",
 		"--unix-socket",
 		"LEAFWIKI_UNIX_SOCKET",
+		"LEAFWIKI_ADMIN_USERNAME",
+		"LEAFWIKI_ADMIN_EMAIL",
 		"LEAFWIKI_ENABLE_METRICS",
 		"LEAFWIKI_METRICS_HOST",
 		"LEAFWIKI_METRICS_PORT",
@@ -54,6 +58,8 @@ func TestRegisterFlags_AcceptsSingleDashLongFlags(t *testing.T) {
 	err := fs.Parse([]string{
 		"-jwt-secret=test-secret",
 		"-admin-password=test-password",
+		"-admin-username=test-admin",
+		"-admin-email=test-admin@example.com",
 		"-allow-insecure=true",
 		"-enable-metrics=true",
 		"-metrics-host=127.0.0.2",
@@ -69,6 +75,12 @@ func TestRegisterFlags_AcceptsSingleDashLongFlags(t *testing.T) {
 	}
 	if got := *flags.adminPassword; got != "test-password" {
 		t.Fatalf("expected admin password %q, got %q", "test-password", got)
+	}
+	if got := *flags.adminUsername; got != "test-admin" {
+		t.Fatalf("expected admin username %q, got %q", "test-admin", got)
+	}
+	if got := *flags.adminEmail; got != "test-admin@example.com" {
+		t.Fatalf("expected admin email %q, got %q", "test-admin@example.com", got)
 	}
 	if !*flags.allowInsecure {
 		t.Fatalf("expected allow-insecure to be true")
@@ -194,6 +206,8 @@ func TestRegisterFlags_AcceptsDoubleDashLongFlags(t *testing.T) {
 	err := fs.Parse([]string{
 		"--jwt-secret=test-secret",
 		"--admin-password=test-password",
+		"--admin-username=test-admin",
+		"--admin-email=test-admin@example.com",
 		"--allow-insecure=true",
 		"--enable-metrics=true",
 		"--metrics-host=127.0.0.2",
@@ -209,6 +223,12 @@ func TestRegisterFlags_AcceptsDoubleDashLongFlags(t *testing.T) {
 	}
 	if got := *flags.adminPassword; got != "test-password" {
 		t.Fatalf("expected admin password %q, got %q", "test-password", got)
+	}
+	if got := *flags.adminUsername; got != "test-admin" {
+		t.Fatalf("expected admin username %q, got %q", "test-admin", got)
+	}
+	if got := *flags.adminEmail; got != "test-admin@example.com" {
+		t.Fatalf("expected admin email %q, got %q", "test-admin@example.com", got)
 	}
 	if !*flags.allowInsecure {
 		t.Fatalf("expected allow-insecure to be true")

--- a/cmd/leafwiki/main_test.go
+++ b/cmd/leafwiki/main_test.go
@@ -134,6 +134,8 @@ func TestValidateRedirectURL(t *testing.T) {
 		{"empty", "", false},
 		{"http", "http://idp.example.com/login", false},
 		{"https", "https://idp.example.com/login", false},
+		{"uppercase scheme", "HTTPS://idp.example.com/login", false},
+		{"mixed-case scheme", "Https://idp.example.com/login", false},
 		{"javascript scheme", "javascript:alert(1)", true},
 		{"relative path", "/login", true},
 		{"data scheme", "data:text/html,<script>alert(1)</script>", true},
@@ -145,6 +147,57 @@ func TestValidateRedirectURL(t *testing.T) {
 				t.Fatalf("validateRedirectURL(%q) error = %v, wantErr %v", tc.url, err, tc.wantErr)
 			}
 		})
+	}
+}
+
+func TestResolveLogoutURL(t *testing.T) {
+	tests := []struct {
+		name               string
+		logoutURL          string
+		deprecatedFlagVal  string
+		visited            map[string]bool
+		wantResolved       string
+		wantUsedDeprecated bool
+	}{
+		{
+			name:         "new flag set, deprecated ignored",
+			logoutURL:    "https://idp.example.com/logout",
+			wantResolved: "https://idp.example.com/logout",
+		},
+		{
+			name:               "only deprecated flag set",
+			deprecatedFlagVal:  "https://idp.example.com/logout",
+			visited:            map[string]bool{"http-remote-user-logout-url": true},
+			wantResolved:       "https://idp.example.com/logout",
+			wantUsedDeprecated: true,
+		},
+		{
+			name:         "neither set",
+			wantResolved: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			visited := tc.visited
+			if visited == nil {
+				visited = map[string]bool{}
+			}
+			resolved, usedDeprecated := resolveLogoutURL(tc.logoutURL, tc.deprecatedFlagVal, visited, "LEAFWIKI_HTTP_REMOTE_USER_LOGOUT_URL")
+			if resolved != tc.wantResolved {
+				t.Fatalf("resolveLogoutURL() resolved = %q, want %q", resolved, tc.wantResolved)
+			}
+			if usedDeprecated != tc.wantUsedDeprecated {
+				t.Fatalf("resolveLogoutURL() usedDeprecated = %v, want %v", usedDeprecated, tc.wantUsedDeprecated)
+			}
+		})
+	}
+}
+
+func TestResolveString_TrimsCLIFlagValue(t *testing.T) {
+	visited := map[string]bool{"login-url": true}
+	got := resolveString("login-url", " https://idp.example.com/login ", visited, "LEAFWIKI_LOGIN_URL", "")
+	if want := "https://idp.example.com/login"; got != want {
+		t.Fatalf("resolveString() = %q, want %q", got, want)
 	}
 }
 

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -106,7 +106,7 @@ start_local() {
     cd "$repo_root"
     go run \
       -ldflags="-X github.com/perber/wiki/internal/http.EmbedFrontend=true -X github.com/perber/wiki/internal/http.Environment=production -X github.com/perber/wiki/internal/wiki/auth.DisableRefreshTokenRateLimit=true" \
-      ./cmd/leafwiki/main.go \
+      ./cmd/leafwiki \
       --host 127.0.0.1 \
       --port "$app_port" \
       --data-dir "$local_data_dir" \

--- a/internal/core/auth/user_service.go
+++ b/internal/core/auth/user_service.go
@@ -8,6 +8,11 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+const (
+	defaultAdminUsername = "admin"
+	defaultAdminEmail    = "admin@localhost"
+)
+
 type UserService struct {
 	store *UserStore
 }
@@ -18,7 +23,7 @@ func NewUserService(store *UserStore) *UserService {
 	}
 }
 
-func (s *UserService) InitDefaultAdmin(newPassword string) error {
+func (s *UserService) InitDefaultAdmin(username, email, newPassword string) error {
 	// Check if admin user already exists
 
 	if _, err := s.store.GetAdminUser(); err == nil {
@@ -26,7 +31,16 @@ func (s *UserService) InitDefaultAdmin(newPassword string) error {
 		return nil
 	}
 
-	if _, err := s.CreateUser("admin", "admin@localhost", newPassword, "admin"); err != nil {
+	username = strings.TrimSpace(username)
+	if username == "" {
+		username = defaultAdminUsername
+	}
+	email = strings.TrimSpace(email)
+	if email == "" {
+		email = defaultAdminEmail
+	}
+
+	if _, err := s.CreateUser(username, email, newPassword, "admin"); err != nil {
 		return fmt.Errorf("failed to create default admin: %w", err)
 	}
 
@@ -291,7 +305,7 @@ func (s *UserService) ResetAdminUserPassword() (*User, error) {
 	if err != nil {
 		if err == ErrUserNotFound {
 			// Create default admin user
-			adminUser, err = s.CreateUser("admin", "admin@localhost", password, RoleAdmin)
+			adminUser, err = s.CreateUser(defaultAdminUsername, defaultAdminEmail, password, RoleAdmin)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create default admin: %w", err)
 			}

--- a/internal/core/auth/user_service.go
+++ b/internal/core/auth/user_service.go
@@ -31,20 +31,23 @@ func (s *UserService) InitDefaultAdmin(username, email, newPassword string) erro
 		return nil
 	}
 
-	username = strings.TrimSpace(username)
-	if username == "" {
-		username = defaultAdminUsername
-	}
-	email = strings.TrimSpace(email)
-	if email == "" {
-		email = defaultAdminEmail
-	}
+	username = defaultIfEmpty(username, defaultAdminUsername)
+	email = defaultIfEmpty(email, defaultAdminEmail)
 
 	if _, err := s.CreateUser(username, email, newPassword, "admin"); err != nil {
 		return fmt.Errorf("failed to create default admin: %w", err)
 	}
 
 	return nil
+}
+
+// defaultIfEmpty trims value and returns fallback if the result is empty.
+func defaultIfEmpty(value, fallback string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback
+	}
+	return value
 }
 
 func (s *UserService) CreateUser(username, email, password, role string) (*User, error) {
@@ -293,7 +296,7 @@ func (s *UserService) ChangeOwnPassword(id, oldPassword, newPassword string) err
 	return nil
 }
 
-func (s *UserService) ResetAdminUserPassword() (*User, error) {
+func (s *UserService) ResetAdminUserPassword(username, email string) (*User, error) {
 	// Generate a new password for the admin user
 	password, err := shared.GenerateRandomPassword(16)
 	if err != nil {
@@ -305,7 +308,9 @@ func (s *UserService) ResetAdminUserPassword() (*User, error) {
 	if err != nil {
 		if err == ErrUserNotFound {
 			// Create default admin user
-			adminUser, err = s.CreateUser(defaultAdminUsername, defaultAdminEmail, password, RoleAdmin)
+			username = defaultIfEmpty(username, defaultAdminUsername)
+			email = defaultIfEmpty(email, defaultAdminEmail)
+			adminUser, err = s.CreateUser(username, email, password, RoleAdmin)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create default admin: %w", err)
 			}

--- a/internal/core/auth/user_service_test.go
+++ b/internal/core/auth/user_service_test.go
@@ -208,7 +208,7 @@ func TestUserService_ResetAdminUserPassword(t *testing.T) {
 	}
 
 	// Reset admin password
-	adminUser, err := service.ResetAdminUserPassword()
+	adminUser, err := service.ResetAdminUserPassword("", "")
 	if err != nil {
 		t.Fatalf("ResetAdminUserPassword failed: %v", err)
 	}
@@ -245,7 +245,7 @@ func TestUserService_ResetAdminUserPassword_NoAdmin(t *testing.T) {
 	// Don't create an admin user first - test should create one
 
 	// Reset admin password (should create new admin)
-	adminUser, err := service.ResetAdminUserPassword()
+	adminUser, err := service.ResetAdminUserPassword("", "")
 	if err != nil {
 		t.Fatalf("ResetAdminUserPassword failed: %v", err)
 	}
@@ -264,6 +264,32 @@ func TestUserService_ResetAdminUserPassword_NoAdmin(t *testing.T) {
 
 	// Verify we can log in with the new password
 	_, err = service.GetUserByEmailOrUsernameAndPassword("admin", adminUser.Password)
+	if err != nil {
+		t.Errorf("Failed to login with new password: %v", err)
+	}
+}
+
+func TestUserService_ResetAdminUserPassword_NoAdmin_UsesGivenUsernameAndEmail(t *testing.T) {
+	service := setupTestUserService(t)
+	defer test_utils.WrapCloseWithErrorCheck(service.Close, t)
+
+	// Don't create an admin user first - test should create one with the given identity
+
+	adminUser, err := service.ResetAdminUserPassword("root", "root@example.com")
+	if err != nil {
+		t.Fatalf("ResetAdminUserPassword failed: %v", err)
+	}
+
+	if adminUser.Username != "root" {
+		t.Errorf("Expected username 'root', got: %s", adminUser.Username)
+	}
+
+	if adminUser.Email != "root@example.com" {
+		t.Errorf("Expected email 'root@example.com', got: %s", adminUser.Email)
+	}
+
+	// Verify we can log in with the new password
+	_, err = service.GetUserByEmailOrUsernameAndPassword("root", adminUser.Password)
 	if err != nil {
 		t.Errorf("Failed to login with new password: %v", err)
 	}

--- a/internal/core/auth/user_service_test.go
+++ b/internal/core/auth/user_service_test.go
@@ -152,14 +152,48 @@ func TestUserService_InitDefaultAdmin(t *testing.T) {
 	store, _ := NewUserStore(t.TempDir())
 	service := NewUserService(store)
 
-	err := service.InitDefaultAdmin("")
+	err := service.InitDefaultAdmin("", "", "")
 	if err != nil {
 		t.Errorf("InitDefaultAdmin failed: %v", err)
 	}
 
 	users, err := service.GetUsers()
-	if err != nil || len(users) != 1 || users[0].Username != "admin" {
+	if err != nil || len(users) != 1 || users[0].Username != "admin" || users[0].Email != "admin@localhost" {
 		t.Errorf("Expected default admin user, got: %+v", users)
+	}
+}
+
+func TestUserService_InitDefaultAdmin_UsesGivenUsernameAndEmail(t *testing.T) {
+	store, _ := NewUserStore(t.TempDir())
+	service := NewUserService(store)
+
+	err := service.InitDefaultAdmin("root", "root@example.com", "")
+	if err != nil {
+		t.Errorf("InitDefaultAdmin failed: %v", err)
+	}
+
+	users, err := service.GetUsers()
+	if err != nil || len(users) != 1 || users[0].Username != "root" || users[0].Email != "root@example.com" {
+		t.Errorf("Expected admin user with custom username/email, got: %+v", users)
+	}
+}
+
+func TestUserService_InitDefaultAdmin_SkipsWhenAdminAlreadyExists(t *testing.T) {
+	store, _ := NewUserStore(t.TempDir())
+	service := NewUserService(store)
+
+	if _, err := service.CreateUser("admin", "admin@localhost", "existing", "admin"); err != nil {
+		t.Fatalf("Failed to create initial admin user: %v", err)
+	}
+
+	err := service.InitDefaultAdmin("root", "root@example.com", "new")
+	if err != nil {
+		t.Errorf("InitDefaultAdmin failed: %v", err)
+	}
+
+	users, err := service.GetUsers()
+	if err != nil || len(users) != 1 || users[0].Username != "admin" || users[0].Email != "admin@localhost" {
+		t.Errorf("Expected existing admin user to be left untouched, got: %+v", users)
 	}
 }
 

--- a/internal/core/tools/adminreset.go
+++ b/internal/core/tools/adminreset.go
@@ -6,7 +6,7 @@ import (
 	"github.com/perber/wiki/internal/core/auth"
 )
 
-func ResetAdminPassword(storageDir string) (*auth.User, error) {
+func ResetAdminPassword(storageDir, username, email string) (*auth.User, error) {
 	store, err := auth.NewUserStore(storageDir)
 	if err != nil {
 		return nil, err
@@ -18,5 +18,5 @@ func ResetAdminPassword(storageDir string) (*auth.User, error) {
 	}()
 
 	userService := auth.NewUserService(store)
-	return userService.ResetAdminUserPassword()
+	return userService.ResetAdminUserPassword(username, email)
 }

--- a/internal/core/tools/adminreset_test.go
+++ b/internal/core/tools/adminreset_test.go
@@ -30,7 +30,7 @@ func TestResetAdminPassword(t *testing.T) {
 	}
 
 	// Now test ResetAdminPassword
-	adminUser, err := ResetAdminPassword(tempDir)
+	adminUser, err := ResetAdminPassword(tempDir, "", "")
 	if err != nil {
 		t.Fatalf("ResetAdminPassword failed: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestResetAdminPassword_NoAdmin(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// Test ResetAdminPassword when no admin exists
-	adminUser, err := ResetAdminPassword(tempDir)
+	adminUser, err := ResetAdminPassword(tempDir, "", "")
 	if err != nil {
 		t.Fatalf("ResetAdminPassword failed: %v", err)
 	}
@@ -98,5 +98,23 @@ func TestResetAdminPassword_NoAdmin(t *testing.T) {
 	_, err = userService.GetUserByEmailOrUsernameAndPassword("admin", adminUser.Password)
 	if err != nil {
 		t.Errorf("Failed to login with new password: %v", err)
+	}
+}
+
+func TestResetAdminPassword_NoAdmin_UsesGivenUsernameAndEmail(t *testing.T) {
+	// Create a temporary directory for the test (no admin user exists)
+	tempDir := t.TempDir()
+
+	adminUser, err := ResetAdminPassword(tempDir, "root", "root@example.com")
+	if err != nil {
+		t.Fatalf("ResetAdminPassword failed: %v", err)
+	}
+
+	if adminUser.Username != "root" {
+		t.Errorf("Expected username 'root', got: %s", adminUser.Username)
+	}
+
+	if adminUser.Email != "root@example.com" {
+		t.Errorf("Expected email 'root@example.com', got: %s", adminUser.Email)
 	}
 }

--- a/internal/http/middleware/auth/auth_test.go
+++ b/internal/http/middleware/auth/auth_test.go
@@ -31,7 +31,7 @@ func createTestAuthFixture(t *testing.T) *authFixture {
 	}
 
 	userService := coreauth.NewUserService(userStore)
-	if err := userService.InitDefaultAdmin("admin"); err != nil {
+	if err := userService.InitDefaultAdmin("", "", "admin"); err != nil {
 		_ = sessionStore.Close()
 		_ = userStore.Close()
 		t.Fatalf("Failed to init default admin: %v", err)

--- a/internal/http/middleware/auth/reverse_proxy_test.go
+++ b/internal/http/middleware/auth/reverse_proxy_test.go
@@ -35,7 +35,7 @@ func createProxyFixture(t *testing.T) *proxyFixture {
 	}
 
 	userService := coreauth.NewUserService(userStore)
-	if err := userService.InitDefaultAdmin("admin"); err != nil {
+	if err := userService.InitDefaultAdmin("", "", "admin"); err != nil {
 		_ = userStore.Close()
 		t.Fatalf("init default admin: %v", err)
 	}

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -79,6 +79,8 @@ const SYSTEM_USER_ID = "system"
 
 type WikiOptions struct {
 	StorageDir              string        // Path to storage directory
+	AdminUsername           string        // Initial admin username (optional; defaults to "admin")
+	AdminEmail              string        // Initial admin email (optional; defaults to "admin@localhost")
 	AdminPassword           string        // Initial admin password
 	JWTSecret               string        // JWT secret for authentication
 	AccessTokenTimeout      time.Duration // Access token timeout duration
@@ -182,7 +184,7 @@ func (w *Wiki) initAuth(options *WikiOptions) error {
 	}
 	w.user = auth.NewUserService(store)
 	if !options.AuthDisabled {
-		if err := w.user.InitDefaultAdmin(options.AdminPassword); err != nil {
+		if err := w.user.InitDefaultAdmin(options.AdminUsername, options.AdminEmail, options.AdminPassword); err != nil {
 			return err
 		}
 	}

--- a/internal/wiki/wiki_test.go
+++ b/internal/wiki/wiki_test.go
@@ -197,6 +197,30 @@ func TestWiki_InitDefaultAdmin_UsesGivenPassword(t *testing.T) {
 	}
 }
 
+func TestWiki_InitDefaultAdmin_UsesGivenUsernameAndEmail(t *testing.T) {
+	wikiInstance, err := NewWiki(&WikiOptions{
+		StorageDir:          t.TempDir(),
+		AdminUsername:       "root",
+		AdminEmail:          "root@example.com",
+		AdminPassword:       "admin",
+		JWTSecret:           "secretkey",
+		AccessTokenTimeout:  15 * time.Minute,
+		RefreshTokenTimeout: 7 * 24 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create wiki instance: %v", err)
+	}
+	defer test_utils.WrapCloseWithErrorCheck(wikiInstance.Close, t)
+
+	user, err := wikiInstance.user.GetUserByEmailOrUsernameAndPassword("root", "admin")
+	if err != nil {
+		t.Fatalf("Admin user with custom username not found: %v", err)
+	}
+	if user.Email != "root@example.com" {
+		t.Errorf("Expected admin email %q, got %q", "root@example.com", user.Email)
+	}
+}
+
 func TestWiki_Login_SuccessAndFailure(t *testing.T) {
 	w := createWikiTestInstance(t)
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)

--- a/ui/leafwiki-ui/src/components/UserToolbar.tsx
+++ b/ui/leafwiki-ui/src/components/UserToolbar.tsx
@@ -16,6 +16,7 @@ import {
   DIALOG_SHORTCUTS_HELP,
 } from '@/lib/registries'
 import { useTranslation } from 'react-i18next'
+import { redirectToExternal } from '@/lib/redirectToExternal'
 import {
   createHotkeyDefinition,
   getShortcutDisplayLabel,
@@ -81,7 +82,7 @@ export default function UserToolbar() {
         <Button
           size="sm"
           onClick={() =>
-            loginUrl ? (window.location.href = loginUrl) : navigate('/login')
+            loginUrl ? redirectToExternal(loginUrl) : navigate('/login')
           }
         >
           {t('login.loginButton')}
@@ -106,7 +107,7 @@ export default function UserToolbar() {
       // clearing it here would flash the local login screen before the
       // browser navigates away (see plans/logout-flash-and-external-user-management.md).
       authAPI.logout().catch(() => {})
-      window.location.href = logoutUrl
+      redirectToExternal(logoutUrl)
       return
     }
     await logout()

--- a/ui/leafwiki-ui/src/features/auth/AuthRedirect.test.tsx
+++ b/ui/leafwiki-ui/src/features/auth/AuthRedirect.test.tsx
@@ -78,7 +78,7 @@ describe('Auth redirect flow', () => {
     )
   })
 
-  it('redirects externally instead of to /login when loginUrl is configured', async () => {
+  it('redirects externally instead of to /login when loginUrl is configured, preserving the requested path', async () => {
     const originalLocation = window.location
     Object.defineProperty(window, 'location', {
       configurable: true,
@@ -106,8 +106,13 @@ describe('Auth redirect flow', () => {
         </MemoryRouter>,
       )
 
+      const expectedReturnTo = encodeURIComponent(
+        `${originalLocation.origin}/some/protected/page`,
+      )
       await waitFor(() => {
-        expect(window.location.href).toBe('https://idp.example.com/login')
+        expect(window.location.href).toBe(
+          `https://idp.example.com/login?redirect_uri=${expectedReturnTo}`,
+        )
       })
       expect(screen.queryByTestId('pathname')).not.toBeInTheDocument()
     } finally {

--- a/ui/leafwiki-ui/src/features/auth/ExternalRedirect.tsx
+++ b/ui/leafwiki-ui/src/features/auth/ExternalRedirect.tsx
@@ -1,8 +1,15 @@
 import { useEffect } from 'react'
+import { redirectToExternal } from '@/lib/redirectToExternal'
 
-export default function ExternalRedirect({ to }: { to: string }) {
+export default function ExternalRedirect({
+  to,
+  returnTo,
+}: {
+  to: string
+  returnTo?: string
+}) {
   useEffect(() => {
-    window.location.href = to
-  }, [to])
+    redirectToExternal(to, returnTo)
+  }, [to, returnTo])
   return null
 }

--- a/ui/leafwiki-ui/src/features/auth/RequireAuth.tsx
+++ b/ui/leafwiki-ui/src/features/auth/RequireAuth.tsx
@@ -18,10 +18,10 @@ export default function RequireAuth({ children }: Props) {
   if (authDisabled) return <>{children}</>
 
   if (!user && !isRefreshing) {
-    if (loginUrl) {
-      return <ExternalRedirect to={loginUrl} />
-    }
     const redirectTo = `${location.pathname}${location.search}${location.hash}`
+    if (loginUrl) {
+      return <ExternalRedirect to={loginUrl} returnTo={redirectTo} />
+    }
     return <Navigate to="/login" replace state={{ redirectTo }} />
   }
 

--- a/ui/leafwiki-ui/src/lib/redirectToExternal.ts
+++ b/ui/leafwiki-ui/src/lib/redirectToExternal.ts
@@ -1,0 +1,12 @@
+// Shared navigation mechanism for all "leave the app for an external URL"
+// call sites (login/logout redirects in ExternalRedirect and UserToolbar),
+// so redirect behavior only needs to change in one place.
+export function redirectToExternal(url: string, returnTo?: string) {
+  if (!returnTo) {
+    window.location.href = url
+    return
+  }
+  const separator = url.includes('?') ? '&' : '?'
+  const absoluteReturnTo = `${window.location.origin}${returnTo}`
+  window.location.href = `${url}${separator}redirect_uri=${encodeURIComponent(absoluteReturnTo)}`
+}


### PR DESCRIPTION
Add optional --admin-username/--admin-email flags (and matching LEAFWIKI_ADMIN_USERNAME/LEAFWIKI_ADMIN_EMAIL env vars), following the existing CLI>ENV>default resolver pattern. Both stay optional and default to the previous hardcoded admin/admin@localhost when unset.
