### PR TITLE
feat(preview): add AutoHotkey syntax highlighting

### DIFF
--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.test.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.test.tsx
@@ -53,6 +53,24 @@ if (Test-Path $path) {
     expect(powershellCodeBlock?.querySelector('.hljs-variable')).not.toBeNull()
   })
 
+  it('highlights AutoHotkey code fences', () => {
+    const content = `\`\`\`autohotkey
+#Requires AutoHotkey v2.0
+if WinExist("Untitled - Notepad") {
+  WinActivate
+}
+\`\`\``
+
+    const { container } = render(<MarkdownPreview content={content} />)
+
+    const autohotkeyCodeBlock = container.querySelector(
+      'code.language-autohotkey.hljs',
+    )
+    expect(autohotkeyCodeBlock).not.toBeNull()
+    expect(autohotkeyCodeBlock?.querySelector('.hljs-meta')).not.toBeNull()
+    expect(autohotkeyCodeBlock?.querySelector('.hljs-string')).not.toBeNull()
+  })
+
   it('renders external images from markdown image syntax', () => {
     const { container } = render(
       <MarkdownPreview content="![Remote diagram](https://example.com/diagram.png)" />,

--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
@@ -2,16 +2,7 @@ import { useDesignModeStore } from '@/features/designtoggle/designmode'
 import { preprocessWikilinks } from '@/lib/preprocessWikilinks'
 import { withBasePath } from '@/lib/routePath'
 import { useTreeStore } from '@/stores/tree'
-import bash from 'highlight.js/lib/languages/bash'
-import dockerfile from 'highlight.js/lib/languages/dockerfile'
-import http from 'highlight.js/lib/languages/http'
-import nginx from 'highlight.js/lib/languages/nginx'
-import nix from 'highlight.js/lib/languages/nix'
-import powershell from 'highlight.js/lib/languages/powershell'
-import protobuf from 'highlight.js/lib/languages/protobuf'
-import shell from 'highlight.js/lib/languages/shell'
 import 'katex/dist/katex.min.css'
-import { common } from 'lowlight'
 import {
   AnchorHTMLAttributes,
   AudioHTMLAttributes,
@@ -51,6 +42,7 @@ import { normalizeMarkdownListIndentation } from './normalizeMarkdownListIndenta
 import { normalizeMarkdownShoutouts } from './normalizeMarkdownShoutouts'
 import { rehypeLineNumber } from './rehypeLineNumber'
 import { rehypeWhitelistStyles } from './rehypeWhitelistStyles'
+import { syntaxHighlightLanguages } from './syntaxHighlightLanguages'
 import { TocDropdownButton } from './TocDropdownButton'
 
 const schema = {
@@ -640,20 +632,7 @@ export default function MarkdownPreview({
               [
                 rehypeHighlight,
                 {
-                  languages: {
-                    ...common,
-                    bash,
-                    sh: bash,
-                    shell,
-                    console: shell,
-                    shellsession: shell,
-                    dockerfile,
-                    http,
-                    nginx,
-                    nix,
-                    powershell,
-                    protobuf,
-                  },
+                  languages: syntaxHighlightLanguages,
                 },
               ],
             ]}

--- a/ui/leafwiki-ui/src/features/preview/syntaxHighlightLanguages.ts
+++ b/ui/leafwiki-ui/src/features/preview/syntaxHighlightLanguages.ts
@@ -1,0 +1,26 @@
+import autohotkey from 'highlight.js/lib/languages/autohotkey'
+import bash from 'highlight.js/lib/languages/bash'
+import dockerfile from 'highlight.js/lib/languages/dockerfile'
+import http from 'highlight.js/lib/languages/http'
+import nginx from 'highlight.js/lib/languages/nginx'
+import nix from 'highlight.js/lib/languages/nix'
+import powershell from 'highlight.js/lib/languages/powershell'
+import protobuf from 'highlight.js/lib/languages/protobuf'
+import shell from 'highlight.js/lib/languages/shell'
+import { common } from 'lowlight'
+
+export const syntaxHighlightLanguages = {
+  ...common,
+  autohotkey,
+  bash,
+  sh: bash,
+  shell,
+  console: shell,
+  shellsession: shell,
+  dockerfile,
+  http,
+  nginx,
+  nix,
+  powershell,
+  protobuf,
+}


### PR DESCRIPTION
## Related issue

Fixes #1309

## What changed

- Register Highlight.js AutoHotkey support for markdown preview code fences.
- Move the explicit preview syntax language registry into a small module.
- Add regression coverage for an `autohotkey` fenced code block.


## Checklist
- [x] I discussed the approach on the linked issue before starting (or this is a trivial fix: typo, docs, obvious one-liner)
- [x] This PR is focused on a single change
- [x] I ran `npm run format` in `ui/leafwiki-ui` (and in `e2e` if e2e tests changed)
- [x] I updated documentation if needed

## Testing
- `npm test -- MarkdownPreview.test.tsx
- `npm run format`
- `npm run lint -- --max-warnings=0`
- `npm run format:check`
- `npm test`
- `npm run build`

Backend Go tests were not run locally because this WSL environment does not have a `go` binary installed.