### PR TITLE
feat(tree): drag & drop page/section reordering in the page tree

### DIFF
--- a/e2e/pages/EditPage.ts
+++ b/e2e/pages/EditPage.ts
@@ -43,6 +43,9 @@ export default class EditPage {
       await expect(saveButton).toBeEnabled({ timeout: 3000 });
       await saveButton.click();
       await this.page.getByText('Page saved successfully').last().waitFor({ state: 'visible' });
+      // The dirty flag can clear slightly after the success toast; closing the
+      // editor before it does trips the unsaved-changes blocker on slow runners.
+      await expect(dirtyIndicator).toHaveCount(0, { timeout: 5000 });
       return;
     } catch {
       await expect(saveButton).toBeDisabled();

--- a/internal/core/tree/tree_service.go
+++ b/internal/core/tree/tree_service.go
@@ -1276,8 +1276,16 @@ func (t *TreeService) EnsurePagePath(userID string, p string, targetTitle string
 	}, nil
 }
 
-// MoveNode moves a node to another parent (root if parentID is empty/"root")
+// MoveNode moves a node to another parent (root if parentID is empty/"root"),
+// appending it at the end of the new parent's children.
 func (t *TreeService) MoveNode(userID string, id string, parentID string, expectedVersion string) error {
+	return t.MoveNodeToPosition(userID, id, parentID, expectedVersion, -1)
+}
+
+// MoveNodeToPosition moves a node to another parent (root if parentID is empty/"root")
+// and inserts it at the given index among the new parent's children.
+// A negative or out-of-range position appends at the end.
+func (t *TreeService) MoveNodeToPosition(userID string, id string, parentID string, expectedVersion string, position int) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -1355,8 +1363,14 @@ func (t *TreeService) MoveNode(userID string, id string, parentID string, expect
 		}
 	}
 
-	node.Position = len(newParent.Children)
-	newParent.Children = append(newParent.Children, node)
+	insertAt := len(newParent.Children)
+	if position >= 0 && position < len(newParent.Children) {
+		insertAt = position
+	}
+	newParent.Children = append(newParent.Children, nil)
+	copy(newParent.Children[insertAt+1:], newParent.Children[insertAt:])
+	newParent.Children[insertAt] = node
+	node.Position = insertAt
 	node.Parent = newParent
 	t.rebuildChildSlugIndexForParentLocked(oldParent)
 	t.rebuildChildSlugIndexForParentLocked(newParent)

--- a/internal/wiki/pages/move_page.go
+++ b/internal/wiki/pages/move_page.go
@@ -16,6 +16,8 @@ type MovePageInput struct {
 	ID       string
 	Version  string
 	ParentID string
+	// Position is the target index among the new parent's children; nil appends at the end.
+	Position *int
 }
 
 // MovePageUseCase moves a page to a new parent, updating links and recording revisions.
@@ -76,7 +78,11 @@ func (uc *MovePageUseCase) Execute(_ context.Context, in MovePageInput) (err err
 		oldPath = beforePage.CalculatePath()
 	}
 
-	if err = uc.tree.MoveNode(in.UserID, in.ID, in.ParentID, in.Version); err != nil {
+	position := -1
+	if in.Position != nil {
+		position = *in.Position
+	}
+	if err = uc.tree.MoveNodeToPosition(in.UserID, in.ID, in.ParentID, in.Version, position); err != nil {
 		return err
 	}
 

--- a/internal/wiki/pages/routes.go
+++ b/internal/wiki/pages/routes.go
@@ -330,6 +330,7 @@ func (r *Routes) handleMove(c *gin.Context) {
 	var req struct {
 		Version  string `json:"version" binding:"required"`
 		ParentID string `json:"parentId"`
+		Position *int   `json:"position"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		respondWithPageStatusError(c, http.StatusBadRequest, ErrCodePageInvalidPayload, "Invalid payload", "invalid payload")
@@ -340,7 +341,7 @@ func (r *Routes) handleMove(c *gin.Context) {
 		return
 	}
 	if err := r.movePage.Execute(c.Request.Context(), MovePageInput{
-		UserID: user.ID, ID: id, Version: req.Version, ParentID: req.ParentID,
+		UserID: user.ID, ID: id, Version: req.Version, ParentID: req.ParentID, Position: req.Position,
 	}); err != nil {
 		respondWithPageError(c, err)
 		return

--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
@@ -616,50 +616,57 @@ export default function MarkdownPreview({
     return () => observer.disconnect()
   }, [showToc, tocEntries.length, onStickyTocChange])
 
-  const markdownBody = (
-    <MarkdownPreviewErrorBoundary resetKey={`${path ?? ''}:${content}`}>
-      <>
-        <ReactMarkdown
-          // singleDollarTextMath disabled: $var in bash/code prose would be parsed
-          // as math delimiters and conflict with wikilink preprocessing. Use $$...$$ for math.
-          remarkPlugins={[
-            [remarkMath, { singleDollarTextMath: false }],
-            remarkGfm,
-          ]}
-          rehypePlugins={[
-            rehypeRaw,
-            rehypeLineNumber,
-            rehypeWhitelistStyles,
-            [rehypeKatex, { output: 'html', strict: 'ignore' }],
-            [rehypeSanitize, schema],
-            [
-              rehypeHighlight,
-              {
-                languages: {
-                  ...common,
-                  bash,
-                  sh: bash,
-                  shell,
-                  console: shell,
-                  shellsession: shell,
-                  dockerfile,
-                  http,
-                  nginx,
-                  nix,
-                  powershell,
-                  protobuf,
+  // Memoized on the resolved markdown string: tree updates (e.g. drag reorder
+  // in the sidebar) swap the store's byId identity on every change, and without
+  // this the whole remark/rehype pipeline would re-parse and re-render the
+  // article on each of those updates even though nothing in it changed.
+  const markdownBody = useMemo(
+    () => (
+      <MarkdownPreviewErrorBoundary resetKey={`${path ?? ''}:${content}`}>
+        <>
+          <ReactMarkdown
+            // singleDollarTextMath disabled: $var in bash/code prose would be parsed
+            // as math delimiters and conflict with wikilink preprocessing. Use $$...$$ for math.
+            remarkPlugins={[
+              [remarkMath, { singleDollarTextMath: false }],
+              remarkGfm,
+            ]}
+            rehypePlugins={[
+              rehypeRaw,
+              rehypeLineNumber,
+              rehypeWhitelistStyles,
+              [rehypeKatex, { output: 'html', strict: 'ignore' }],
+              [rehypeSanitize, schema],
+              [
+                rehypeHighlight,
+                {
+                  languages: {
+                    ...common,
+                    bash,
+                    sh: bash,
+                    shell,
+                    console: shell,
+                    shellsession: shell,
+                    dockerfile,
+                    http,
+                    nginx,
+                    nix,
+                    powershell,
+                    protobuf,
+                  },
                 },
-              },
-            ],
-          ]}
-          components={components}
-          urlTransform={transformMarkdownUrl}
-        >
-          {normalizedContent}
-        </ReactMarkdown>
-        <div id="mermaid-renderer"></div>
-      </>
-    </MarkdownPreviewErrorBoundary>
+              ],
+            ]}
+            components={components}
+            urlTransform={transformMarkdownUrl}
+          >
+            {normalizedContent}
+          </ReactMarkdown>
+          <div id="mermaid-renderer"></div>
+        </>
+      </MarkdownPreviewErrorBoundary>
+    ),
+    [normalizedContent, components, path, content],
   )
 
   if (!showToc || tocEntries.length <= 3) {

--- a/ui/leafwiki-ui/src/features/tree/TreeDnd.tsx
+++ b/ui/leafwiki-ui/src/features/tree/TreeDnd.tsx
@@ -1,0 +1,354 @@
+import {
+  convertPage,
+  movePage,
+  NODE_KIND_PAGE,
+  NODE_KIND_SECTION,
+  PageNode,
+  sortPages,
+} from '@/lib/api/pages'
+import { useTreeStore } from '@/stores/tree'
+import {
+  DndContext,
+  DragEndEvent,
+  DragMoveEvent,
+  DragOverlay,
+  DragStartEvent,
+  Modifier,
+  MouseSensor,
+  TouchSensor,
+  pointerWithin,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import { getEventCoordinates } from '@dnd-kit/utilities'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { toast } from 'sonner'
+import { TreeDndContext } from './treeDndContext'
+import {
+  buildOrderedIds,
+  collectSubtreeIds,
+  DropResolution,
+  DropTarget,
+  getDropZone,
+  resolveDrop,
+  ROOT_ID,
+} from './treeDndUtils'
+
+const EXPAND_ON_HOVER_DELAY_MS = 600
+
+// Dragging the last child out of a section leaves it empty. That may well
+// be intentional (mid-reorganization), so it is never converted back
+// automatically — instead a toast offers the conversion as a one-click
+// action, mirroring how nesting created the section in the first place.
+function offerConvertBackToPage(parentId: string) {
+  const { byId } = useTreeStore.getState()
+  const parent = byId[parentId]
+  if (!parent || parent.kind !== NODE_KIND_SECTION) return
+  if ((parent.children?.length ?? 0) > 0) return
+
+  toast(`"${parent.title}" is now an empty section`, {
+    action: {
+      label: 'Convert back to page',
+      onClick: () => {
+        const node = useTreeStore.getState().byId[parentId]
+        if (!node) return
+        convertPage(parentId, NODE_KIND_PAGE, node.version)
+          .then(() => useTreeStore.getState().reloadTree({ silent: true }))
+          .then(() => toast.success(`"${node.title}" is a page again`))
+          .catch((err) => {
+            console.warn(err)
+            toast.error('Failed to convert section back to page')
+          })
+      },
+    },
+  })
+}
+
+// Keeps the overlay chip attached to the cursor (12px right of it,
+// vertically centered) instead of at the dragged row's original offset.
+const followCursor: Modifier = ({
+  activatorEvent,
+  draggingNodeRect,
+  transform,
+}) => {
+  if (!draggingNodeRect || !activatorEvent) {
+    return transform
+  }
+  const coords = getEventCoordinates(activatorEvent)
+  if (!coords) {
+    return transform
+  }
+  return {
+    ...transform,
+    x: transform.x + coords.x - draggingNodeRect.left + 12,
+    y:
+      transform.y +
+      coords.y -
+      draggingNodeRect.top -
+      draggingNodeRect.height / 2,
+  }
+}
+
+function getPointerY(
+  activatorEvent: Event,
+  delta: { y: number },
+): number | null {
+  const mouseLike = activatorEvent as MouseEvent
+  if (typeof mouseLike.clientY === 'number') {
+    return mouseLike.clientY + delta.y
+  }
+  const touch = (activatorEvent as TouchEvent).touches?.[0]
+  if (touch) {
+    return touch.clientY + delta.y
+  }
+  return null
+}
+
+// The click that follows a drop must never reach the row links: in Firefox
+// it targets the dragged link itself and bypasses React's synthetic
+// handlers entirely, so the anchor's default action would do a full-page
+// navigation. A native window-level capture listener runs before any
+// framework code and independent of React event timing, which is why the
+// suppression lives here and not in an onClickCapture prop. Armed for the
+// whole drag so it's in place no matter when the browser fires the click;
+// one drag produces at most one click, so it disarms itself after the
+// first one and a stray armed listener can never swallow more.
+function suppressClickCapture(e: MouseEvent) {
+  e.preventDefault()
+  e.stopPropagation()
+  window.removeEventListener('click', suppressClickCapture, true)
+}
+
+function disarmClickSuppression() {
+  window.removeEventListener('click', suppressClickCapture, true)
+}
+
+export function TreeDndProvider({
+  enabled,
+  children,
+}: {
+  enabled: boolean
+  children: React.ReactNode
+}) {
+  const [activeNode, setActiveNode] = useState<PageNode | null>(null)
+  const [dropTarget, setDropTarget] = useState<DropTarget | null>(null)
+  const [saving, setSaving] = useState(false)
+  const subtreeIdsRef = useRef<Set<string>>(new Set())
+  const expandTimerRef = useRef<{ nodeId: string; timer: number } | null>(null)
+  const disarmClickTimerRef = useRef<number | null>(null)
+
+  const armClickSuppression = useCallback(() => {
+    if (disarmClickTimerRef.current) {
+      window.clearTimeout(disarmClickTimerRef.current)
+      disarmClickTimerRef.current = null
+    }
+    // Re-adding the same listener/capture pair is a no-op, so this is safe
+    // even if a previous drag's listener is still armed.
+    window.addEventListener('click', suppressClickCapture, true)
+  }, [])
+
+  const scheduleClickSuppressionDisarm = useCallback(() => {
+    if (disarmClickTimerRef.current) {
+      window.clearTimeout(disarmClickTimerRef.current)
+    }
+    disarmClickTimerRef.current = window.setTimeout(() => {
+      disarmClickSuppression()
+      disarmClickTimerRef.current = null
+    }, 400)
+  }, [])
+
+  useEffect(() => disarmClickSuppression, [])
+
+  const sensors = useSensors(
+    // Distance threshold keeps plain clicks navigating; on touch a long
+    // press starts the drag so the tree still scrolls normally.
+    useSensor(MouseSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 250, tolerance: 8 },
+    }),
+  )
+
+  const clearExpandTimer = () => {
+    if (expandTimerRef.current) {
+      window.clearTimeout(expandTimerRef.current.timer)
+      expandTimerRef.current = null
+    }
+  }
+
+  const resetDragState = () => {
+    setActiveNode(null)
+    setDropTarget(null)
+    subtreeIdsRef.current = new Set()
+    clearExpandTimer()
+  }
+
+  const updateDropTarget = (next: DropTarget | null) => {
+    setDropTarget((prev) =>
+      prev?.nodeId === next?.nodeId && prev?.zone === next?.zone ? prev : next,
+    )
+  }
+
+  const handleDragStart = (event: DragStartEvent) => {
+    const node = event.active.data.current?.node as PageNode | undefined
+    if (!node) return
+    armClickSuppression()
+    setActiveNode(node)
+    subtreeIdsRef.current = collectSubtreeIds(node)
+  }
+
+  const handleDragMove = (event: DragMoveEvent) => {
+    const target = event.over?.data.current?.node as PageNode | undefined
+
+    if (!event.over || !target || subtreeIdsRef.current.has(target.id)) {
+      updateDropTarget(null)
+      clearExpandTimer()
+      return
+    }
+
+    const pointerY = getPointerY(event.activatorEvent, event.delta)
+    const zone =
+      pointerY === null ? null : getDropZone(pointerY, event.over.rect)
+    if (!zone) {
+      updateDropTarget(null)
+      clearExpandTimer()
+      return
+    }
+
+    updateDropTarget({ nodeId: target.id, zone })
+
+    const { isNodeOpen, openNode } = useTreeStore.getState()
+    if (
+      zone === 'inside' &&
+      target.kind === NODE_KIND_SECTION &&
+      !isNodeOpen(target.id)
+    ) {
+      if (expandTimerRef.current?.nodeId !== target.id) {
+        clearExpandTimer()
+        const timer = window.setTimeout(() => {
+          openNode(target.id)
+          expandTimerRef.current = null
+        }, EXPAND_ON_HOVER_DELAY_MS)
+        expandTimerRef.current = { nodeId: target.id, timer }
+      }
+    } else {
+      clearExpandTimer()
+    }
+  }
+
+  const performDrop = async (dragged: PageNode, resolution: DropResolution) => {
+    const { byId, moveNodeLocally, reloadTree, openNode } =
+      useTreeStore.getState()
+    const currentParentId = dragged.parentId ?? ROOT_ID
+    const sameParent = resolution.parentId === currentParentId
+
+    if (sameParent) {
+      const siblings = byId[resolution.parentId]?.children ?? []
+      const orderedIds = buildOrderedIds(siblings, dragged.id, resolution.index)
+      const unchanged = orderedIds.every((id, i) => siblings[i]?.id === id)
+      if (unchanged) return
+
+      moveNodeLocally(dragged.id, resolution.parentId, resolution.index)
+      setSaving(true)
+      try {
+        await sortPages(resolution.parentId, orderedIds)
+        await reloadTree({ silent: true })
+      } catch (err) {
+        console.warn(err)
+        toast.error('Failed to reorder pages')
+        await reloadTree({ silent: true })
+      } finally {
+        setSaving(false)
+      }
+      return
+    }
+
+    moveNodeLocally(dragged.id, resolution.parentId, resolution.index)
+    if (resolution.parentId !== ROOT_ID) {
+      openNode(resolution.parentId)
+    }
+    setSaving(true)
+    try {
+      await movePage(
+        dragged.id,
+        dragged.version,
+        resolution.parentId,
+        resolution.index,
+      )
+      await reloadTree({ silent: true })
+      if (currentParentId !== ROOT_ID) {
+        offerConvertBackToPage(currentParentId)
+      }
+    } catch (err) {
+      console.warn(err)
+      toast.error('Failed to move page')
+      await reloadTree({ silent: true })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    scheduleClickSuppressionDisarm()
+
+    const dragged = event.active.data.current?.node as PageNode | undefined
+    const target = dropTarget
+    resetDragState()
+
+    if (!dragged || !target) return
+
+    const { byId, isNodeOpen } = useTreeStore.getState()
+    const targetNode = byId[target.nodeId]
+    if (!targetNode) return
+
+    const resolution = resolveDrop({
+      dragged,
+      target: targetNode,
+      zone: target.zone,
+      byId,
+      isNodeOpen,
+    })
+    if (!resolution) return
+
+    void performDrop(dragged, resolution)
+  }
+
+  return (
+    <TreeDndContext.Provider
+      value={{
+        enabled: enabled && !saving,
+        activeId: activeNode?.id ?? null,
+        dropTarget,
+      }}
+    >
+      <DndContext
+        sensors={sensors}
+        collisionDetection={pointerWithin}
+        autoScroll={{ threshold: { x: 0, y: 0.2 } }}
+        onDragStart={handleDragStart}
+        onDragMove={handleDragMove}
+        onDragEnd={handleDragEnd}
+        onDragCancel={() => {
+          scheduleClickSuppressionDisarm()
+          resetDragState()
+        }}
+      >
+        {children}
+        {/* Portaled to <body>: the sidebar panel animates via a CSS
+            transform, which would otherwise become the containing block
+            for the fixed-positioned overlay and offset it from the
+            cursor. */}
+        {createPortal(
+          <DragOverlay dropAnimation={null} modifiers={[followCursor]}>
+            {activeNode ? (
+              <div className="tree-dnd__overlay">
+                {activeNode.title || 'Untitled Page'}
+              </div>
+            ) : null}
+          </DragOverlay>,
+          document.body,
+        )}
+      </DndContext>
+    </TreeDndContext.Provider>
+  )
+}

--- a/ui/leafwiki-ui/src/features/tree/TreeNode.tsx
+++ b/ui/leafwiki-ui/src/features/tree/TreeNode.tsx
@@ -6,10 +6,12 @@ import { useIsMobile } from '@/lib/useIsMobile'
 import { useIsReadOnly } from '@/lib/useIsReadOnly'
 import { useDialogsStore } from '@/stores/dialogs'
 import { useTreeStore } from '@/stores/tree'
+import { useDraggable, useDroppable } from '@dnd-kit/core'
 import clsx from 'clsx'
-import { ChevronUp, FilePlus } from 'lucide-react'
+import { ChevronUp, FilePlus, FolderPlus } from 'lucide-react'
 import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
+import { useTreeDnd } from './treeDndContext'
 import { useTreeNodeActionsMenusStore } from './treeNodeActionsMenus'
 import TreeNodeActionsMenu from './TreeNodeActionsMenu'
 
@@ -31,6 +33,27 @@ export const TreeNode = React.memo(function TreeNode({ node }: Props) {
   )
   const isActive = isStoreActive
 
+  const dnd = useTreeDnd()
+  const {
+    setNodeRef: setDragRef,
+    listeners,
+    isDragging,
+  } = useDraggable({
+    id: node.id,
+    data: { node },
+    disabled: !dnd.enabled,
+  })
+  const { setNodeRef: setDropRef } = useDroppable({
+    id: node.id,
+    data: { node },
+    disabled: !dnd.enabled,
+  })
+  const setRowRef = (el: HTMLElement | null) => {
+    setDragRef(el)
+    setDropRef(el)
+  }
+  const dropTarget = dnd.dropTarget?.nodeId === node.id ? dnd.dropTarget : null
+
   const indent = 4
   const markerOffset = 8 // Distance from left for the vertical line
 
@@ -42,6 +65,7 @@ export const TreeNode = React.memo(function TreeNode({ node }: Props) {
         className="tree-node__link"
         data-testid={`tree-node-link-${node.id}`}
         aria-current={isActive ? 'page' : undefined}
+        draggable={false}
       >
         <span
           className={clsx('tree-node__title', {
@@ -59,15 +83,29 @@ export const TreeNode = React.memo(function TreeNode({ node }: Props) {
   return (
     <>
       <div
+        ref={setRowRef}
+        {...(dnd.enabled ? listeners : {})}
         className={clsx('tree-node', {
           'tree-node--active': isActive,
           'tree-node--inactive': !isActive,
+          'tree-node--dragging': isDragging,
+          'tree-node--drop-inside': dropTarget?.zone === 'inside',
         })}
         data-testid={`tree-node-${node.id}`}
         style={{ paddingLeft: indent }}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
       >
+        {dropTarget?.zone === 'before' && (
+          <div className="tree-node__drop-line tree-node__drop-line--top" />
+        )}
+        {dropTarget?.zone === 'after' && (
+          <div className="tree-node__drop-line tree-node__drop-line--bottom" />
+        )}
+        {dropTarget?.zone === 'inside' && node.kind !== NODE_KIND_SECTION && (
+          // Nesting into a page converts it into a section on drop
+          <FolderPlus size={14} className="tree-node__nest-hint" />
+        )}
         <div
           className={clsx('tree-node__marker', {
             'tree-node__marker--active': isActive,
@@ -123,6 +161,7 @@ export const TreeNode = React.memo(function TreeNode({ node }: Props) {
       <div
         className={clsx('tree-node__children', {
           'tree-node__children--closed': !open,
+          'tree-node__children--dragging': dnd.activeId === node.id,
         })}
       >
         {hasChildren &&

--- a/ui/leafwiki-ui/src/features/tree/TreeView.tsx
+++ b/ui/leafwiki-ui/src/features/tree/TreeView.tsx
@@ -30,6 +30,7 @@ import { useTranslation } from 'react-i18next'
 import { useLocation } from 'react-router-dom'
 import { usePageEditorStore } from '../editor/pageEditorStore'
 import { PinnedSection } from './PinnedSection'
+import { TreeDndProvider } from './TreeDnd'
 import { TreeNode } from './TreeNode'
 
 export default function TreeView() {
@@ -208,11 +209,13 @@ export default function TreeView() {
         collapseToggleLabel={t('pinned.togglePagesSection')}
         actions={pagesToolbar}
       >
-        <div className="tree-view__nodes">
-          {tree?.children?.map((node) => (
-            <TreeNode key={node.id} node={node} />
-          ))}
-        </div>
+        <TreeDndProvider enabled={!readOnlyMode}>
+          <div className="tree-view__nodes">
+            {tree?.children?.map((node) => (
+              <TreeNode key={node.id} node={node} />
+            ))}
+          </div>
+        </TreeDndProvider>
       </SidebarAccordionSection>
     </Accordion>
   )

--- a/ui/leafwiki-ui/src/features/tree/treeDndContext.ts
+++ b/ui/leafwiki-ui/src/features/tree/treeDndContext.ts
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react'
+import { DropTarget } from './treeDndUtils'
+
+export type TreeDndState = {
+  enabled: boolean
+  activeId: string | null
+  dropTarget: DropTarget | null
+}
+
+export const TreeDndContext = createContext<TreeDndState>({
+  enabled: false,
+  activeId: null,
+  dropTarget: null,
+})
+
+export function useTreeDnd() {
+  return useContext(TreeDndContext)
+}

--- a/ui/leafwiki-ui/src/features/tree/treeDndUtils.ts
+++ b/ui/leafwiki-ui/src/features/tree/treeDndUtils.ts
@@ -1,0 +1,93 @@
+import { NODE_KIND_SECTION, PageNode } from '@/lib/api/pages'
+
+export const ROOT_ID = 'root'
+
+export type DropZone = 'before' | 'after' | 'inside'
+
+export type DropTarget = {
+  nodeId: string
+  zone: DropZone
+}
+
+export type DropResolution = {
+  parentId: string
+  // Index among the parent's children with the dragged node removed
+  index: number
+}
+
+export function collectSubtreeIds(node: PageNode): Set<string> {
+  const ids = new Set<string>()
+  const walk = (n: PageNode) => {
+    ids.add(n.id)
+    for (const child of n.children || []) walk(child)
+  }
+  walk(node)
+  return ids
+}
+
+// Every row splits 25/50/25: top quarter = before, middle half = into,
+// bottom quarter = after. Dropping "into" a page nests the dragged node
+// inside it — the backend converts the page into a section on move.
+export function getDropZone(
+  pointerY: number,
+  rect: { top: number; height: number },
+): DropZone | null {
+  if (rect.height <= 0) return null
+  const fraction = (pointerY - rect.top) / rect.height
+
+  if (fraction < 0.25) return 'before'
+  if (fraction > 0.75) return 'after'
+  return 'inside'
+}
+
+export function resolveDrop({
+  dragged,
+  target,
+  zone,
+  byId,
+  isNodeOpen,
+}: {
+  dragged: PageNode
+  target: PageNode
+  zone: DropZone
+  byId: Record<string, PageNode>
+  isNodeOpen: (id: string) => boolean
+}): DropResolution | null {
+  if (zone === 'inside') {
+    const children = (target.children ?? []).filter((c) => c.id !== dragged.id)
+    return { parentId: target.id, index: children.length }
+  }
+
+  const parentId = target.parentId ?? ROOT_ID
+  const parent = byId[parentId]
+  const siblings = (parent?.children ?? []).filter((c) => c.id !== dragged.id)
+  const targetIndex = siblings.findIndex((c) => c.id === target.id)
+  if (targetIndex === -1) return null
+
+  if (zone === 'after') {
+    // Dropping right below an expanded section visually points at the slot
+    // above its first child, so place the node there instead of after the
+    // whole section.
+    if (
+      target.kind === NODE_KIND_SECTION &&
+      isNodeOpen(target.id) &&
+      (target.children ?? []).some((c) => c.id !== dragged.id)
+    ) {
+      return { parentId: target.id, index: 0 }
+    }
+    return { parentId, index: targetIndex + 1 }
+  }
+
+  return { parentId, index: targetIndex }
+}
+
+export function buildOrderedIds(
+  children: PageNode[],
+  draggedId: string,
+  index: number,
+): string[] {
+  const ids = children.map((c) => c.id).filter((id) => id !== draggedId)
+  const insertAt = Math.max(0, Math.min(index, ids.length))
+  ids.splice(insertAt, 0, draggedId)
+  return ids
+}

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -2645,6 +2645,37 @@
     @apply hidden;
   }
 
+  .tree-node--dragging,
+  .tree-node__children--dragging {
+    @apply opacity-40;
+  }
+
+  .tree-node--drop-inside {
+    @apply bg-brand/10 rounded;
+    box-shadow: inset 0 0 0 1.5px hsl(var(--brand) / 0.45);
+  }
+
+  .tree-node__drop-line {
+    @apply bg-brand pointer-events-none absolute right-1 left-1 z-10 h-0.5 rounded;
+  }
+
+  .tree-node__drop-line--top {
+    top: -1px;
+  }
+
+  .tree-node__drop-line--bottom {
+    bottom: -1px;
+  }
+
+  .tree-node__nest-hint {
+    @apply text-brand pointer-events-none absolute top-1/2 right-2 z-10 -translate-y-1/2;
+  }
+
+  .tree-dnd__overlay {
+    @apply border-surface-border text-interface-text pointer-events-none max-w-56 cursor-grabbing truncate rounded border px-2.5 py-1.5 text-sm shadow-md;
+    background: hsl(var(--surface));
+  }
+
   .btn {
     @apply inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-medium;
   }

--- a/ui/leafwiki-ui/src/lib/api/pages.ts
+++ b/ui/leafwiki-ui/src/lib/api/pages.ts
@@ -182,13 +182,18 @@ export async function movePage(
   id: string,
   version: string,
   parentId: string | null,
+  position?: number,
 ) {
   if (parentId === '' || parentId == 'root') parentId = null
 
   return await fetchWithAuth(`/api/pages/${id}/move`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ version, parentId }),
+    body: JSON.stringify(
+      position === undefined
+        ? { version, parentId }
+        : { version, parentId, position },
+    ),
   })
 }
 

--- a/ui/leafwiki-ui/src/stores/tree.ts
+++ b/ui/leafwiki-ui/src/stores/tree.ts
@@ -1,4 +1,9 @@
-import { fetchTree, PageNode } from '@/lib/api/pages'
+import {
+  fetchTree,
+  NODE_KIND_PAGE,
+  NODE_KIND_SECTION,
+  PageNode,
+} from '@/lib/api/pages'
 import { FlatPageSearchItem, buildFlatPageSearchItems } from '@/lib/pageSearch'
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
@@ -54,8 +59,13 @@ type TreeStore = {
   pinnedPages: PageNode[]
   expandAll: () => void
   collapseAll: () => void
-  reloadTree: () => Promise<void>
+  reloadTree: (options?: { silent?: boolean }) => Promise<void>
   patchNodeVersion: (id: string, version: string) => void
+  moveNodeLocally: (
+    nodeId: string,
+    targetParentId: string,
+    index: number,
+  ) => void
   setPinnedLocally: (id: string, pinned: boolean, version: string) => void
   toggleNode: (id: string) => void
   openNode: (id: string) => void
@@ -192,6 +202,45 @@ export const useTreeStore = create<TreeStore>()(
         })
       },
 
+      moveNodeLocally: (
+        nodeId: string,
+        targetParentId: string,
+        index: number,
+      ) => {
+        const current = get().tree
+        if (!current) return
+
+        const tree = structuredClone(current)
+        const { byId: clonedById } = buildIndexes(tree)
+
+        const node = clonedById[nodeId]
+        const target = clonedById[targetParentId]
+        const oldParent = node?.parentId ? clonedById[node.parentId] : null
+        if (!node || !target || !oldParent?.children) return
+
+        const oldIndex = oldParent.children.findIndex((c) => c.id === nodeId)
+        if (oldIndex === -1) return
+        oldParent.children.splice(oldIndex, 1)
+
+        const children = target.children ?? []
+        target.children = children
+        const insertAt = Math.max(0, Math.min(index, children.length))
+        children.splice(insertAt, 0, node)
+        if (target.kind === NODE_KIND_PAGE) {
+          // Moving a node under a page converts that page into a section
+          // server-side; mirror it locally so the row updates instantly.
+          target.kind = NODE_KIND_SECTION
+        }
+
+        assignParentIds(tree)
+        const { byPath, byId } = buildIndexes(tree)
+        const flatPages = buildFlatPageSearchItems(tree)
+        const pinnedPages = Object.values(byId)
+          .filter((n) => n.pinned === true)
+          .sort((a, b) => a.title.localeCompare(b.title))
+        set({ tree, byPath, byId, flatPages, pinnedPages })
+      },
+
       setPinnedLocally: (id: string, pinned: boolean, version: string) => {
         const byId = get().byId
         const byPath = get().byPath
@@ -209,8 +258,10 @@ export const useTreeStore = create<TreeStore>()(
         })
       },
 
-      reloadTree: async () => {
-        set({ loading: true, error: null })
+      reloadTree: async (options?: { silent?: boolean }) => {
+        const silent = options?.silent === true
+        if (silent) set({ error: null })
+        else set({ loading: true, error: null })
 
         try {
           const tree = await fetchTree()
@@ -237,7 +288,7 @@ export const useTreeStore = create<TreeStore>()(
             set({ error: 'An unknown error occurred' })
           }
         } finally {
-          set({ loading: false })
+          if (!silent) set({ loading: false })
         }
       },
     }),


### PR DESCRIPTION
## Related issue

Issue #1110

## What changed

Pages and sections can now be reordered and moved directly in the sidebar
page tree via drag & drop, instead of only through the Sort and Move dialogs.

### UX

- **Drag anywhere on a row** to pick it up (6px movement threshold so plain
  clicks still navigate; long-press ~250ms on touch so scrolling stays free).
  A floating chip follows the cursor.
- **Drop between rows** to reorder — an insertion line shows the target slot,
  including between children of a *different* section (which re-parents).
- **Drop onto the middle of a section row** to move the node into it
  (highlighted, appended at the end). Hovering a collapsed section for ~600ms
  auto-expands it. Pages are never "drop into" targets, so an errant drop can
  never auto-convert a page into a section.
- Dropping just below an expanded section inserts as its first child,
  matching what the indicator visually points at.
- Dropping a section into its own descendants is blocked client-side
  (backend re-validates). Read-only users get no drag behavior.
- Drops apply optimistically, then re-sync via a silent tree reload;
  failures show a toast and roll back to server state.

The existing Sort dialog and Move dialog are unchanged and share the same
endpoints (the dialog remains the keyboard-accessible alternative).

### Backend

- `TreeService.MoveNode` is now a thin wrapper around a new
  `MoveNodeToPosition`, which inserts at a target index among the new
  parent's children instead of always appending. Negative/out-of-range
  positions append, so existing callers are unaffected.
- `PUT /api/pages/:id/move` accepts an optional `position` field so
  "move into parent X at index N" is one atomic request under the tree lock
  (existing `version` optimistic locking included). Omitted → append,
  fully backwards compatible.
- Same-parent reorders reuse the existing `PUT /api/pages/:id/sort`.

### Frontend

- `features/tree/TreeDnd.tsx` — dnd-kit `DndContext` provider: sensors,
  drag state, drop execution, auto-expand timer, and post-drag click
  suppression.
- `features/tree/treeDndUtils.ts` — pure drop-zone / drop-resolution logic
  (kept side-effect free for testability).
- `features/tree/treeDndContext.ts` — context consumed by rows.
- `TreeNode` rows are draggable + droppable and render the drop indicators;
  `stores/tree.ts` gains `moveNodeLocally` (optimistic patch) and a
  `silent` option for `reloadTree`.

### Fixes folded in (found while testing this feature)

- **Firefox: full page reload on drop.** The browser click that follows a
  drop lands on the dragged row's link and, in Firefox, bypasses React's
  synthetic handlers entirely — the anchor's default action then triggered a
  real navigation. Click suppression is now a native window-level capture
  listener armed for the duration of the drag (the approach
  react-beautiful-dnd uses), verified against Firefox, Chromium, and WebKit
  with real-input Playwright runs: drops produce zero navigations/page
  loads, and normal row clicks still SPA-navigate afterwards.
- **Article re-render on every tree change.** `MarkdownPreview` subscribes
  to the tree store's `byId` (for wikilink resolution), whose identity
  changes on every tree update — each drop re-parsed and re-rendered the
  whole article (visible repaint on content with diagrams/math). The
  rendered markdown element is now memoized on the resolved content string,
  so tree updates only re-render the article when wikilink resolution
  actually changed. This also removes the same repaint on pin/unpin and
  Sort-dialog saves.

## Checklist

- [x] I discussed the approach on the linked issue before starting (or this is a trivial fix: typo, docs, obvious one-liner)
- [x] This PR is focused on a single change
- [x] I ran `npm run format` in `ui/leafwiki-ui` (and in `e2e` if e2e tests changed)
- [x] I updated documentation if needed
