### PR TITLE
feat(favorites): add per-user favorite pages

### DIFF
--- a/internal/favorites/favorites_store.go
+++ b/internal/favorites/favorites_store.go
@@ -1,0 +1,157 @@
+// Package favorites stores each user's private set of favorited pages.
+// Unlike tags/links/properties/search, this data is not derived from the
+// filesystem tree and must never be touched by resync (see ADR-0001).
+package favorites
+
+import (
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/perber/wiki/internal/core/shared"
+	"github.com/perber/wiki/internal/core/shared/sqliteutil"
+	_ "modernc.org/sqlite"
+)
+
+const logCloseRowsFailed = "could not close rows"
+
+type FavoritesStore struct {
+	mu sync.Mutex
+	db *sql.DB
+}
+
+func NewFavoritesStore(storageDir string) (*FavoritesStore, error) {
+	normalized := filepath.FromSlash(strings.ReplaceAll(storageDir, `\`, `/`))
+	dbPath := filepath.Join(normalized, "favorites.db")
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open favorites database: %w", err)
+	}
+
+	s := &FavoritesStore{db: db}
+	if err := s.ensureSchema(); err != nil {
+		_ = db.Close()
+		if !sqliteutil.IsSQLiteRecoverableError(err) {
+			return nil, err
+		}
+		slog.Default().Warn("favorites database corrupt, removing and retrying", "error", err)
+		sqliteutil.RemoveSQLiteFiles(dbPath)
+		db, err = sql.Open("sqlite", dbPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to reopen favorites database after recovery: %w", err)
+		}
+		s = &FavoritesStore{db: db}
+		if err = s.ensureSchema(); err != nil {
+			_ = db.Close()
+			return nil, err
+		}
+	}
+	return s, nil
+}
+
+func (s *FavoritesStore) ensureSchema() error {
+	_, err := s.db.Exec(`
+		CREATE TABLE IF NOT EXISTS favorites (
+			user_id    TEXT NOT NULL,
+			page_id    TEXT NOT NULL,
+			created_at TIMESTAMP NOT NULL,
+			PRIMARY KEY (user_id, page_id)
+		);
+		CREATE INDEX IF NOT EXISTS favorites_user_id_idx ON favorites(user_id);
+	`)
+	return err
+}
+
+// Add favorites pageID for userID. Idempotent — favoriting an already-favorited page is a no-op.
+func (s *FavoritesStore) Add(userID, pageID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	_, err := s.db.Exec(
+		`INSERT OR IGNORE INTO favorites (user_id, page_id, created_at) VALUES (?, ?, ?)`,
+		userID, pageID, time.Now().UTC(),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to add favorite for user %s, page %s: %w", userID, pageID, err)
+	}
+	return nil
+}
+
+// Remove un-favorites pageID for userID. Idempotent — removing a non-favorited page is a no-op.
+func (s *FavoritesStore) Remove(userID, pageID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	_, err := s.db.Exec(`DELETE FROM favorites WHERE user_id = ? AND page_id = ?`, userID, pageID)
+	if err != nil {
+		return fmt.Errorf("failed to remove favorite for user %s, page %s: %w", userID, pageID, err)
+	}
+	return nil
+}
+
+// ListPageIDsForUser returns the page IDs favorited by userID, most recently favorited first.
+func (s *FavoritesStore) ListPageIDsForUser(userID string) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	rows, err := s.db.Query(
+		`SELECT page_id FROM favorites WHERE user_id = ? ORDER BY created_at DESC`,
+		userID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer shared.LogClose(rows.Close, logCloseRowsFailed)
+
+	var pageIDs []string
+	for rows.Next() {
+		var pageID string
+		if err := rows.Scan(&pageID); err != nil {
+			return nil, err
+		}
+		pageIDs = append(pageIDs, pageID)
+	}
+	return pageIDs, rows.Err()
+}
+
+// DeleteAllForPage removes every user's favorite of pageID. Called on page delete.
+func (s *FavoritesStore) DeleteAllForPage(pageID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	_, err := s.db.Exec(`DELETE FROM favorites WHERE page_id = ?`, pageID)
+	if err != nil {
+		return fmt.Errorf("failed to delete favorites for page %s: %w", pageID, err)
+	}
+	return nil
+}
+
+// DeleteAllForUser removes every favorite belonging to userID. Called on user delete.
+func (s *FavoritesStore) DeleteAllForUser(userID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	_, err := s.db.Exec(`DELETE FROM favorites WHERE user_id = ?`, userID)
+	if err != nil {
+		return fmt.Errorf("failed to delete favorites for user %s: %w", userID, err)
+	}
+	return nil
+}
+
+func (s *FavoritesStore) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db != nil {
+		if err := s.db.Close(); err != nil {
+			return err
+		}
+		s.db = nil
+	}
+	return nil
+}

--- a/internal/favorites/favorites_store_test.go
+++ b/internal/favorites/favorites_store_test.go
@@ -1,0 +1,202 @@
+package favorites
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/perber/wiki/internal/test_utils"
+)
+
+func newTestStore(t *testing.T) *FavoritesStore {
+	t.Helper()
+	store, err := NewFavoritesStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFavoritesStore: %v", err)
+	}
+	t.Cleanup(func() { test_utils.WrapCloseWithErrorCheck(store.Close, t) })
+	return store
+}
+
+func TestFavoritesStore_CreatesDatabaseInStorageDir(t *testing.T) {
+	tmp := t.TempDir()
+	store, err := NewFavoritesStore(tmp)
+	if err != nil {
+		t.Fatalf("NewFavoritesStore: %v", err)
+	}
+	defer test_utils.WrapCloseWithErrorCheck(store.Close, t)
+
+	if _, err := os.Stat(filepath.Join(tmp, "favorites.db")); err != nil {
+		t.Fatalf("expected favorites.db to exist: %v", err)
+	}
+}
+
+func TestFavoritesStore_IdempotentSchema(t *testing.T) {
+	tmp := t.TempDir()
+	for i := 0; i < 3; i++ {
+		store, err := NewFavoritesStore(tmp)
+		if err != nil {
+			t.Fatalf("NewFavoritesStore (run %d): %v", i, err)
+		}
+		if err := store.Close(); err != nil {
+			t.Fatalf("Close (run %d): %v", i, err)
+		}
+	}
+}
+
+func TestFavoritesStore_Add_ThenListPageIDsForUser_ReturnsIt(t *testing.T) {
+	store := newTestStore(t)
+
+	if err := store.Add("user-1", "page-1"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	got, err := store.ListPageIDsForUser("user-1")
+	if err != nil {
+		t.Fatalf("ListPageIDsForUser: %v", err)
+	}
+	if len(got) != 1 || got[0] != "page-1" {
+		t.Fatalf("expected [page-1], got %v", got)
+	}
+}
+
+func TestFavoritesStore_Add_IsIdempotent(t *testing.T) {
+	store := newTestStore(t)
+
+	if err := store.Add("user-1", "page-1"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := store.Add("user-1", "page-1"); err != nil {
+		t.Fatalf("Add (again): %v", err)
+	}
+
+	got, err := store.ListPageIDsForUser("user-1")
+	if err != nil {
+		t.Fatalf("ListPageIDsForUser: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected exactly one favorite, got %v", got)
+	}
+}
+
+func TestFavoritesStore_Remove_IsIdempotentAndRemovesOnlyThatUsersFavorite(t *testing.T) {
+	store := newTestStore(t)
+
+	if err := store.Add("user-1", "page-1"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := store.Add("user-2", "page-1"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	if err := store.Remove("user-1", "page-1"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	// Removing again (already removed) must not error.
+	if err := store.Remove("user-1", "page-1"); err != nil {
+		t.Fatalf("Remove (again): %v", err)
+	}
+
+	got1, err := store.ListPageIDsForUser("user-1")
+	if err != nil {
+		t.Fatalf("ListPageIDsForUser user-1: %v", err)
+	}
+	if len(got1) != 0 {
+		t.Fatalf("expected user-1 to have no favorites, got %v", got1)
+	}
+
+	got2, err := store.ListPageIDsForUser("user-2")
+	if err != nil {
+		t.Fatalf("ListPageIDsForUser user-2: %v", err)
+	}
+	if len(got2) != 1 || got2[0] != "page-1" {
+		t.Fatalf("expected user-2 to still have page-1, got %v", got2)
+	}
+}
+
+func TestFavoritesStore_ListPageIDsForUser_ScopedPerUser(t *testing.T) {
+	store := newTestStore(t)
+
+	if err := store.Add("user-1", "page-1"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := store.Add("user-2", "page-2"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	got, err := store.ListPageIDsForUser("user-1")
+	if err != nil {
+		t.Fatalf("ListPageIDsForUser: %v", err)
+	}
+	if len(got) != 1 || got[0] != "page-1" {
+		t.Fatalf("expected [page-1] for user-1, got %v", got)
+	}
+}
+
+func TestFavoritesStore_DeleteAllForPage_RemovesAcrossUsers(t *testing.T) {
+	store := newTestStore(t)
+
+	if err := store.Add("user-1", "page-1"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := store.Add("user-2", "page-1"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := store.Add("user-1", "page-2"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	if err := store.DeleteAllForPage("page-1"); err != nil {
+		t.Fatalf("DeleteAllForPage: %v", err)
+	}
+
+	got1, err := store.ListPageIDsForUser("user-1")
+	if err != nil {
+		t.Fatalf("ListPageIDsForUser user-1: %v", err)
+	}
+	if len(got1) != 1 || got1[0] != "page-2" {
+		t.Fatalf("expected user-1 to only have page-2 left, got %v", got1)
+	}
+
+	got2, err := store.ListPageIDsForUser("user-2")
+	if err != nil {
+		t.Fatalf("ListPageIDsForUser user-2: %v", err)
+	}
+	if len(got2) != 0 {
+		t.Fatalf("expected user-2 to have no favorites left, got %v", got2)
+	}
+}
+
+func TestFavoritesStore_DeleteAllForUser_RemovesOnlyThatUsersFavorites(t *testing.T) {
+	store := newTestStore(t)
+
+	if err := store.Add("user-1", "page-1"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := store.Add("user-1", "page-2"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := store.Add("user-2", "page-1"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	if err := store.DeleteAllForUser("user-1"); err != nil {
+		t.Fatalf("DeleteAllForUser: %v", err)
+	}
+
+	got1, err := store.ListPageIDsForUser("user-1")
+	if err != nil {
+		t.Fatalf("ListPageIDsForUser user-1: %v", err)
+	}
+	if len(got1) != 0 {
+		t.Fatalf("expected user-1 to have no favorites left, got %v", got1)
+	}
+
+	got2, err := store.ListPageIDsForUser("user-2")
+	if err != nil {
+		t.Fatalf("ListPageIDsForUser user-2: %v", err)
+	}
+	if len(got2) != 1 || got2[0] != "page-1" {
+		t.Fatalf("expected user-2 to still have page-1, got %v", got2)
+	}
+}

--- a/internal/wiki/auth/use_cases.go
+++ b/internal/wiki/auth/use_cases.go
@@ -10,6 +10,7 @@ import (
 
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	sharederrors "github.com/perber/wiki/internal/core/shared/errors"
+	"github.com/perber/wiki/internal/favorites"
 )
 
 // ErrAuthDisabled is returned when an auth operation is called while auth is disabled.
@@ -247,13 +248,14 @@ func (uc *ChangeOwnPasswordUseCase) Execute(_ context.Context, in ChangeOwnPassw
 type DeleteUserInput struct{ ID string }
 
 type DeleteUserUseCase struct {
-	user     *coreauth.UserService
-	resolver *coreauth.UserResolver
-	log      *slog.Logger
+	user      *coreauth.UserService
+	resolver  *coreauth.UserResolver
+	favorites *favorites.FavoritesStore
+	log       *slog.Logger
 }
 
-func NewDeleteUserUseCase(u *coreauth.UserService, r *coreauth.UserResolver, log *slog.Logger) *DeleteUserUseCase {
-	return &DeleteUserUseCase{user: u, resolver: r, log: log}
+func NewDeleteUserUseCase(u *coreauth.UserService, r *coreauth.UserResolver, f *favorites.FavoritesStore, log *slog.Logger) *DeleteUserUseCase {
+	return &DeleteUserUseCase{user: u, resolver: r, favorites: f, log: log}
 }
 
 func (uc *DeleteUserUseCase) Execute(_ context.Context, in DeleteUserInput) error {
@@ -262,6 +264,9 @@ func (uc *DeleteUserUseCase) Execute(_ context.Context, in DeleteUserInput) erro
 	}
 	if err := uc.resolver.Reload(); err != nil {
 		log.Printf(logReloadUserResolverCacheWarning, err)
+	}
+	if err := uc.favorites.DeleteAllForUser(in.ID); err != nil {
+		uc.log.Warn("failed to delete favorites for deleted user", "userID", in.ID, "error", err)
 	}
 	return nil
 }

--- a/internal/wiki/auth/use_cases_test.go
+++ b/internal/wiki/auth/use_cases_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	coreauth "github.com/perber/wiki/internal/core/auth"
+	"github.com/perber/wiki/internal/favorites"
 )
 
 func setupUpdateUserUseCase(t *testing.T) (*UpdateUserUseCase, *coreauth.UserService) {
@@ -206,5 +207,56 @@ func TestUpdateUser_AdminInvalidRole(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected validation error for invalid role, got nil")
+	}
+}
+
+// TestDeleteUser_RemovesFavoritesForUser verifies that deleting a user cascades
+// to clean up their favorites.db rows, even though sessions.db does not have
+// the same cleanup today (deliberately not copying that gap, see plans/favorites.md).
+func TestDeleteUser_RemovesFavoritesForUser(t *testing.T) {
+	store, err := coreauth.NewUserStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewUserStore: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Close user store: %v", err)
+		}
+	})
+	userSvc := coreauth.NewUserService(store)
+	resolver, err := coreauth.NewUserResolver(userSvc)
+	if err != nil {
+		t.Fatalf("NewUserResolver: %v", err)
+	}
+
+	favoritesStore, err := favorites.NewFavoritesStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFavoritesStore: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := favoritesStore.Close(); err != nil {
+			t.Errorf("Close favorites store: %v", err)
+		}
+	})
+
+	user, err := userSvc.CreateUser("bob", "bob@example.com", "pass", coreauth.RoleViewer)
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if err := favoritesStore.Add(user.ID, "page-1"); err != nil {
+		t.Fatalf("failed to seed favorite: %v", err)
+	}
+
+	uc := NewDeleteUserUseCase(userSvc, resolver, favoritesStore, slog.Default())
+	if err := uc.Execute(context.Background(), DeleteUserInput{ID: user.ID}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	ids, err := favoritesStore.ListPageIDsForUser(user.ID)
+	if err != nil {
+		t.Fatalf("ListPageIDsForUser: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Errorf("expected favorites for deleted user to be cleaned up, got %v", ids)
 	}
 }

--- a/internal/wiki/pages/add_favorite.go
+++ b/internal/wiki/pages/add_favorite.go
@@ -1,0 +1,32 @@
+package pages
+
+import (
+	"context"
+
+	"github.com/perber/wiki/internal/core/tree"
+	"github.com/perber/wiki/internal/favorites"
+)
+
+type AddFavoriteInput struct {
+	UserID string
+	PageID string
+}
+
+// AddFavoriteUseCase favorites a page for a given user. Any authenticated
+// user may favorite any page they can read — this is a personal bookmark,
+// not an editorial action (unlike Pinned Pages).
+type AddFavoriteUseCase struct {
+	treeService *tree.TreeService
+	store       *favorites.FavoritesStore
+}
+
+func NewAddFavoriteUseCase(treeService *tree.TreeService, store *favorites.FavoritesStore) *AddFavoriteUseCase {
+	return &AddFavoriteUseCase{treeService: treeService, store: store}
+}
+
+func (uc *AddFavoriteUseCase) Execute(_ context.Context, in AddFavoriteInput) error {
+	if _, err := uc.treeService.GetPage(in.PageID); err != nil {
+		return err
+	}
+	return uc.store.Add(in.UserID, in.PageID)
+}

--- a/internal/wiki/pages/delete_page.go
+++ b/internal/wiki/pages/delete_page.go
@@ -8,6 +8,7 @@ import (
 	"github.com/perber/wiki/internal/core/assets"
 	"github.com/perber/wiki/internal/core/revision"
 	"github.com/perber/wiki/internal/core/tree"
+	"github.com/perber/wiki/internal/favorites"
 	httpmetrics "github.com/perber/wiki/internal/http/metrics"
 	"github.com/perber/wiki/internal/wiki/pagesave"
 )
@@ -25,6 +26,7 @@ type DeletePageUseCase struct {
 	tree         *tree.TreeService
 	revision     *revision.Service
 	assets       *assets.AssetService
+	favorites    *favorites.FavoritesStore
 	orchestrator *pagesave.PageSaveOrchestrator
 	log          *slog.Logger
 	metrics      *httpmetrics.HTTPMetrics
@@ -35,11 +37,12 @@ func NewDeletePageUseCase(
 	t *tree.TreeService,
 	r *revision.Service,
 	a *assets.AssetService,
+	f *favorites.FavoritesStore,
 	o *pagesave.PageSaveOrchestrator,
 	log *slog.Logger,
 	metrics *httpmetrics.HTTPMetrics,
 ) *DeletePageUseCase {
-	return &DeletePageUseCase{tree: t, revision: r, assets: a, orchestrator: o, log: log, metrics: metrics}
+	return &DeletePageUseCase{tree: t, revision: r, assets: a, favorites: f, orchestrator: o, log: log, metrics: metrics}
 }
 
 // Execute deletes the page, cleaning up links (via orchestrator), assets, and revision data.
@@ -102,6 +105,9 @@ func (uc *DeletePageUseCase) Execute(_ context.Context, in DeletePageInput) (err
 			if err := uc.assets.DeleteAllAssetsForPage(p.PageNode); err != nil {
 				uc.log.Warn("failed to delete assets for page", "pageID", p.ID, "error", err)
 			}
+			if err := uc.favorites.DeleteAllForPage(p.ID); err != nil {
+				uc.log.Warn("failed to delete favorites for page", "pageID", p.ID, "error", err)
+			}
 		}
 
 		return deleteRevisionData(uc.revision, subtreeIDs)
@@ -124,6 +130,9 @@ func (uc *DeletePageUseCase) Execute(_ context.Context, in DeletePageInput) (err
 
 	if err := uc.assets.DeleteAllAssetsForPage(page.PageNode); err != nil {
 		uc.log.Warn("failed to delete assets for page", "pageID", page.ID, "error", err)
+	}
+	if err := uc.favorites.DeleteAllForPage(page.ID); err != nil {
+		uc.log.Warn("failed to delete favorites for page", "pageID", page.ID, "error", err)
 	}
 
 	return deleteRevisionData(uc.revision, []string{in.ID})

--- a/internal/wiki/pages/list_favorites.go
+++ b/internal/wiki/pages/list_favorites.go
@@ -1,0 +1,51 @@
+package pages
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/perber/wiki/internal/core/tree"
+	"github.com/perber/wiki/internal/favorites"
+)
+
+type ListFavoritesInput struct {
+	UserID string
+}
+
+type ListFavoritesOutput struct {
+	Pages []*tree.Page
+}
+
+// ListFavoritesUseCase resolves a user's favorited page IDs to full pages,
+// silently skipping ids that no longer resolve (e.g. leftover rows from
+// before the delete-cascade cleanup shipped).
+type ListFavoritesUseCase struct {
+	treeService *tree.TreeService
+	store       *favorites.FavoritesStore
+	log         *slog.Logger
+}
+
+func NewListFavoritesUseCase(treeService *tree.TreeService, store *favorites.FavoritesStore, log *slog.Logger) *ListFavoritesUseCase {
+	return &ListFavoritesUseCase{treeService: treeService, store: store, log: log}
+}
+
+func (uc *ListFavoritesUseCase) Execute(_ context.Context, in ListFavoritesInput) (*ListFavoritesOutput, error) {
+	ids, err := uc.store.ListPageIDsForUser(in.UserID)
+	if err != nil {
+		return nil, err
+	}
+	if len(ids) == 0 {
+		return &ListFavoritesOutput{Pages: []*tree.Page{}}, nil
+	}
+
+	pages, errs := uc.treeService.GetPages(ids)
+	result := make([]*tree.Page, 0, len(pages))
+	for i, p := range pages {
+		if errs[i] != nil {
+			uc.log.Warn("skipping stale favorite", "userID", in.UserID, "pageID", ids[i], "error", errs[i])
+			continue
+		}
+		result = append(result, p)
+	}
+	return &ListFavoritesOutput{Pages: result}, nil
+}

--- a/internal/wiki/pages/pages_test.go
+++ b/internal/wiki/pages/pages_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/perber/wiki/internal/core/revision"
 	sharederrors "github.com/perber/wiki/internal/core/shared/errors"
 	"github.com/perber/wiki/internal/core/tree"
+	"github.com/perber/wiki/internal/favorites"
 	httpmetrics "github.com/perber/wiki/internal/http/metrics"
 	"github.com/perber/wiki/internal/links"
 	"github.com/perber/wiki/internal/test_utils"
@@ -33,6 +34,7 @@ type testDeps struct {
 	revision   *revision.Service
 	links      *links.LinkService
 	assets     *assets.AssetService
+	favorites  *favorites.FavoritesStore
 }
 
 func newTestDeps(t *testing.T) *testDeps {
@@ -58,6 +60,16 @@ func newTestDeps(t *testing.T) *testDeps {
 		revision.ServiceOptions{},
 	)
 
+	favoritesStore, err := favorites.NewFavoritesStore(storageDir)
+	if err != nil {
+		t.Fatalf("failed to create favorites store: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := favoritesStore.Close(); err != nil {
+			t.Errorf("failed to close favorites store: %v", err)
+		}
+	})
+
 	return &testDeps{
 		storageDir: storageDir,
 		tree:       treeService,
@@ -65,6 +77,7 @@ func newTestDeps(t *testing.T) *testDeps {
 		revision:   revService,
 		links:      linkService,
 		assets:     assetService,
+		favorites:  favoritesStore,
 	}
 }
 
@@ -363,7 +376,7 @@ func TestUpdatePageUseCase_EmptyTitle_ReturnsValidationError(t *testing.T) {
 func TestDeletePageUseCase_HappyPath(t *testing.T) {
 	deps := newTestDeps(t)
 	createUC := pages.NewCreatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default(), nil)
-	deleteUC := pages.NewDeletePageUseCase(deps.tree, deps.revision, deps.assets, deps.orchestrator(), slog.Default(), nil)
+	deleteUC := pages.NewDeletePageUseCase(deps.tree, deps.revision, deps.assets, deps.favorites, deps.orchestrator(), slog.Default(), nil)
 
 	created, _ := createUC.Execute(context.Background(), pages.CreatePageInput{
 		UserID: "user1", Title: "To Delete", Slug: "to-delete", Kind: pageKind(),
@@ -386,7 +399,7 @@ func TestDeletePageUseCase_HappyPath(t *testing.T) {
 
 func TestDeletePageUseCase_Root_ReturnsError(t *testing.T) {
 	deps := newTestDeps(t)
-	deleteUC := pages.NewDeletePageUseCase(deps.tree, deps.revision, deps.assets, deps.orchestrator(), slog.Default(), nil)
+	deleteUC := pages.NewDeletePageUseCase(deps.tree, deps.revision, deps.assets, deps.favorites, deps.orchestrator(), slog.Default(), nil)
 
 	err := deleteUC.Execute(context.Background(), pages.DeletePageInput{
 		UserID: "user1", ID: "root", Recursive: false,
@@ -399,7 +412,7 @@ func TestDeletePageUseCase_Root_ReturnsError(t *testing.T) {
 func TestDeletePageUseCase_WithChildren_Recursive(t *testing.T) {
 	deps := newTestDeps(t)
 	createUC := pages.NewCreatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default(), nil)
-	deleteUC := pages.NewDeletePageUseCase(deps.tree, deps.revision, deps.assets, deps.orchestrator(), slog.Default(), nil)
+	deleteUC := pages.NewDeletePageUseCase(deps.tree, deps.revision, deps.assets, deps.favorites, deps.orchestrator(), slog.Default(), nil)
 
 	parent, _ := createUC.Execute(context.Background(), pages.CreatePageInput{
 		UserID: "user1", Title: "Parent", Slug: "parent", Kind: pageKind(),
@@ -413,6 +426,235 @@ func TestDeletePageUseCase_WithChildren_Recursive(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("unexpected error on recursive delete: %v", err)
+	}
+}
+
+func TestDeletePageUseCase_NonRecursive_RemovesFavoritesForPage(t *testing.T) {
+	deps := newTestDeps(t)
+	createUC := pages.NewCreatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default(), nil)
+	deleteUC := pages.NewDeletePageUseCase(deps.tree, deps.revision, deps.assets, deps.favorites, deps.orchestrator(), slog.Default(), nil)
+
+	created, _ := createUC.Execute(context.Background(), pages.CreatePageInput{
+		UserID: "user1", Title: "To Delete", Slug: "to-delete", Kind: pageKind(),
+	})
+	if err := deps.favorites.Add("user1", created.Page.ID); err != nil {
+		t.Fatalf("failed to seed favorite: %v", err)
+	}
+
+	if err := deleteUC.Execute(context.Background(), pages.DeletePageInput{
+		UserID: "user1", ID: created.Page.ID, Version: created.Page.Version(), Recursive: false,
+	}); err != nil {
+		t.Fatalf("unexpected error deleting page: %v", err)
+	}
+
+	ids, err := deps.favorites.ListPageIDsForUser("user1")
+	if err != nil {
+		t.Fatalf("ListPageIDsForUser: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Errorf("expected favorites for deleted page to be cleaned up, got %v", ids)
+	}
+}
+
+func TestDeletePageUseCase_Recursive_RemovesFavoritesForWholeSubtree(t *testing.T) {
+	deps := newTestDeps(t)
+	createUC := pages.NewCreatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default(), nil)
+	deleteUC := pages.NewDeletePageUseCase(deps.tree, deps.revision, deps.assets, deps.favorites, deps.orchestrator(), slog.Default(), nil)
+
+	parent, _ := createUC.Execute(context.Background(), pages.CreatePageInput{
+		UserID: "user1", Title: "Parent", Slug: "parent", Kind: pageKind(),
+	})
+	child, _ := createUC.Execute(context.Background(), pages.CreatePageInput{
+		UserID: "user1", ParentID: &parent.Page.ID, Title: "Child", Slug: "child", Kind: pageKind(),
+	})
+	if err := deps.favorites.Add("user1", parent.Page.ID); err != nil {
+		t.Fatalf("failed to seed favorite: %v", err)
+	}
+	if err := deps.favorites.Add("user1", child.Page.ID); err != nil {
+		t.Fatalf("failed to seed favorite: %v", err)
+	}
+
+	if err := deleteUC.Execute(context.Background(), pages.DeletePageInput{
+		UserID: "user1", ID: parent.Page.ID, Version: parent.Page.Version(), Recursive: true,
+	}); err != nil {
+		t.Fatalf("unexpected error on recursive delete: %v", err)
+	}
+
+	ids, err := deps.favorites.ListPageIDsForUser("user1")
+	if err != nil {
+		t.Fatalf("ListPageIDsForUser: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Errorf("expected favorites for deleted subtree to be cleaned up, got %v", ids)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AddFavoriteUseCase / RemoveFavoriteUseCase / ListFavoritesUseCase
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestAddFavoriteUseCase_HappyPath(t *testing.T) {
+	deps := newTestDeps(t)
+	createUC := pages.NewCreatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default(), nil)
+	addFavoriteUC := pages.NewAddFavoriteUseCase(deps.tree, deps.favorites)
+
+	created, _ := createUC.Execute(context.Background(), pages.CreatePageInput{
+		UserID: "user1", Title: "Page", Slug: "page", Kind: pageKind(),
+	})
+
+	if err := addFavoriteUC.Execute(context.Background(), pages.AddFavoriteInput{
+		UserID: "user1", PageID: created.Page.ID,
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ids, err := deps.favorites.ListPageIDsForUser("user1")
+	if err != nil {
+		t.Fatalf("ListPageIDsForUser: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != created.Page.ID {
+		t.Errorf("expected [%s], got %v", created.Page.ID, ids)
+	}
+}
+
+func TestAddFavoriteUseCase_NonExistentPage_ReturnsError(t *testing.T) {
+	deps := newTestDeps(t)
+	addFavoriteUC := pages.NewAddFavoriteUseCase(deps.tree, deps.favorites)
+
+	err := addFavoriteUC.Execute(context.Background(), pages.AddFavoriteInput{
+		UserID: "user1", PageID: "does-not-exist",
+	})
+	if !errors.Is(err, tree.ErrPageNotFound) {
+		t.Fatalf("expected ErrPageNotFound, got %v", err)
+	}
+}
+
+func TestAddFavoriteUseCase_Idempotent(t *testing.T) {
+	deps := newTestDeps(t)
+	createUC := pages.NewCreatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default(), nil)
+	addFavoriteUC := pages.NewAddFavoriteUseCase(deps.tree, deps.favorites)
+
+	created, _ := createUC.Execute(context.Background(), pages.CreatePageInput{
+		UserID: "user1", Title: "Page", Slug: "page", Kind: pageKind(),
+	})
+
+	for i := 0; i < 2; i++ {
+		if err := addFavoriteUC.Execute(context.Background(), pages.AddFavoriteInput{
+			UserID: "user1", PageID: created.Page.ID,
+		}); err != nil {
+			t.Fatalf("unexpected error on attempt %d: %v", i, err)
+		}
+	}
+
+	ids, err := deps.favorites.ListPageIDsForUser("user1")
+	if err != nil {
+		t.Fatalf("ListPageIDsForUser: %v", err)
+	}
+	if len(ids) != 1 {
+		t.Errorf("expected exactly one favorite, got %v", ids)
+	}
+}
+
+func TestRemoveFavoriteUseCase_HappyPath(t *testing.T) {
+	deps := newTestDeps(t)
+	createUC := pages.NewCreatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default(), nil)
+	addFavoriteUC := pages.NewAddFavoriteUseCase(deps.tree, deps.favorites)
+	removeFavoriteUC := pages.NewRemoveFavoriteUseCase(deps.favorites)
+
+	created, _ := createUC.Execute(context.Background(), pages.CreatePageInput{
+		UserID: "user1", Title: "Page", Slug: "page", Kind: pageKind(),
+	})
+	if err := addFavoriteUC.Execute(context.Background(), pages.AddFavoriteInput{
+		UserID: "user1", PageID: created.Page.ID,
+	}); err != nil {
+		t.Fatalf("failed to seed favorite: %v", err)
+	}
+
+	if err := removeFavoriteUC.Execute(context.Background(), pages.RemoveFavoriteInput{
+		UserID: "user1", PageID: created.Page.ID,
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ids, err := deps.favorites.ListPageIDsForUser("user1")
+	if err != nil {
+		t.Fatalf("ListPageIDsForUser: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Errorf("expected no favorites, got %v", ids)
+	}
+}
+
+func TestRemoveFavoriteUseCase_NotFavorited_IsNoOp(t *testing.T) {
+	deps := newTestDeps(t)
+	removeFavoriteUC := pages.NewRemoveFavoriteUseCase(deps.favorites)
+
+	if err := removeFavoriteUC.Execute(context.Background(), pages.RemoveFavoriteInput{
+		UserID: "user1", PageID: "never-favorited",
+	}); err != nil {
+		t.Fatalf("expected no error removing a non-favorited page, got %v", err)
+	}
+}
+
+func TestListFavoritesUseCase_ResolvesFavoritedPages(t *testing.T) {
+	deps := newTestDeps(t)
+	createUC := pages.NewCreatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default(), nil)
+	addFavoriteUC := pages.NewAddFavoriteUseCase(deps.tree, deps.favorites)
+	listFavoritesUC := pages.NewListFavoritesUseCase(deps.tree, deps.favorites, slog.Default())
+
+	pageA, _ := createUC.Execute(context.Background(), pages.CreatePageInput{
+		UserID: "user1", Title: "Page A", Slug: "page-a", Kind: pageKind(),
+	})
+	createUC.Execute(context.Background(), pages.CreatePageInput{ //nolint:errcheck
+		UserID: "user1", Title: "Page B", Slug: "page-b", Kind: pageKind(),
+	})
+	if err := addFavoriteUC.Execute(context.Background(), pages.AddFavoriteInput{
+		UserID: "user1", PageID: pageA.Page.ID,
+	}); err != nil {
+		t.Fatalf("failed to seed favorite: %v", err)
+	}
+
+	out, err := listFavoritesUC.Execute(context.Background(), pages.ListFavoritesInput{UserID: "user1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.Pages) != 1 || out.Pages[0].ID != pageA.Page.ID {
+		t.Fatalf("expected only page A, got %#v", out.Pages)
+	}
+
+	// Page B was never favorited and must not leak into another user's list.
+	otherUserOut, err := listFavoritesUC.Execute(context.Background(), pages.ListFavoritesInput{UserID: "user2"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(otherUserOut.Pages) != 0 {
+		t.Errorf("expected user2 to have no favorites, got %#v", otherUserOut.Pages)
+	}
+}
+
+func TestListFavoritesUseCase_SkipsStaleFavoriteForDeletedPage(t *testing.T) {
+	deps := newTestDeps(t)
+	createUC := pages.NewCreatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default(), nil)
+	listFavoritesUC := pages.NewListFavoritesUseCase(deps.tree, deps.favorites, slog.Default())
+
+	created, _ := createUC.Execute(context.Background(), pages.CreatePageInput{
+		UserID: "user1", Title: "Page", Slug: "page", Kind: pageKind(),
+	})
+	// Simulate a stale row (e.g. pre-dating the delete-cascade cleanup) by
+	// favoriting an id that does not resolve to a live page.
+	if err := deps.favorites.Add("user1", "stale-page-id"); err != nil {
+		t.Fatalf("failed to seed stale favorite: %v", err)
+	}
+	if err := deps.favorites.Add("user1", created.Page.ID); err != nil {
+		t.Fatalf("failed to seed favorite: %v", err)
+	}
+
+	out, err := listFavoritesUC.Execute(context.Background(), pages.ListFavoritesInput{UserID: "user1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.Pages) != 1 || out.Pages[0].ID != created.Page.ID {
+		t.Fatalf("expected stale favorite to be silently skipped, got %#v", out.Pages)
 	}
 }
 
@@ -733,7 +975,7 @@ func TestUpdatePageUseCase_AllowsUppercaseSlug(t *testing.T) {
 
 func TestDeletePageUseCase_EmptyID_ReturnsError(t *testing.T) {
 	deps := newTestDeps(t)
-	deleteUC := pages.NewDeletePageUseCase(deps.tree, deps.revision, deps.assets, deps.orchestrator(), slog.Default(), nil)
+	deleteUC := pages.NewDeletePageUseCase(deps.tree, deps.revision, deps.assets, deps.favorites, deps.orchestrator(), slog.Default(), nil)
 
 	err := deleteUC.Execute(context.Background(), pages.DeletePageInput{
 		UserID: "user1", ID: "", Recursive: false,
@@ -1807,7 +2049,7 @@ func TestDeletePageUseCase_NonRecursive_MarksIncomingBroken(t *testing.T) {
 	deps := newTestDeps(t)
 	createUC := pages.NewCreatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default(), nil)
 	updateUC := pages.NewUpdatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default(), nil)
-	deleteUC := pages.NewDeletePageUseCase(deps.tree, deps.revision, deps.assets, deps.orchestrator(), slog.Default(), nil)
+	deleteUC := pages.NewDeletePageUseCase(deps.tree, deps.revision, deps.assets, deps.favorites, deps.orchestrator(), slog.Default(), nil)
 
 	a, err := createUC.Execute(context.Background(), pages.CreatePageInput{
 		UserID: "system", Title: "Page A", Slug: "a", Kind: pageKind(),
@@ -1869,7 +2111,7 @@ func TestDeletePageUseCase_Recursive_RemovesOutgoingForSubtree_AndBreaksIncoming
 	deps := newTestDeps(t)
 	createUC := pages.NewCreatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default(), nil)
 	updateUC := pages.NewUpdatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default(), nil)
-	deleteUC := pages.NewDeletePageUseCase(deps.tree, deps.revision, deps.assets, deps.orchestrator(), slog.Default(), nil)
+	deleteUC := pages.NewDeletePageUseCase(deps.tree, deps.revision, deps.assets, deps.favorites, deps.orchestrator(), slog.Default(), nil)
 
 	docs, _ := createUC.Execute(context.Background(), pages.CreatePageInput{
 		UserID: "system", Title: "Docs", Slug: "docs", Kind: pageKind(),
@@ -1945,7 +2187,7 @@ func TestDeletePageUseCase_SingleDelete_HealsSentinelWhenDuplicateTitleRemoved(t
 	deps := newTestDeps(t)
 	createUC := pages.NewCreatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default(), nil)
 	updateUC := pages.NewUpdatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default(), nil)
-	deleteUC := pages.NewDeletePageUseCase(deps.tree, deps.revision, deps.assets, deps.orchestrator(), slog.Default(), nil)
+	deleteUC := pages.NewDeletePageUseCase(deps.tree, deps.revision, deps.assets, deps.favorites, deps.orchestrator(), slog.Default(), nil)
 
 	// Two pages share the title "Kafka".
 	kafka1, err := createUC.Execute(context.Background(), pages.CreatePageInput{
@@ -2013,7 +2255,7 @@ func TestDeletePageUseCase_Recursive_HealsSentinelWhenDuplicateTitleRemoved(t *t
 	deps := newTestDeps(t)
 	createUC := pages.NewCreatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default(), nil)
 	updateUC := pages.NewUpdatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default(), nil)
-	deleteUC := pages.NewDeletePageUseCase(deps.tree, deps.revision, deps.assets, deps.orchestrator(), slog.Default(), nil)
+	deleteUC := pages.NewDeletePageUseCase(deps.tree, deps.revision, deps.assets, deps.favorites, deps.orchestrator(), slog.Default(), nil)
 
 	// kafka1 lives inside a section that we will delete recursively.
 	section, err := createUC.Execute(context.Background(), pages.CreatePageInput{
@@ -2098,7 +2340,7 @@ func TestDeletePageUseCase_Recursive_MarksHealedWikiLinkSentinelBroken(t *testin
 	deps := newTestDeps(t)
 	createUC := pages.NewCreatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default(), nil)
 	updateUC := pages.NewUpdatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default(), nil)
-	deleteUC := pages.NewDeletePageUseCase(deps.tree, deps.revision, deps.assets, deps.orchestrator(), slog.Default(), nil)
+	deleteUC := pages.NewDeletePageUseCase(deps.tree, deps.revision, deps.assets, deps.favorites, deps.orchestrator(), slog.Default(), nil)
 
 	// Step 1: source writes [[Kafka]] before any Kafka page exists → broken sentinel.
 	source, err := createUC.Execute(context.Background(), pages.CreatePageInput{

--- a/internal/wiki/pages/remove_favorite.go
+++ b/internal/wiki/pages/remove_favorite.go
@@ -1,0 +1,26 @@
+package pages
+
+import (
+	"context"
+
+	"github.com/perber/wiki/internal/favorites"
+)
+
+type RemoveFavoriteInput struct {
+	UserID string
+	PageID string
+}
+
+// RemoveFavoriteUseCase un-favorites a page for a given user. Idempotent —
+// removing a page that isn't favorited (or no longer exists) is not an error.
+type RemoveFavoriteUseCase struct {
+	store *favorites.FavoritesStore
+}
+
+func NewRemoveFavoriteUseCase(store *favorites.FavoritesStore) *RemoveFavoriteUseCase {
+	return &RemoveFavoriteUseCase{store: store}
+}
+
+func (uc *RemoveFavoriteUseCase) Execute(_ context.Context, in RemoveFavoriteInput) error {
+	return uc.store.Remove(in.UserID, in.PageID)
+}

--- a/internal/wiki/pages/routes.go
+++ b/internal/wiki/pages/routes.go
@@ -42,6 +42,9 @@ type Routes struct {
 	previewRefactor  *PreviewPageRefactorUseCase
 	applyRefactor    *ApplyPageRefactorUseCase
 	pinPage          *PinPageUseCase
+	addFavorite      *AddFavoriteUseCase
+	removeFavorite   *RemoveFavoriteUseCase
+	listFavorites    *ListFavoritesUseCase
 	userResolver     *coreauth.UserResolver
 	authService      *coreauth.AuthService
 }
@@ -66,6 +69,9 @@ type RoutesConfig struct {
 	PreviewRefactor  *PreviewPageRefactorUseCase
 	ApplyRefactor    *ApplyPageRefactorUseCase
 	PinPage          *PinPageUseCase
+	AddFavorite      *AddFavoriteUseCase
+	RemoveFavorite   *RemoveFavoriteUseCase
+	ListFavorites    *ListFavoritesUseCase
 	UserResolver     *coreauth.UserResolver
 	AuthService      *coreauth.AuthService
 }
@@ -91,6 +97,9 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 		previewRefactor:  cfg.PreviewRefactor,
 		applyRefactor:    cfg.ApplyRefactor,
 		pinPage:          cfg.PinPage,
+		addFavorite:      cfg.AddFavorite,
+		removeFavorite:   cfg.RemoveFavorite,
+		listFavorites:    cfg.ListFavorites,
 		userResolver:     cfg.UserResolver,
 		authService:      cfg.AuthService,
 	}
@@ -133,6 +142,11 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	authGroup.PUT("/pages/:id/move", authmw.RequireEditorOrAdmin(), r.handleMove)
 	authGroup.PUT("/pages/:id/sort", authmw.RequireEditorOrAdmin(), r.handleSort)
 	authGroup.PUT("/pages/:id/pin", authmw.RequireEditorOrAdmin(), r.handlePin)
+	// Favorites are a personal bookmark, not an editorial action — any
+	// authenticated user (already enforced by authGroup) may set their own.
+	authGroup.PUT("/pages/:id/favorite", r.handleAddFavorite)
+	authGroup.DELETE("/pages/:id/favorite", r.handleRemoveFavorite)
+	authGroup.GET("/favorites", r.handleListFavorites)
 	authGroup.POST("/pages/ensure", authmw.RequireEditorOrAdmin(), r.handleEnsurePath)
 	authGroup.POST("/pages/convert/:id", authmw.RequireEditorOrAdmin(), r.handleConvert)
 	authGroup.POST("/pages/copy/:id", authmw.RequireEditorOrAdmin(), r.handleCopy)
@@ -386,6 +400,55 @@ func (r *Routes) handlePin(c *gin.Context) {
 		return
 	}
 	r.respondPage(c, http.StatusOK, out.Page)
+}
+
+func (r *Routes) handleAddFavorite(c *gin.Context) {
+	id := strings.TrimSpace(c.Param("id"))
+	user := authmw.MustGetUser(c)
+	if user == nil {
+		return
+	}
+	if err := r.addFavorite.Execute(c.Request.Context(), AddFavoriteInput{
+		UserID: user.ID, PageID: id,
+	}); err != nil {
+		respondWithPageError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "Page favorited"})
+}
+
+func (r *Routes) handleRemoveFavorite(c *gin.Context) {
+	id := strings.TrimSpace(c.Param("id"))
+	user := authmw.MustGetUser(c)
+	if user == nil {
+		return
+	}
+	if err := r.removeFavorite.Execute(c.Request.Context(), RemoveFavoriteInput{
+		UserID: user.ID, PageID: id,
+	}); err != nil {
+		respondWithPageError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "Page unfavorited"})
+}
+
+func (r *Routes) handleListFavorites(c *gin.Context) {
+	user := authmw.MustGetUser(c)
+	if user == nil {
+		return
+	}
+	out, err := r.listFavorites.Execute(c.Request.Context(), ListFavoritesInput{UserID: user.ID})
+	if err != nil {
+		respondWithPageError(c, err)
+		return
+	}
+	apiPages := make([]*dto.Page, 0, len(out.Pages))
+	for _, p := range out.Pages {
+		apiPage := dto.ToAPIPage(p, r.userResolver)
+		r.enrichPageMetadata(apiPage)
+		apiPages = append(apiPages, apiPage)
+	}
+	c.JSON(http.StatusOK, gin.H{"pages": apiPages})
 }
 
 func (r *Routes) handleEnsurePath(c *gin.Context) {

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -13,6 +13,7 @@ import (
 	"github.com/perber/wiki/internal/core/auth"
 	"github.com/perber/wiki/internal/core/revision"
 	"github.com/perber/wiki/internal/core/tree"
+	"github.com/perber/wiki/internal/favorites"
 	httpinternal "github.com/perber/wiki/internal/http"
 	httpmetrics "github.com/perber/wiki/internal/http/metrics"
 	coreimporter "github.com/perber/wiki/internal/importer"
@@ -64,6 +65,7 @@ type Wiki struct {
 	links            *links.LinkService
 	tags             *tags.TagsService
 	props            *properties.PropertiesService
+	favorites        *favorites.FavoritesStore
 	backupRoutes     *wikibackup.Routes
 	resyncRoutes     *wikiresync.Routes
 	resyncJob        *wikiresync.ResyncJob
@@ -116,6 +118,9 @@ func NewWiki(options *WikiOptions) (*Wiki, error) {
 		return nil, err
 	}
 	if err := w.initPropertiesService(); err != nil {
+		return nil, err
+	}
+	if err := w.initFavoritesService(); err != nil {
 		return nil, err
 	}
 	w.bootstrapTagsAndProperties()
@@ -242,6 +247,15 @@ func (w *Wiki) initPropertiesService() error {
 	return nil
 }
 
+func (w *Wiki) initFavoritesService() error {
+	store, err := favorites.NewFavoritesStore(w.storageDir)
+	if err != nil {
+		return fmt.Errorf("failed to init favorites store: %w", err)
+	}
+	w.favorites = store
+	return nil
+}
+
 // bootstrapTagsAndProperties clears and rebuilds tag and property indexes in a single
 // parallel GetPages pass — avoids two sequential ReadPageRaw loops at startup.
 func (w *Wiki) bootstrapTagsAndProperties() {
@@ -352,7 +366,7 @@ func (w *Wiki) buildPagesRoutes() *wikipages.Routes {
 		TreeService:      w.tree,
 		CreatePage:       wikipages.NewCreatePageUseCase(w.tree, w.slug, o, w.log, w.metrics),
 		UpdatePage:       wikipages.NewUpdatePageUseCase(w.tree, w.slug, o, w.log, w.metrics),
-		DeletePage:       wikipages.NewDeletePageUseCase(w.tree, w.revision, w.asset, o, w.log, w.metrics),
+		DeletePage:       wikipages.NewDeletePageUseCase(w.tree, w.revision, w.asset, w.favorites, o, w.log, w.metrics),
 		MovePage:         wikipages.NewMovePageUseCase(w.tree, o, w.log, w.metrics),
 		ConvertPage:      wikipages.NewConvertPageUseCase(w.tree, w.revision, w.log),
 		CopyPage:         wikipages.NewCopyPageUseCase(w.tree, w.slug, o, w.asset, w.log),
@@ -367,6 +381,9 @@ func (w *Wiki) buildPagesRoutes() *wikipages.Routes {
 		PreviewRefactor:  wikipages.NewPreviewPageRefactorUseCase(w.tree, w.slug, w.links, w.log),
 		ApplyRefactor:    wikipages.NewApplyPageRefactorUseCase(w.tree, w.slug, w.revision, w.links, w.log, w.metrics),
 		PinPage:          wikipages.NewPinPageUseCase(w.tree, w.log),
+		AddFavorite:      wikipages.NewAddFavoriteUseCase(w.tree, w.favorites),
+		RemoveFavorite:   wikipages.NewRemoveFavoriteUseCase(w.favorites),
+		ListFavorites:    wikipages.NewListFavoritesUseCase(w.tree, w.favorites, w.log),
 		UserResolver:     w.userResolver,
 		AuthService:      w.auth,
 	})
@@ -380,7 +397,7 @@ func (w *Wiki) buildAuthRoutes() *wikiauth.Routes {
 		CreateUser:        wikiauth.NewCreateUserUseCase(w.user, w.userResolver, w.log),
 		UpdateUser:        wikiauth.NewUpdateUserUseCase(w.user, w.userResolver, w.log),
 		ChangeOwnPassword: wikiauth.NewChangeOwnPasswordUseCase(w.user),
-		DeleteUser:        wikiauth.NewDeleteUserUseCase(w.user, w.userResolver, w.log),
+		DeleteUser:        wikiauth.NewDeleteUserUseCase(w.user, w.userResolver, w.favorites, w.log),
 		GetUsers:          wikiauth.NewGetUsersUseCase(w.user),
 		GetUserByID:       wikiauth.NewGetUserByIDUseCase(w.user),
 		AuthService:       w.auth,

--- a/internal/wiki/wiki_test.go
+++ b/internal/wiki/wiki_test.go
@@ -92,7 +92,7 @@ func deletePageForTest(t *testing.T, w *Wiki, userID, id string, recursive bool)
 		t.Fatalf("GetPage before delete failed: %v", err)
 	}
 
-	if err := wikipages.NewDeletePageUseCase(w.tree, w.revision, w.asset, w.newPageOrchestrator(), w.log, nil).Execute(
+	if err := wikipages.NewDeletePageUseCase(w.tree, w.revision, w.asset, w.favorites, w.newPageOrchestrator(), w.log, nil).Execute(
 		context.Background(),
 		wikipages.DeletePageInput{UserID: userID, ID: id, Version: current.Version(), Recursive: recursive},
 	); err != nil {
@@ -116,7 +116,7 @@ func TestWiki_DeletePage_WithChildren(t *testing.T) {
 	parent := createPageForTest(t, w, "system", nil, "Parent", "parent", pageNodeKind())
 	createPageForTest(t, w, "system", &parent.ID, "Child", "child", pageNodeKind())
 
-	err := wikipages.NewDeletePageUseCase(w.tree, w.revision, w.asset, w.newPageOrchestrator(), w.log, nil).Execute(
+	err := wikipages.NewDeletePageUseCase(w.tree, w.revision, w.asset, w.favorites, w.newPageOrchestrator(), w.log, nil).Execute(
 		context.Background(),
 		wikipages.DeletePageInput{UserID: "system", ID: parent.ID, Version: parent.Version(), Recursive: false},
 	)

--- a/ui/leafwiki-ui/src/App.tsx
+++ b/ui/leafwiki-ui/src/App.tsx
@@ -3,6 +3,7 @@ import { createLeafWikiRouter } from '@/features/router/router'
 import { useBootstrapAuth } from '@/lib/bootstrapAuth'
 import { BASE_PATH } from '@/lib/config'
 import { useIsReadOnly } from '@/lib/useIsReadOnly'
+import { useFavoritesStore } from '@/stores/favorites'
 import { useSessionStore } from '@/stores/session'
 import useApplyDesignMode from '@/useApplyDesignMode'
 import { Loader2 } from 'lucide-react'
@@ -28,14 +29,28 @@ function App() {
   useBootstrapAuth(configHasLoaded && !authDisabled)
 
   const isLoggedIn = useSessionStore((s) => !!s.user)
+  const userId = useSessionStore((s) => s.user?.id ?? null)
   const isRefreshing = useSessionStore((s) => s.isRefreshing)
   const isReadOnly = useIsReadOnly()
   const isReadOnlyViewer = isReadOnly && !isLoggedIn
+  const loadFavorites = useFavoritesStore((s) => s.loadFavorites)
+  const clearFavorites = useFavoritesStore((s) => s.clearFavorites)
 
   useApplyDesignMode()
   useEffect(() => {
     loadConfig()
   }, [loadConfig])
+
+  // Favorites are per-user server truth — (re)load whenever the logged-in
+  // user changes, and clear them on logout so a second user on the same
+  // browser never sees the first user's favorites.
+  useEffect(() => {
+    if (userId) {
+      loadFavorites()
+    } else {
+      clearFavorites()
+    }
+  }, [userId, loadFavorites, clearFavorites])
 
   useLayoutEffect(() => {
     // Load branding configuration

--- a/ui/leafwiki-ui/src/features/favorites/FavoriteItem.tsx
+++ b/ui/leafwiki-ui/src/features/favorites/FavoriteItem.tsx
@@ -1,0 +1,38 @@
+import { FavoriteToggleButton } from '@/features/favorites/FavoriteToggleButton'
+import { NODE_KIND_SECTION, PageNode } from '@/lib/api/pages'
+import { buildViewUrl } from '@/lib/routePath'
+import { useTreeStore } from '@/stores/tree'
+import clsx from 'clsx'
+import { File, Folder } from 'lucide-react'
+import { Link } from 'react-router-dom'
+
+type Props = {
+  node: PageNode
+}
+
+export function FavoriteItem({ node }: Props) {
+  const activeNodeId = useTreeStore((s) => s.activeNodeId)
+  const isActive = activeNodeId === node.id
+  const Icon = node.kind === NODE_KIND_SECTION ? Folder : File
+
+  return (
+    <div
+      className={clsx('tree-view__favorite-item', {
+        'tree-view__favorite-item--active': isActive,
+      })}
+      data-testid="favorite-item"
+    >
+      <Link
+        to={buildViewUrl(`/${node.path}`)}
+        className="tree-view__favorite-item-link"
+      >
+        <Icon size={13} className="tree-view__favorite-item-icon" />
+        <span className="tree-view__favorite-item-title">{node.title}</span>
+      </Link>
+      <FavoriteToggleButton
+        pageId={node.id}
+        className="tree-view__favorite-item-remove"
+      />
+    </div>
+  )
+}

--- a/ui/leafwiki-ui/src/features/favorites/FavoriteToggleButton.tsx
+++ b/ui/leafwiki-ui/src/features/favorites/FavoriteToggleButton.tsx
@@ -1,0 +1,58 @@
+import { TooltipWrapper } from '@/components/TooltipWrapper'
+import { useFavoritesStore } from '@/stores/favorites'
+import clsx from 'clsx'
+import { Star } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+type Props = {
+  pageId: string
+  size?: number
+  className?: string
+}
+
+export function FavoriteToggleButton({ pageId, size = 13, className }: Props) {
+  const { t } = useTranslation('viewer')
+  const isFavorited = useFavoritesStore((s) => s.favoritePageIds.has(pageId))
+  const addFavorite = useFavoritesStore((s) => s.addFavorite)
+  const removeFavorite = useFavoritesStore((s) => s.removeFavorite)
+
+  const handleToggle = async () => {
+    try {
+      if (isFavorited) {
+        await removeFavorite(pageId)
+        toast.success(t('favorites.removeSuccess'))
+      } else {
+        await addFavorite(pageId)
+        toast.success(t('favorites.addSuccess'))
+      }
+    } catch {
+      toast.error(t('favorites.favoriteError'))
+    }
+  }
+
+  const label = isFavorited
+    ? t('favorites.removeFavorite')
+    : t('favorites.addFavorite')
+
+  return (
+    <TooltipWrapper label={label} side="top" align="start">
+      <button
+        type="button"
+        className={clsx('favorite-toggle-button', className, {
+          'favorite-toggle-button--active': isFavorited,
+        })}
+        onClick={(e) => {
+          e.preventDefault()
+          e.stopPropagation()
+          handleToggle()
+        }}
+        aria-label={label}
+        aria-pressed={isFavorited}
+        data-testid={`favorite-toggle-${pageId}`}
+      >
+        <Star size={size} fill={isFavorited ? 'currentColor' : 'none'} />
+      </button>
+    </TooltipWrapper>
+  )
+}

--- a/ui/leafwiki-ui/src/features/favorites/FavoritesSection.test.tsx
+++ b/ui/leafwiki-ui/src/features/favorites/FavoritesSection.test.tsx
@@ -1,0 +1,89 @@
+import type { PageNode } from '@/lib/api/pages'
+import { useFavoritesStore } from '@/stores/favorites'
+import { useTreeStore } from '@/stores/tree'
+import { render, screen } from '@testing-library/react'
+import type React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { FavoritesSection } from './FavoritesSection'
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: {
+    type: '3rdParty',
+    init: () => {},
+  },
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('@/components/TooltipWrapper', () => ({
+  TooltipWrapper: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+function makeNode(id: string, title: string): PageNode {
+  return {
+    id,
+    title,
+    slug: id,
+    path: id,
+    version: 'v1',
+    children: null,
+    kind: 'page',
+  }
+}
+
+describe('FavoritesSection', () => {
+  beforeEach(() => {
+    useFavoritesStore.setState({ favoritePageIds: new Set(), loaded: false })
+    useTreeStore.setState({ byId: {} })
+  })
+
+  it('renders nothing when there are no favorites', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <FavoritesSection />
+      </MemoryRouter>,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders favorited pages resolved from the tree store, sorted by title', () => {
+    useTreeStore.setState({
+      byId: {
+        'page-1': makeNode('page-1', 'Zebra'),
+        'page-2': makeNode('page-2', 'Alpha'),
+      },
+    })
+    useFavoritesStore.setState({
+      favoritePageIds: new Set(['page-1', 'page-2']),
+    })
+
+    render(
+      <MemoryRouter>
+        <FavoritesSection />
+      </MemoryRouter>,
+    )
+
+    const items = screen.getAllByTestId('favorite-item')
+    expect(items).toHaveLength(2)
+    expect(items[0]).toHaveTextContent('Alpha')
+    expect(items[1]).toHaveTextContent('Zebra')
+  })
+
+  it('silently skips a favorited page id that no longer resolves in the tree', () => {
+    useTreeStore.setState({
+      byId: { 'page-1': makeNode('page-1', 'Still here') },
+    })
+    useFavoritesStore.setState({
+      favoritePageIds: new Set(['page-1', 'stale-id']),
+    })
+
+    render(
+      <MemoryRouter>
+        <FavoritesSection />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getAllByTestId('favorite-item')).toHaveLength(1)
+    expect(screen.getByText('Still here')).toBeInTheDocument()
+  })
+})

--- a/ui/leafwiki-ui/src/features/favorites/FavoritesSection.tsx
+++ b/ui/leafwiki-ui/src/features/favorites/FavoritesSection.tsx
@@ -1,0 +1,24 @@
+import { PageNode } from '@/lib/api/pages'
+import { useFavoritesStore } from '@/stores/favorites'
+import { useTreeStore } from '@/stores/tree'
+import { FavoriteItem } from './FavoriteItem'
+
+export function FavoritesSection() {
+  const favoritePageIds = useFavoritesStore((s) => s.favoritePageIds)
+  const byId = useTreeStore((s) => s.byId)
+
+  const favoritePages = Array.from(favoritePageIds)
+    .map((id) => byId[id])
+    .filter((n): n is PageNode => !!n)
+    .sort((a, b) => a.title.localeCompare(b.title))
+
+  if (favoritePages.length === 0) return null
+
+  return (
+    <div className="tree-view__favorites" data-testid="favorites-section">
+      {favoritePages.map((node) => (
+        <FavoriteItem key={node.id} node={node} />
+      ))}
+    </div>
+  )
+}

--- a/ui/leafwiki-ui/src/features/tree/TreeNode.tsx
+++ b/ui/leafwiki-ui/src/features/tree/TreeNode.tsx
@@ -1,3 +1,4 @@
+import { FavoriteToggleButton } from '@/features/favorites/FavoriteToggleButton'
 import { TreeViewActionButton } from '@/features/tree/TreeViewActionButton'
 import { NODE_KIND_SECTION, PageNode } from '@/lib/api/pages'
 import { DIALOG_ADD_PAGE } from '@/lib/registries'
@@ -5,6 +6,7 @@ import { createNavigationVisitState } from '@/lib/navigationVisit'
 import { useIsMobile } from '@/lib/useIsMobile'
 import { useIsReadOnly } from '@/lib/useIsReadOnly'
 import { useDialogsStore } from '@/stores/dialogs'
+import { useSessionStore } from '@/stores/session'
 import { useTreeStore } from '@/stores/tree'
 import clsx from 'clsx'
 import { ChevronUp, FilePlus } from 'lucide-react'
@@ -29,6 +31,7 @@ export const TreeNode = React.memo(function TreeNode({ node }: Props) {
   const isActionsMenuOpen = useTreeNodeActionsMenusStore(
     (s) => s.openMenuNodeId === node.id,
   )
+  const isLoggedIn = useSessionStore((s) => s.user !== null)
   const isActive = isStoreActive
 
   const indent = 4
@@ -96,25 +99,35 @@ export const TreeNode = React.memo(function TreeNode({ node }: Props) {
             )
           }
           {linkText}
-          {!readOnlyMode && (isMobile || hovered || isActionsMenuOpen) && (
+          {(isMobile || hovered || isActionsMenuOpen) && (
             <div className={clsx('tree-node__actions', treeActionButtonStyle)}>
-              <TreeViewActionButton
-                actionName="add"
-                icon={
-                  <FilePlus
-                    size={18}
-                    className={clsx(
-                      'tree-node__action-icon',
-                      isMobile && 'text-brand/70!',
-                    )}
+              {isLoggedIn && (
+                <FavoriteToggleButton
+                  pageId={node.id}
+                  className="tree-node__favorite-toggle"
+                />
+              )}
+              {!readOnlyMode && (
+                <>
+                  <TreeViewActionButton
+                    actionName="add"
+                    icon={
+                      <FilePlus
+                        size={18}
+                        className={clsx(
+                          'tree-node__action-icon',
+                          isMobile && 'text-brand/70!',
+                        )}
+                      />
+                    }
+                    tooltip="Create new page"
+                    onClick={() =>
+                      openDialog(DIALOG_ADD_PAGE, { parentId: node.id })
+                    }
                   />
-                }
-                tooltip="Create new page"
-                onClick={() =>
-                  openDialog(DIALOG_ADD_PAGE, { parentId: node.id })
-                }
-              />
-              <TreeNodeActionsMenu node={node} />
+                  <TreeNodeActionsMenu node={node} />
+                </>
+              )}
             </div>
           )}
         </div>

--- a/ui/leafwiki-ui/src/features/tree/TreeView.tsx
+++ b/ui/leafwiki-ui/src/features/tree/TreeView.tsx
@@ -5,6 +5,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { FavoritesSection } from '@/features/favorites/FavoritesSection'
 import { SidebarAccordionSection } from '@/features/sidebar/SidebarAccordionSection'
 import { TreeViewActionButton } from '@/features/tree/TreeViewActionButton'
 import { NODE_KIND_PAGE, NODE_KIND_SECTION } from '@/lib/api/pages'
@@ -14,6 +15,8 @@ import { useAppMode } from '@/lib/useAppMode'
 import { useIsReadOnly } from '@/lib/useIsReadOnly'
 import { toWikiLookupPath } from '@/lib/wikiPath'
 import { useDialogsStore } from '@/stores/dialogs'
+import { useFavoritesStore } from '@/stores/favorites'
+import { useSessionStore } from '@/stores/session'
 import { useSidebarPanelsStore } from '@/stores/sidebarPanels'
 import { useTreeStore } from '@/stores/tree'
 import {
@@ -24,6 +27,7 @@ import {
   List,
   MoreHorizontal,
   Pin,
+  Star,
 } from 'lucide-react'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -53,6 +57,9 @@ export default function TreeView() {
 
   const pinnedPages = useTreeStore((s) => s.pinnedPages)
   const hasPinned = pinnedPages.length > 0
+  const favoritePageIds = useFavoritesStore((s) => s.favoritePageIds)
+  const isLoggedIn = useSessionStore((s) => s.user !== null)
+  const hasFavorites = isLoggedIn && favoritePageIds.size > 0
   const openDialog = useDialogsStore((state) => state.openDialog)
   const readOnlyMode = useIsReadOnly()
   const openSections = useSidebarPanelsStore((s) => s.openSections)
@@ -200,6 +207,16 @@ export default function TreeView() {
           collapseToggleLabel={t('pinned.togglePinnedSection')}
         >
           <PinnedSection />
+        </SidebarAccordionSection>
+      )}
+      {hasFavorites && (
+        <SidebarAccordionSection
+          value="favorites"
+          title={t('favorites.sectionTitle')}
+          icon={<Star size={11} />}
+          collapseToggleLabel={t('favorites.toggleFavoritesSection')}
+        >
+          <FavoritesSection />
         </SidebarAccordionSection>
       )}
       <SidebarAccordionSection

--- a/ui/leafwiki-ui/src/features/viewer/PageViewer.tsx
+++ b/ui/leafwiki-ui/src/features/viewer/PageViewer.tsx
@@ -10,6 +10,7 @@ import {
   DIALOG_PAGE_PERMALINK,
 } from '@/lib/registries'
 import { buildHistoryUrl } from '@/lib/routePath'
+import { FavoriteToggleButton } from '@/features/favorites/FavoriteToggleButton'
 import { pinPage } from '@/lib/api/pages'
 import { createHotkeyDefinition } from '@/lib/shortcuts/shortcutCatalog'
 import { useScrollRestoration } from '@/lib/useScrollRestoration'
@@ -21,6 +22,7 @@ import {
 } from '@/lib/wikiPath'
 import { useDialogsStore } from '@/stores/dialogs'
 import { useHotKeysStore } from '@/stores/hotkeys'
+import { useSessionStore } from '@/stores/session'
 import { useTocPanelStore } from '@/stores/tocPanel'
 import { useTreeStore } from '@/stores/tree'
 import { useCallback, useEffect, useMemo } from 'react'
@@ -65,6 +67,7 @@ export default function PageViewer() {
   const isPinned = useTreeStore((s) =>
     page ? (s.byId[page.id]?.pinned ?? false) : false,
   )
+  const isLoggedIn = useSessionStore((s) => s.user !== null)
 
   const actions = {
     pageKind: page?.kind,
@@ -193,6 +196,13 @@ export default function PageViewer() {
                     </div>
                   )}
                 </div>
+                {isLoggedIn && (
+                  <FavoriteToggleButton
+                    pageId={page.id}
+                    size={16}
+                    className="page-viewer__favorite-toggle"
+                  />
+                )}
               </div>
               {showTocButton && (
                 <div className="page-viewer__toc-button">

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -2554,6 +2554,35 @@
     border: none;
   }
 
+  .tree-view__favorite-item {
+    @apply text-interface-text relative flex items-center text-sm;
+  }
+
+  .tree-view__favorite-item--active {
+    @apply text-brand;
+  }
+
+  .tree-view__favorite-item:not(.tree-view__favorite-item--active):hover {
+    @apply bg-tree-node-hover;
+  }
+
+  .tree-view__favorite-item-link {
+    @apply flex min-w-0 flex-1 items-center gap-1.5 truncate px-1 py-2 no-underline;
+    color: inherit;
+  }
+
+  .tree-view__favorite-item-icon {
+    @apply shrink-0 opacity-60;
+  }
+
+  .tree-view__favorite-item-title {
+    @apply truncate;
+  }
+
+  .tree-view__favorite-item-remove {
+    @apply ml-auto;
+  }
+
   .tree-node {
     @apply text-interface-text relative flex cursor-pointer items-center transition-all;
   }
@@ -2635,6 +2664,20 @@
 
   .tree-node__action-icon {
     @apply text-muted hover:text-interface-text cursor-pointer;
+  }
+
+  .favorite-toggle-button {
+    @apply text-muted hover:text-interface-text shrink-0 cursor-pointer rounded p-0.5 opacity-70 hover:opacity-100;
+    background: none;
+    border: none;
+  }
+
+  .favorite-toggle-button--active {
+    @apply text-brand opacity-100;
+  }
+
+  .page-viewer__favorite-toggle {
+    @apply ml-2 shrink-0;
   }
 
   .tree-node__children {

--- a/ui/leafwiki-ui/src/lib/api/favorites.ts
+++ b/ui/leafwiki-ui/src/lib/api/favorites.ts
@@ -1,0 +1,15 @@
+import { fetchWithAuth } from './auth'
+import type { Page } from './pages'
+
+export async function getFavorites(): Promise<Page[]> {
+  const res = (await fetchWithAuth('/api/favorites')) as { pages: Page[] }
+  return res.pages
+}
+
+export async function addFavorite(pageId: string): Promise<void> {
+  await fetchWithAuth(`/api/pages/${pageId}/favorite`, { method: 'PUT' })
+}
+
+export async function removeFavorite(pageId: string): Promise<void> {
+  await fetchWithAuth(`/api/pages/${pageId}/favorite`, { method: 'DELETE' })
+}

--- a/ui/leafwiki-ui/src/locales/en/viewer.json
+++ b/ui/leafwiki-ui/src/locales/en/viewer.json
@@ -39,6 +39,15 @@
     "togglePinnedSection": "Toggle pinned pages section",
     "togglePagesSection": "Toggle pages section"
   },
+  "favorites": {
+    "sectionTitle": "Favorites",
+    "addFavorite": "Add to favorites",
+    "removeFavorite": "Remove from favorites",
+    "addSuccess": "Added to favorites",
+    "removeSuccess": "Removed from favorites",
+    "favoriteError": "Failed to update favorites",
+    "toggleFavoritesSection": "Toggle favorites section"
+  },
   "toc": {
     "title": "Table of contents",
     "onThisPage": "On this page",

--- a/ui/leafwiki-ui/src/stores/favorites.test.ts
+++ b/ui/leafwiki-ui/src/stores/favorites.test.ts
@@ -1,0 +1,133 @@
+import type { Page } from '@/lib/api/pages'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/api/favorites', () => ({
+  getFavorites: vi.fn(),
+  addFavorite: vi.fn(),
+  removeFavorite: vi.fn(),
+}))
+
+import * as favoritesAPI from '@/lib/api/favorites'
+import { useFavoritesStore } from './favorites'
+
+function makePage(id: string): Page {
+  return {
+    id,
+    slug: id,
+    path: id,
+    title: id,
+    content: '',
+    version: 'v1',
+    kind: 'page',
+  }
+}
+
+describe('useFavoritesStore', () => {
+  beforeEach(() => {
+    useFavoritesStore.setState({ favoritePageIds: new Set(), loaded: false })
+    vi.mocked(favoritesAPI.getFavorites).mockReset()
+    vi.mocked(favoritesAPI.addFavorite).mockReset()
+    vi.mocked(favoritesAPI.removeFavorite).mockReset()
+  })
+
+  it('loadFavorites populates favoritePageIds from the API', async () => {
+    vi.mocked(favoritesAPI.getFavorites).mockResolvedValue([
+      makePage('page-1'),
+      makePage('page-2'),
+    ])
+
+    await useFavoritesStore.getState().loadFavorites()
+
+    expect(useFavoritesStore.getState().favoritePageIds).toEqual(
+      new Set(['page-1', 'page-2']),
+    )
+    expect(useFavoritesStore.getState().loaded).toBe(true)
+  })
+
+  it('loadFavorites swallows API errors and leaves state as-is', async () => {
+    vi.mocked(favoritesAPI.getFavorites).mockRejectedValue(
+      new Error('network error'),
+    )
+
+    await expect(
+      useFavoritesStore.getState().loadFavorites(),
+    ).resolves.toBeUndefined()
+    expect(useFavoritesStore.getState().favoritePageIds.size).toBe(0)
+  })
+
+  it('addFavorite optimistically adds the page id before the API resolves', async () => {
+    let resolveAdd: () => void = () => {}
+    vi.mocked(favoritesAPI.addFavorite).mockReturnValue(
+      new Promise((resolve) => {
+        resolveAdd = () => resolve(undefined)
+      }),
+    )
+
+    const promise = useFavoritesStore.getState().addFavorite('page-1')
+    expect(useFavoritesStore.getState().favoritePageIds.has('page-1')).toBe(
+      true,
+    )
+
+    resolveAdd()
+    await promise
+    expect(useFavoritesStore.getState().favoritePageIds.has('page-1')).toBe(
+      true,
+    )
+  })
+
+  it('addFavorite rolls back the optimistic update when the API call fails', async () => {
+    vi.mocked(favoritesAPI.addFavorite).mockRejectedValue(new Error('boom'))
+
+    await expect(
+      useFavoritesStore.getState().addFavorite('page-1'),
+    ).rejects.toThrow('boom')
+    expect(useFavoritesStore.getState().favoritePageIds.has('page-1')).toBe(
+      false,
+    )
+  })
+
+  it('removeFavorite optimistically removes the page id before the API resolves', async () => {
+    useFavoritesStore.setState({ favoritePageIds: new Set(['page-1']) })
+    let resolveRemove: () => void = () => {}
+    vi.mocked(favoritesAPI.removeFavorite).mockReturnValue(
+      new Promise((resolve) => {
+        resolveRemove = () => resolve(undefined)
+      }),
+    )
+
+    const promise = useFavoritesStore.getState().removeFavorite('page-1')
+    expect(useFavoritesStore.getState().favoritePageIds.has('page-1')).toBe(
+      false,
+    )
+
+    resolveRemove()
+    await promise
+    expect(useFavoritesStore.getState().favoritePageIds.has('page-1')).toBe(
+      false,
+    )
+  })
+
+  it('removeFavorite rolls back the optimistic update when the API call fails', async () => {
+    useFavoritesStore.setState({ favoritePageIds: new Set(['page-1']) })
+    vi.mocked(favoritesAPI.removeFavorite).mockRejectedValue(new Error('boom'))
+
+    await expect(
+      useFavoritesStore.getState().removeFavorite('page-1'),
+    ).rejects.toThrow('boom')
+    expect(useFavoritesStore.getState().favoritePageIds.has('page-1')).toBe(
+      true,
+    )
+  })
+
+  it('clearFavorites resets to empty and not-loaded', () => {
+    useFavoritesStore.setState({
+      favoritePageIds: new Set(['page-1']),
+      loaded: true,
+    })
+
+    useFavoritesStore.getState().clearFavorites()
+
+    expect(useFavoritesStore.getState().favoritePageIds.size).toBe(0)
+    expect(useFavoritesStore.getState().loaded).toBe(false)
+  })
+})

--- a/ui/leafwiki-ui/src/stores/favorites.ts
+++ b/ui/leafwiki-ui/src/stores/favorites.ts
@@ -1,0 +1,61 @@
+// stores/favorites.ts
+// A logged-in user's private set of favorited pages. Unlike Pinned Pages
+// (global, part of the tree), this is per-user server truth fetched once via
+// GET /api/favorites and never persisted to localStorage — it must be
+// re-fetched per session and cleared on logout so a second user on the same
+// browser never sees the first user's favorites. App.tsx owns calling
+// loadFavorites()/clearFavorites() as the session's logged-in state changes.
+
+import {
+  addFavorite as addFavoriteAPI,
+  getFavorites,
+  removeFavorite as removeFavoriteAPI,
+} from '@/lib/api/favorites'
+import { create } from 'zustand'
+
+type FavoritesStore = {
+  favoritePageIds: Set<string>
+  loaded: boolean
+  loadFavorites: () => Promise<void>
+  addFavorite: (pageId: string) => Promise<void>
+  removeFavorite: (pageId: string) => Promise<void>
+  clearFavorites: () => void
+}
+
+export const useFavoritesStore = create<FavoritesStore>()((set, get) => ({
+  favoritePageIds: new Set(),
+  loaded: false,
+  loadFavorites: async () => {
+    try {
+      const pages = await getFavorites()
+      set({ favoritePageIds: new Set(pages.map((p) => p.id)), loaded: true })
+    } catch (err) {
+      console.warn('Failed to load favorites:', err)
+    }
+  },
+  addFavorite: async (pageId: string) => {
+    const previous = get().favoritePageIds
+    const optimistic = new Set(previous)
+    optimistic.add(pageId)
+    set({ favoritePageIds: optimistic })
+    try {
+      await addFavoriteAPI(pageId)
+    } catch (err) {
+      set({ favoritePageIds: previous })
+      throw err
+    }
+  },
+  removeFavorite: async (pageId: string) => {
+    const previous = get().favoritePageIds
+    const optimistic = new Set(previous)
+    optimistic.delete(pageId)
+    set({ favoritePageIds: optimistic })
+    try {
+      await removeFavoriteAPI(pageId)
+    } catch (err) {
+      set({ favoritePageIds: previous })
+      throw err
+    }
+  },
+  clearFavorites: () => set({ favoritePageIds: new Set(), loaded: false }),
+}))

--- a/ui/leafwiki-ui/src/stores/sidebarPanels.ts
+++ b/ui/leafwiki-ui/src/stores/sidebarPanels.ts
@@ -13,7 +13,7 @@ type SidebarPanelsStore = {
 export const useSidebarPanelsStore = create<SidebarPanelsStore>()(
   persist(
     (set) => ({
-      openSections: ['pinned', 'pages'],
+      openSections: ['pinned', 'favorites', 'pages'],
       setOpenSections: (ids) => set({ openSections: ids }),
     }),
     {


### PR DESCRIPTION
Adds a private, per-user favorites list, separate from the global editorial "Pinned Pages" flag: any authenticated user (not just editor/admin) can favorite/unfavorite any page they can read.

Backend: new internal/favorites package (own favorites.db, outside resync's reach per ADR-0001), AddFavorite/RemoveFavorite/ListFavorites use cases, PUT/DELETE /api/pages/:id/favorite and GET /api/favorites routes, cascade cleanup on page delete and user delete.

Frontend: stores/favorites.ts (optimistic add/remove), star toggle on tree rows and the page viewer header, new "Favorites" sidebar accordion section between Pinned and Pages, loaded/cleared reactively off the session user id in App.tsx.