### PR TITLE
feat(sidebar): make pinned/pages sidebar sections collapsible accordion

### DIFF
--- a/ui/leafwiki-ui/src/features/sidebar/SidebarAccordionSection.test.tsx
+++ b/ui/leafwiki-ui/src/features/sidebar/SidebarAccordionSection.test.tsx
@@ -1,0 +1,93 @@
+import { Accordion } from '@/components/ui/accordion'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { useState } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { SidebarAccordionSection } from './SidebarAccordionSection'
+
+function ControlledAccordion({
+  defaultValue,
+  onValueChangeSpy,
+}: {
+  defaultValue: string[]
+  onValueChangeSpy?: (value: string[]) => void
+}) {
+  const [value, setValue] = useState(defaultValue)
+  return (
+    <Accordion
+      type="multiple"
+      value={value}
+      onValueChange={(next) => {
+        setValue(next)
+        onValueChangeSpy?.(next)
+      }}
+    >
+      <SidebarAccordionSection
+        value="pinned"
+        title="Pinned"
+        collapseToggleLabel="Toggle pinned pages section"
+        actions={<button>Add page</button>}
+      >
+        <div data-testid="pinned-content">pinned content</div>
+      </SidebarAccordionSection>
+    </Accordion>
+  )
+}
+
+describe('SidebarAccordionSection', () => {
+  it('renders the title and children', () => {
+    render(<ControlledAccordion defaultValue={['pinned']} />)
+    expect(screen.getByText('Pinned')).toBeInTheDocument()
+    expect(screen.getByTestId('pinned-content')).toBeInTheDocument()
+  })
+
+  it('renders actions in the header, always visible', () => {
+    render(<ControlledAccordion defaultValue={[]} />)
+    expect(screen.getByText('Add page')).toBeInTheDocument()
+  })
+
+  it('collapses the section when the chevron toggle is clicked', () => {
+    const onValueChangeSpy = vi.fn()
+    render(
+      <ControlledAccordion
+        defaultValue={['pinned']}
+        onValueChangeSpy={onValueChangeSpy}
+      />,
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Toggle pinned pages section' }),
+    )
+
+    expect(onValueChangeSpy).toHaveBeenCalledWith([])
+  })
+
+  it('expands the section when the chevron toggle is clicked while closed', () => {
+    const onValueChangeSpy = vi.fn()
+    render(
+      <ControlledAccordion
+        defaultValue={[]}
+        onValueChangeSpy={onValueChangeSpy}
+      />,
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Toggle pinned pages section' }),
+    )
+
+    expect(onValueChangeSpy).toHaveBeenCalledWith(['pinned'])
+  })
+
+  it('clicking an action button does not toggle the section', () => {
+    const onValueChangeSpy = vi.fn()
+    render(
+      <ControlledAccordion
+        defaultValue={['pinned']}
+        onValueChangeSpy={onValueChangeSpy}
+      />,
+    )
+
+    fireEvent.click(screen.getByText('Add page'))
+
+    expect(onValueChangeSpy).not.toHaveBeenCalled()
+  })
+})

--- a/ui/leafwiki-ui/src/features/sidebar/SidebarAccordionSection.tsx
+++ b/ui/leafwiki-ui/src/features/sidebar/SidebarAccordionSection.tsx
@@ -1,0 +1,59 @@
+import { AccordionItem } from '@/components/ui/accordion'
+import { cn } from '@/lib/utils'
+import * as AccordionPrimitive from '@radix-ui/react-accordion'
+import { ChevronDown } from 'lucide-react'
+import { ReactNode } from 'react'
+
+type SidebarAccordionSectionProps = {
+  value: string
+  title: ReactNode
+  icon?: ReactNode
+  count?: number
+  actions?: ReactNode
+  collapseToggleLabel: string
+  children: ReactNode
+  className?: string
+}
+
+export function SidebarAccordionSection({
+  value,
+  title,
+  icon,
+  count,
+  actions,
+  collapseToggleLabel,
+  children,
+  className,
+}: SidebarAccordionSectionProps) {
+  return (
+    <AccordionItem
+      value={value}
+      className={cn('sidebar-accordion-section', className)}
+    >
+      <AccordionPrimitive.Header className="sidebar-accordion-section__header">
+        <div className="sidebar-accordion-section__title">
+          {icon}
+          <span>{title}</span>
+          {typeof count === 'number' && (
+            <span className="sidebar-accordion-section__count">{count}</span>
+          )}
+        </div>
+        <div className="sidebar-accordion-section__actions">
+          {actions}
+          <AccordionPrimitive.Trigger asChild>
+            <button
+              type="button"
+              className="sidebar-accordion-section__trigger"
+              aria-label={collapseToggleLabel}
+            >
+              <ChevronDown size={14} />
+            </button>
+          </AccordionPrimitive.Trigger>
+        </div>
+      </AccordionPrimitive.Header>
+      <AccordionPrimitive.Content className="sidebar-accordion-section__panel data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden">
+        <div className="sidebar-accordion-section__content">{children}</div>
+      </AccordionPrimitive.Content>
+    </AccordionItem>
+  )
+}

--- a/ui/leafwiki-ui/src/features/tree/PinnedSection.tsx
+++ b/ui/leafwiki-ui/src/features/tree/PinnedSection.tsx
@@ -1,6 +1,5 @@
 import { pinPage } from '@/lib/api/pages'
 import { useTreeStore } from '@/stores/tree'
-import { Pin } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { PinnedPageItem } from './PinnedPageItem'
@@ -24,10 +23,6 @@ export function PinnedSection() {
 
   return (
     <div className="tree-view__pinned" data-testid="pinned-section">
-      <div className="tree-view__pinned-header">
-        <Pin size={11} />
-        <span>{t('pinned.sectionTitle')}</span>
-      </div>
       {pinnedPages.map((node) => (
         <PinnedPageItem
           key={node.id}
@@ -35,7 +30,6 @@ export function PinnedSection() {
           onUnpin={() => handleUnpin(node.id, node.version)}
         />
       ))}
-      <div className="tree-view__pinned-divider" />
     </div>
   )
 }

--- a/ui/leafwiki-ui/src/features/tree/TreeView.tsx
+++ b/ui/leafwiki-ui/src/features/tree/TreeView.tsx
@@ -1,9 +1,11 @@
+import { Accordion } from '@/components/ui/accordion'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { SidebarAccordionSection } from '@/features/sidebar/SidebarAccordionSection'
 import { TreeViewActionButton } from '@/features/tree/TreeViewActionButton'
 import { NODE_KIND_PAGE, NODE_KIND_SECTION } from '@/lib/api/pages'
 import { DIALOG_ADD_PAGE, DIALOG_SORT_PAGES } from '@/lib/registries'
@@ -12,6 +14,7 @@ import { useAppMode } from '@/lib/useAppMode'
 import { useIsReadOnly } from '@/lib/useIsReadOnly'
 import { toWikiLookupPath } from '@/lib/wikiPath'
 import { useDialogsStore } from '@/stores/dialogs'
+import { useSidebarPanelsStore } from '@/stores/sidebarPanels'
 import { useTreeStore } from '@/stores/tree'
 import {
   ChevronsDown,
@@ -20,6 +23,7 @@ import {
   FolderPlus,
   List,
   MoreHorizontal,
+  Pin,
 } from 'lucide-react'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -51,6 +55,8 @@ export default function TreeView() {
   const hasPinned = pinnedPages.length > 0
   const openDialog = useDialogsStore((state) => state.openDialog)
   const readOnlyMode = useIsReadOnly()
+  const openSections = useSidebarPanelsStore((s) => s.openSections)
+  const setOpenSections = useSidebarPanelsStore((s) => s.setOpenSections)
 
   useEffect(() => {
     if (!tree || !currentPath) return
@@ -99,103 +105,115 @@ export default function TreeView() {
       </p>
     )
 
-  return (
-    <div className="tree-view">
-      <PinnedSection />
-      <div className="tree-view__pages">
-        {hasPinned && (
-          <div className="tree-view__section-header">
-            {t('pinned.pagesSectionTitle')}
-          </div>
-        )}
-        <div className="tree-view__toolbar">
-          {!readOnlyMode && (
-            <>
-              <TreeViewActionButton
-                actionName="add"
-                icon={
-                  <FilePlus
-                    className="tree-view__action-icon text-brand/70!"
-                    size={18}
-                  />
-                }
-                tooltip="Create new page"
-                onClick={() =>
-                  openDialog(DIALOG_ADD_PAGE, {
-                    parentId: '',
-                    nodeKind: NODE_KIND_PAGE,
-                  })
-                }
+  const pagesToolbar = (
+    <>
+      {!readOnlyMode && (
+        <>
+          <TreeViewActionButton
+            actionName="add"
+            icon={
+              <FilePlus
+                className="tree-view__action-icon text-brand/70!"
+                size={18}
               />
-              <TreeViewActionButton
-                actionName="add-section"
-                icon={
-                  <FolderPlus
-                    className="tree-view__action-icon text-brand/70!"
-                    size={18}
-                  />
-                }
-                tooltip="Create new section"
-                onClick={() =>
-                  openDialog(DIALOG_ADD_PAGE, {
-                    parentId: '',
-                    nodeKind: NODE_KIND_SECTION,
-                  })
-                }
+            }
+            tooltip="Create new page"
+            onClick={() =>
+              openDialog(DIALOG_ADD_PAGE, {
+                parentId: '',
+                nodeKind: NODE_KIND_PAGE,
+              })
+            }
+          />
+          <TreeViewActionButton
+            actionName="add-section"
+            icon={
+              <FolderPlus
+                className="tree-view__action-icon text-brand/70!"
+                size={18}
               />
-            </>
+            }
+            tooltip="Create new section"
+            onClick={() =>
+              openDialog(DIALOG_ADD_PAGE, {
+                parentId: '',
+                nodeKind: NODE_KIND_SECTION,
+              })
+            }
+          />
+        </>
+      )}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <TreeViewActionButton
+            actionName="tree-overflow"
+            icon={
+              <MoreHorizontal className="tree-view__action-icon" size={18} />
+            }
+            tooltip="More actions"
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-44">
+          <DropdownMenuItem
+            className="cursor-pointer gap-2"
+            onClick={expandAll}
+            data-testid="tree-view-action-button-expand-all"
+          >
+            <ChevronsDown size={15} />
+            Expand all
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="cursor-pointer gap-2"
+            onClick={collapseAll}
+            data-testid="tree-view-action-button-collapse-all"
+          >
+            <ChevronsUp size={15} />
+            Collapse all
+          </DropdownMenuItem>
+          {!readOnlyMode && tree && (
+            <DropdownMenuItem
+              className="cursor-pointer gap-2"
+              onClick={() => openDialog(DIALOG_SORT_PAGES, { parent: tree })}
+              data-testid="tree-view-action-button-sort"
+            >
+              <List size={15} />
+              Sort pages
+            </DropdownMenuItem>
           )}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <TreeViewActionButton
-                actionName="tree-overflow"
-                icon={
-                  <MoreHorizontal
-                    className="tree-view__action-icon"
-                    size={18}
-                  />
-                }
-                tooltip="More actions"
-              />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="w-44">
-              <DropdownMenuItem
-                className="cursor-pointer gap-2"
-                onClick={expandAll}
-                data-testid="tree-view-action-button-expand-all"
-              >
-                <ChevronsDown size={15} />
-                Expand all
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                className="cursor-pointer gap-2"
-                onClick={collapseAll}
-                data-testid="tree-view-action-button-collapse-all"
-              >
-                <ChevronsUp size={15} />
-                Collapse all
-              </DropdownMenuItem>
-              {!readOnlyMode && tree && (
-                <DropdownMenuItem
-                  className="cursor-pointer gap-2"
-                  onClick={() =>
-                    openDialog(DIALOG_SORT_PAGES, { parent: tree })
-                  }
-                  data-testid="tree-view-action-button-sort"
-                >
-                  <List size={15} />
-                  Sort pages
-                </DropdownMenuItem>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </>
+  )
+
+  return (
+    <Accordion
+      type="multiple"
+      value={openSections}
+      onValueChange={setOpenSections}
+      className="tree-view"
+    >
+      {hasPinned && (
+        <SidebarAccordionSection
+          value="pinned"
+          title={t('pinned.sectionTitle')}
+          icon={<Pin size={11} />}
+          collapseToggleLabel={t('pinned.togglePinnedSection')}
+        >
+          <PinnedSection />
+        </SidebarAccordionSection>
+      )}
+      <SidebarAccordionSection
+        value="pages"
+        title={t('pinned.pagesSectionTitle')}
+        collapseToggleLabel={t('pinned.togglePagesSection')}
+        actions={pagesToolbar}
+      >
         <div className="tree-view__nodes">
           {tree?.children?.map((node) => (
             <TreeNode key={node.id} node={node} />
           ))}
         </div>
-      </div>
-    </div>
+      </SidebarAccordionSection>
+    </Accordion>
   )
 }

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -2465,8 +2465,38 @@
     @apply w-full;
   }
 
-  .tree-view__toolbar {
-    @apply mt-1 mb-2 ml-1 flex;
+  .sidebar-accordion-section__header {
+    @apply flex w-full items-center justify-between gap-2 px-1 py-1;
+  }
+
+  .sidebar-accordion-section__title {
+    @apply text-muted flex items-center gap-1 text-xs font-medium tracking-wide uppercase select-none;
+  }
+
+  .sidebar-accordion-section__count {
+    @apply text-muted text-xs font-normal normal-case;
+  }
+
+  .sidebar-accordion-section__actions {
+    @apply flex items-center gap-1;
+  }
+
+  .sidebar-accordion-section__trigger {
+    @apply text-muted hover:text-interface-text flex cursor-pointer items-center justify-center rounded p-0.5 opacity-70 hover:opacity-100;
+    background: none;
+    border: none;
+  }
+
+  .sidebar-accordion-section__trigger svg {
+    @apply transition-transform duration-200;
+  }
+
+  .sidebar-accordion-section__trigger[data-state='open'] svg {
+    @apply rotate-180;
+  }
+
+  .sidebar-accordion-section__content {
+    @apply pt-1 pb-2;
   }
 
   .tree-view__status {
@@ -2490,19 +2520,7 @@
   }
 
   .tree-view__pinned {
-    @apply mb-1 w-full;
-  }
-
-  .tree-view__section-header {
-    @apply text-muted flex items-center gap-1 px-1 py-0.5 text-xs font-medium tracking-wide uppercase select-none;
-  }
-
-  .tree-view__pinned-header {
-    @apply text-muted flex items-center gap-1 px-1 py-0.5 text-xs font-medium tracking-wide uppercase select-none;
-  }
-
-  .tree-view__pinned-divider {
-    @apply bg-surface-border mt-1 mb-2 h-px w-full;
+    @apply w-full;
   }
 
   .tree-view__pinned-item {

--- a/ui/leafwiki-ui/src/locales/en/viewer.json
+++ b/ui/leafwiki-ui/src/locales/en/viewer.json
@@ -35,7 +35,9 @@
     "unpinPage": "Unpin",
     "pinSuccess": "Page pinned",
     "unpinSuccess": "Page unpinned",
-    "pinError": "Failed to update pin status"
+    "pinError": "Failed to update pin status",
+    "togglePinnedSection": "Toggle pinned pages section",
+    "togglePagesSection": "Toggle pages section"
   },
   "toc": {
     "title": "Table of contents",

--- a/ui/leafwiki-ui/src/stores/sidebarPanels.test.ts
+++ b/ui/leafwiki-ui/src/stores/sidebarPanels.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useSidebarPanelsStore } from './sidebarPanels'
+
+describe('useSidebarPanelsStore', () => {
+  beforeEach(() => {
+    useSidebarPanelsStore.setState({ openSections: ['pinned', 'pages'] })
+  })
+
+  it('starts with pinned and pages expanded by default', () => {
+    expect(useSidebarPanelsStore.getState().openSections).toEqual([
+      'pinned',
+      'pages',
+    ])
+  })
+
+  it('setOpenSections replaces the open section ids', () => {
+    useSidebarPanelsStore.getState().setOpenSections(['pages'])
+    expect(useSidebarPanelsStore.getState().openSections).toEqual(['pages'])
+  })
+
+  it('setOpenSections can close all sections', () => {
+    useSidebarPanelsStore.getState().setOpenSections([])
+    expect(useSidebarPanelsStore.getState().openSections).toEqual([])
+  })
+
+  it('setOpenSections can add a new section id (e.g. a future "favorites" section)', () => {
+    useSidebarPanelsStore
+      .getState()
+      .setOpenSections(['pinned', 'pages', 'favorites'])
+    expect(useSidebarPanelsStore.getState().openSections).toEqual([
+      'pinned',
+      'pages',
+      'favorites',
+    ])
+  })
+})

--- a/ui/leafwiki-ui/src/stores/sidebarPanels.ts
+++ b/ui/leafwiki-ui/src/stores/sidebarPanels.ts
@@ -1,0 +1,23 @@
+// stores/sidebarPanels.ts
+// Tracks which sidebar accordion sections (Pinned Pages, Pages, ...) are
+// expanded. The state is persisted across sessions using localStorage.
+
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+type SidebarPanelsStore = {
+  openSections: string[]
+  setOpenSections: (ids: string[]) => void
+}
+
+export const useSidebarPanelsStore = create<SidebarPanelsStore>()(
+  persist(
+    (set) => ({
+      openSections: ['pinned', 'pages'],
+      setOpenSections: (ids) => set({ openSections: ids }),
+    }),
+    {
+      name: 'leafwiki-sidebar-panels', // localStorage key
+    },
+  ),
+)


### PR DESCRIPTION
Wrap the Pinned and Pages tree sections in a persisted multi-open accordion (sidebarPanels store) so each block can be collapsed independently, while tree-wide expand/collapse-all keeps operating on individual tree nodes as before.
