### PR TITLE
refactor(sqliteutil): share open/corruption-recovery logic across stores

### DIFF
--- a/internal/core/shared/sqliteutil/sqlite.go
+++ b/internal/core/shared/sqliteutil/sqlite.go
@@ -42,3 +42,29 @@ func RemoveSQLiteFiles(dbPath string) {
 		}
 	}
 }
+
+// RetryOnCorruption calls open, which is expected to fully bring a store to
+// a working state (open the connection and ensure its schema exists),
+// cleaning up after itself on failure. If open's error is a recoverable
+// SQLite I/O/corruption error, the database files at dbPath are removed and
+// open is called exactly once more; any other error, or a second failure,
+// is returned as-is.
+//
+// This factors out the "open → ensure schema → on recoverable corruption,
+// wipe and retry once" sequence that is otherwise duplicated, near-verbatim,
+// across every per-domain SQLite store constructor (tags, links, properties,
+// search, favorites). Each store keeps its own opening mechanics (eager
+// sql.Open, a lazy Connect(), or a fully lazy withDB helper) inside the
+// closure; only the recovery policy is shared.
+func RetryOnCorruption(dbPath string, open func() error) error {
+	err := open()
+	if err == nil {
+		return nil
+	}
+	if !IsSQLiteRecoverableError(err) {
+		return err
+	}
+	slog.Default().Warn("database corrupt, removing and retrying", "path", dbPath, "error", err)
+	RemoveSQLiteFiles(dbPath)
+	return open()
+}

--- a/internal/core/shared/sqliteutil/sqlite_test.go
+++ b/internal/core/shared/sqliteutil/sqlite_test.go
@@ -96,6 +96,84 @@ func TestRemoveSQLiteFiles_NoOpWhenMissing(t *testing.T) {
 	}
 }
 
+func TestRetryOnCorruption_SucceedsOnFirstTry(t *testing.T) {
+	calls := 0
+	err := RetryOnCorruption("unused.db", func() error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("RetryOnCorruption: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected open to be called once, got %d", calls)
+	}
+}
+
+func TestRetryOnCorruption_NonRecoverableError_ReturnsImmediately(t *testing.T) {
+	calls := 0
+	wantErr := errors.New("boom")
+	err := RetryOnCorruption("unused.db", func() error {
+		calls++
+		return wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected wantErr, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected open to be called once (no retry), got %d", calls)
+	}
+}
+
+func TestRetryOnCorruption_RecoverableError_RetriesOnceAndRemovesFiles(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "corrupt.db")
+	paths := []string{dbPath, dbPath + "-journal", dbPath + "-wal", dbPath + "-shm"}
+	for _, path := range paths {
+		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+			t.Fatalf("failed to create %q: %v", path, err)
+		}
+	}
+
+	calls := 0
+	err := RetryOnCorruption(dbPath, func() error {
+		calls++
+		if calls == 1 {
+			return sqliteErrorWithCode(11) // SQLITE_CORRUPT
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("RetryOnCorruption: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected open to be called twice (initial + retry), got %d", calls)
+	}
+	for _, path := range paths {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("expected %q to have been removed before retry, err=%v", path, err)
+		}
+	}
+}
+
+func TestRetryOnCorruption_RecoverableError_SecondFailureReturnsThatError(t *testing.T) {
+	calls := 0
+	secondErr := errors.New("still broken")
+	err := RetryOnCorruption(t.TempDir()+"/corrupt.db", func() error {
+		calls++
+		if calls == 1 {
+			return sqliteErrorWithCode(11) // SQLITE_CORRUPT
+		}
+		return secondErr
+	})
+	if !errors.Is(err, secondErr) {
+		t.Fatalf("expected secondErr, got %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected open to be called twice, got %d", calls)
+	}
+}
+
 func sqliteErrorWithCode(code int) error {
 	e := &sqlite.Error{}
 	// modernc.org/sqlite does not expose a public constructor for sqlite.Error,

--- a/internal/favorites/favorites_store.go
+++ b/internal/favorites/favorites_store.go
@@ -6,7 +6,6 @@ package favorites
 import (
 	"database/sql"
 	"fmt"
-	"log/slog"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -28,28 +27,22 @@ func NewFavoritesStore(storageDir string) (*FavoritesStore, error) {
 	normalized := filepath.FromSlash(strings.ReplaceAll(storageDir, `\`, `/`))
 	dbPath := filepath.Join(normalized, "favorites.db")
 
-	db, err := sql.Open("sqlite", dbPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open favorites database: %w", err)
-	}
-
-	s := &FavoritesStore{db: db}
-	if err := s.ensureSchema(); err != nil {
-		_ = db.Close()
-		if !sqliteutil.IsSQLiteRecoverableError(err) {
-			return nil, err
-		}
-		slog.Default().Warn("favorites database corrupt, removing and retrying", "error", err)
-		sqliteutil.RemoveSQLiteFiles(dbPath)
-		db, err = sql.Open("sqlite", dbPath)
+	s := &FavoritesStore{}
+	err := sqliteutil.RetryOnCorruption(dbPath, func() error {
+		db, err := sql.Open("sqlite", dbPath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to reopen favorites database after recovery: %w", err)
+			return fmt.Errorf("failed to open favorites database: %w", err)
 		}
-		s = &FavoritesStore{db: db}
-		if err = s.ensureSchema(); err != nil {
+		s.db = db
+		if err := s.ensureSchema(); err != nil {
 			_ = db.Close()
-			return nil, err
+			s.db = nil
+			return err
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return s, nil
 }

--- a/internal/links/links_store.go
+++ b/internal/links/links_store.go
@@ -44,28 +44,21 @@ func NewLinksStore(storageDir string) (*LinksStore, error) {
 		filename:   "links.db",
 	}
 
-	if err := s.Connect(); err != nil {
+	// ensureSchema calls Connect() itself (idempotently), so it alone is
+	// enough to bring the store to a working state.
+	err := sqliteutil.RetryOnCorruption(linksDatabasePath(s.storageDir, s.filename), func() error {
+		if err := s.ensureSchema(); err != nil {
+			if s.db != nil {
+				_ = s.db.Close()
+				s.db = nil
+			}
+			return err
+		}
+		return nil
+	})
+	if err != nil {
 		return nil, err
 	}
-
-	if err := s.ensureSchema(); err != nil {
-		_ = s.db.Close()
-		s.db = nil
-		if !sqliteutil.IsSQLiteRecoverableError(err) {
-			return nil, err
-		}
-		slog.Default().Warn("links database corrupt, removing and retrying", "error", err)
-		sqliteutil.RemoveSQLiteFiles(linksDatabasePath(s.storageDir, s.filename))
-		if err2 := s.Connect(); err2 != nil {
-			return nil, err2
-		}
-		if err2 := s.ensureSchema(); err2 != nil {
-			_ = s.db.Close()
-			s.db = nil
-			return nil, err2
-		}
-	}
-
 	return s, nil
 }
 

--- a/internal/properties/properties_store.go
+++ b/internal/properties/properties_store.go
@@ -3,7 +3,6 @@ package properties
 import (
 	"database/sql"
 	"fmt"
-	"log/slog"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -36,28 +35,22 @@ func NewPropertiesStore(storageDir string) (*PropertiesStore, error) {
 	normalized := filepath.FromSlash(strings.ReplaceAll(storageDir, `\`, `/`))
 	dbPath := filepath.Join(normalized, "properties.db")
 
-	db, err := sql.Open("sqlite", dbPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open properties database: %w", err)
-	}
-
-	s := &PropertiesStore{db: db}
-	if err := s.ensureSchema(); err != nil {
-		_ = db.Close()
-		if !sqliteutil.IsSQLiteRecoverableError(err) {
-			return nil, err
-		}
-		slog.Default().Warn("properties database corrupt, removing and retrying", "error", err)
-		sqliteutil.RemoveSQLiteFiles(dbPath)
-		db, err = sql.Open("sqlite", dbPath)
+	s := &PropertiesStore{}
+	err := sqliteutil.RetryOnCorruption(dbPath, func() error {
+		db, err := sql.Open("sqlite", dbPath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to reopen properties database after recovery: %w", err)
+			return fmt.Errorf("failed to open properties database: %w", err)
 		}
-		s = &PropertiesStore{db: db}
-		if err = s.ensureSchema(); err != nil {
+		s.db = db
+		if err := s.ensureSchema(); err != nil {
 			_ = db.Close()
-			return nil, err
+			s.db = nil
+			return err
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return s, nil
 }

--- a/internal/search/sqlite_index.go
+++ b/internal/search/sqlite_index.go
@@ -109,22 +109,17 @@ func NewSQLiteIndex(storageDir string) (*SQLiteIndex, error) {
 		filename:   "search.db",
 	}
 
-	if err := s.ensureSchema(); err != nil {
-		// Only attempt recovery for genuine SQLite I/O or corruption errors
-		// (SQLITE_IOERR=10, SQLITE_CORRUPT=11, SQLITE_NOTADB=26).
-		// Transient errors like SQLITE_BUSY are returned immediately.
-		if !sqliteutil.IsSQLiteRecoverableError(err) {
-			return nil, err
+	err := sqliteutil.RetryOnCorruption(searchIndexDatabasePath(s.storageDir, s.filename), func() error {
+		if err := s.ensureSchema(); err != nil {
+			if closeErr := s.Close(); closeErr != nil {
+				slog.Default().Warn("failed to close corrupt search database before recovery", "error", closeErr)
+			}
+			return err
 		}
-		slog.Default().Warn("search index initialization failed, removing corrupt database and retrying", "error", err)
-		if closeErr := s.Close(); closeErr != nil {
-			slog.Default().Warn("failed to close corrupt search database before recovery", "error", closeErr)
-		}
-		sqliteutil.RemoveSQLiteFiles(searchIndexDatabasePath(s.storageDir, s.filename))
-		if err2 := s.ensureSchema(); err2 != nil {
-			_ = s.Close()
-			return nil, err2
-		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return s, nil

--- a/internal/tags/tags_store.go
+++ b/internal/tags/tags_store.go
@@ -3,7 +3,6 @@ package tags
 import (
 	"database/sql"
 	"fmt"
-	"log/slog"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -32,28 +31,22 @@ func NewTagsStore(storageDir string) (*TagsStore, error) {
 	normalized := filepath.FromSlash(strings.ReplaceAll(storageDir, `\`, `/`))
 	dbPath := filepath.Join(normalized, "tags.db")
 
-	db, err := sql.Open("sqlite", dbPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open tags database: %w", err)
-	}
-
-	s := &TagsStore{db: db}
-	if err := s.ensureSchema(); err != nil {
-		_ = db.Close()
-		if !sqliteutil.IsSQLiteRecoverableError(err) {
-			return nil, err
-		}
-		slog.Default().Warn("tags database corrupt, removing and retrying", "error", err)
-		sqliteutil.RemoveSQLiteFiles(dbPath)
-		db, err = sql.Open("sqlite", dbPath)
+	s := &TagsStore{}
+	err := sqliteutil.RetryOnCorruption(dbPath, func() error {
+		db, err := sql.Open("sqlite", dbPath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to reopen tags database after recovery: %w", err)
+			return fmt.Errorf("failed to open tags database: %w", err)
 		}
-		s = &TagsStore{db: db}
-		if err = s.ensureSchema(); err != nil {
+		s.db = db
+		if err := s.ensureSchema(); err != nil {
 			_ = db.Close()
-			return nil, err
+			s.db = nil
+			return err
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return s, nil
 }


### PR DESCRIPTION
Extract the "open → ensure schema → on recoverable SQLite corruption, wipe and retry once" sequence, previously copy-pasted near-verbatim in tags, links, properties, and search's store constructors, into a single sqliteutil.RetryOnCorruption helper. Each store keeps its own opening mechanics (eager sql.Open, links' lazy Connect(), search's fully lazy withDB); only the recovery policy is now shared.
