### PR TITLE
feat(preview): add opt-in line numbers for code blocks

### DIFF
--- a/ui/leafwiki-ui/src/features/preview/MarkdownCodeBlock.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownCodeBlock.tsx
@@ -11,6 +11,7 @@ import {
   useState,
 } from 'react'
 import { toast } from 'sonner'
+import { LINE_NUMBERS_CLASS } from './rehypeCodeLineNumbers'
 
 type CodeElementProps = {
   className?: string
@@ -60,6 +61,10 @@ export default function MarkdownCodeBlock(
 
   const className = child.props.className ?? ''
   const code = readTextContent(child.props.children)
+  const showLineNumbers = className.split(/\s+/).includes(LINE_NUMBERS_CLASS)
+  const lineCount = showLineNumbers
+    ? Math.max(1, code.replace(/\n$/, '').split('\n').length)
+    : 0
 
   const isCodeBlock = className.includes('language-') || code.includes('\n')
   if (!isCodeBlock) {
@@ -77,29 +82,59 @@ export default function MarkdownCodeBlock(
     toast.success('Code copied')
   }
 
+  const actions = (
+    <div className="markdown-code-block__actions">
+      <TooltipWrapper label={copied ? 'Copied' : 'Copy code'}>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="markdown-code-block__copy-button"
+          onClick={handleCopy}
+          aria-label={copied ? 'Code copied' : 'Copy code'}
+          data-testid="markdown-code-copy-button"
+        >
+          {copied ? <Check /> : <Copy />}
+        </Button>
+      </TooltipWrapper>
+    </div>
+  )
+
+  const pre = (
+    <pre
+      {...preProps}
+      className={`custom-scrollbar ${preProps.className ?? ''}`.trim()}
+    >
+      {children}
+    </pre>
+  )
+
+  if (showLineNumbers) {
+    return (
+      <div className="markdown-code-block markdown-code-block--line-numbers">
+        {actions}
+        <div className="markdown-code-block__body">
+          <span
+            className="markdown-code-block__line-numbers"
+            aria-hidden="true"
+            data-testid="markdown-code-line-numbers"
+          >
+            {Array.from({ length: lineCount }, (_, index) => (
+              <span key={index} className="markdown-code-block__line-number">
+                {index + 1}
+              </span>
+            ))}
+          </span>
+          {pre}
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="markdown-code-block">
-      <div className="markdown-code-block__actions">
-        <TooltipWrapper label={copied ? 'Copied' : 'Copy code'}>
-          <Button
-            type="button"
-            variant="outline"
-            size="icon"
-            className="markdown-code-block__copy-button"
-            onClick={handleCopy}
-            aria-label={copied ? 'Code copied' : 'Copy code'}
-            data-testid="markdown-code-copy-button"
-          >
-            {copied ? <Check /> : <Copy />}
-          </Button>
-        </TooltipWrapper>
-      </div>
-      <pre
-        {...preProps}
-        className={`custom-scrollbar ${preProps.className ?? ''}`.trim()}
-      >
-        {children}
-      </pre>
+      {actions}
+      {pre}
     </div>
   )
 }

--- a/ui/leafwiki-ui/src/features/preview/MarkdownCodeLineNumbers.test.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownCodeLineNumbers.test.tsx
@@ -1,0 +1,78 @@
+import { render } from '@testing-library/react'
+import { useDesignModeStore } from '@/features/designtoggle/designmode'
+import MarkdownPreview from './MarkdownPreview'
+
+describe('MarkdownPreview code block line numbers (#1313)', () => {
+  beforeEach(() => {
+    localStorage.setItem('design-mode', 'light')
+    useDesignModeStore.setState({ mode: 'light' })
+    window.matchMedia = vi.fn().mockImplementation(() => ({
+      matches: true,
+      media: '(prefers-color-scheme: light)',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  })
+
+  it('renders a numbered gutter when the fence language ends with "="', () => {
+    const content = '```js=\nconst a = 1\nconst b = 2\nconst c = 3\n```'
+    const { container } = render(<MarkdownPreview content={content} />)
+
+    const gutter = container.querySelector(
+      '[data-testid="markdown-code-line-numbers"]',
+    )
+    expect(gutter).not.toBeNull()
+
+    const numbers = gutter?.querySelectorAll(
+      '.markdown-code-block__line-number',
+    )
+    expect(numbers?.length).toBe(3)
+    expect(Array.from(numbers ?? []).map((n) => n.textContent)).toEqual([
+      '1',
+      '2',
+      '3',
+    ])
+
+    expect(
+      container.querySelector('.markdown-code-block--line-numbers'),
+    ).not.toBeNull()
+
+    // The trailing "=" is stripped so the real language is still highlighted.
+    const code = container.querySelector('code.md-line-numbers')
+    expect(code).not.toBeNull()
+    expect(code?.getAttribute('class')).toContain('language-js')
+    expect(code?.getAttribute('class')).not.toContain('language-js=')
+    expect(code?.classList.contains('hljs')).toBe(true)
+    expect(code?.querySelector('.hljs-keyword')).not.toBeNull()
+  })
+
+  it('counts every line, including the last non-empty line', () => {
+    const content = '```python=\nx = 1\ny = 2\n```'
+    const { container } = render(<MarkdownPreview content={content} />)
+
+    const numbers = container.querySelectorAll(
+      '.markdown-code-block__line-number',
+    )
+    expect(numbers.length).toBe(2)
+  })
+
+  it('does not render line numbers for a plain fenced block', () => {
+    const content = '```js\nconst a = 1\nconst b = 2\n```'
+    const { container } = render(<MarkdownPreview content={content} />)
+
+    expect(
+      container.querySelector('[data-testid="markdown-code-line-numbers"]'),
+    ).toBeNull()
+    expect(
+      container.querySelector('.markdown-code-block--line-numbers'),
+    ).toBeNull()
+
+    const code = container.querySelector('code.language-js.hljs')
+    expect(code).not.toBeNull()
+    expect(code?.classList.contains('md-line-numbers')).toBe(false)
+  })
+})

--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
@@ -40,6 +40,7 @@ import './markdownPreviewCodeTheme.css'
 import MermaidBlock from './MermaidBlock'
 import { normalizeMarkdownListIndentation } from './normalizeMarkdownListIndentation'
 import { normalizeMarkdownShoutouts } from './normalizeMarkdownShoutouts'
+import { rehypeCodeLineNumbers } from './rehypeCodeLineNumbers'
 import { rehypeLineNumber } from './rehypeLineNumber'
 import { rehypeWhitelistStyles } from './rehypeWhitelistStyles'
 import { syntaxHighlightLanguages } from './syntaxHighlightLanguages'
@@ -629,6 +630,7 @@ export default function MarkdownPreview({
               rehypeWhitelistStyles,
               [rehypeKatex, { output: 'html', strict: 'ignore' }],
               [rehypeSanitize, schema],
+              rehypeCodeLineNumbers,
               [
                 rehypeHighlight,
                 {

--- a/ui/leafwiki-ui/src/features/preview/markdownPreviewCodeTheme.css
+++ b/ui/leafwiki-ui/src/features/preview/markdownPreviewCodeTheme.css
@@ -141,6 +141,55 @@
   color: var(--hljs-foreground);
 }
 
+/* Line numbers: opt-in via a trailing "=" on the code fence language (#1313).
+   The gutter shares the code block's top padding and line-height so numbers
+   line up with their source lines (fenced code does not soft-wrap). */
+.page-viewer__content .markdown-code-block__body,
+.markdown-editor__preview .markdown-code-block__body,
+.page-history__preview-body .markdown-code-block__body {
+  display: flex;
+  align-items: stretch;
+  min-width: 0;
+}
+
+.page-viewer__content
+  .markdown-code-block--line-numbers
+  .markdown-code-block__line-numbers,
+.markdown-editor__preview
+  .markdown-code-block--line-numbers
+  .markdown-code-block__line-numbers,
+.page-history__preview-body
+  .markdown-code-block--line-numbers
+  .markdown-code-block__line-numbers {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  padding: 1em 0.75em;
+  text-align: right;
+  user-select: none;
+  font-family:
+    ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono',
+    monospace;
+  line-height: 1.7;
+  color: var(--hljs-comment);
+  background: var(--hljs-background);
+  border-right: 1px solid
+    color-mix(in oklab, var(--hljs-foreground) 12%, transparent);
+}
+
+.page-viewer__content .markdown-code-block--line-numbers pre,
+.markdown-editor__preview .markdown-code-block--line-numbers pre,
+.page-history__preview-body .markdown-code-block--line-numbers pre {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.page-viewer__content .markdown-code-block--line-numbers pre code.hljs,
+.markdown-editor__preview .markdown-code-block--line-numbers pre code.hljs,
+.page-history__preview-body .markdown-code-block--line-numbers pre code.hljs {
+  line-height: 1.7;
+}
+
 .page-viewer__content pre code.hljs,
 .markdown-editor__preview pre code.hljs,
 .page-history__preview-body pre code.hljs {

--- a/ui/leafwiki-ui/src/features/preview/rehypeCodeLineNumbers.ts
+++ b/ui/leafwiki-ui/src/features/preview/rehypeCodeLineNumbers.ts
@@ -1,0 +1,54 @@
+import { Element, Root } from 'hast'
+import { Plugin } from 'unified'
+import { visit } from 'unist-util-visit'
+
+export const LINE_NUMBERS_CLASS = 'md-line-numbers'
+
+/**
+ * Enables line numbers on fenced code blocks whose language identifier ends
+ * with an equal sign, e.g.
+ *
+ * ```js=
+ * const answer = 42
+ * ```
+ *
+ * This follows the Otter Wiki convention adopted for leafwiki in #1264/#1313:
+ * append `=` to turn line numbers on, leave it off to keep them off.
+ *
+ * react-markdown lowers ```js= to `<code class="language-js=">`, which
+ * rehype-highlight cannot tokenize (there is no "js=" grammar). This plugin
+ * must therefore run BEFORE rehype-highlight: it strips the trailing `=` so the
+ * real language is highlighted as usual, and tags the `<code>` element with the
+ * {@link LINE_NUMBERS_CLASS} marker so the renderer knows to draw a gutter.
+ */
+export const rehypeCodeLineNumbers: Plugin<[], Root> = () => {
+  return (tree) => {
+    visit(tree, 'element', (node: Element) => {
+      if (node.tagName !== 'code') return
+
+      const properties = node.properties ?? (node.properties = {})
+      const className = properties.className
+      const classes = Array.isArray(className)
+        ? [...className]
+        : typeof className === 'string'
+          ? className.split(/\s+/).filter(Boolean)
+          : []
+
+      let enabled = false
+      const rewritten = classes.map((cls) => {
+        if (typeof cls === 'string' && /^language-.*=$/.test(cls)) {
+          enabled = true
+          return cls.slice(0, -1)
+        }
+        return cls
+      })
+
+      if (!enabled) return
+
+      if (!rewritten.includes(LINE_NUMBERS_CLASS)) {
+        rewritten.push(LINE_NUMBERS_CLASS)
+      }
+      properties.className = rewritten
+    })
+  }
+}


### PR DESCRIPTION
## What

Adds opt-in line numbers for fenced code blocks. Append `=` to the language identifier to turn them on; leave it off to keep the current behavior — the convention agreed in discussion #1264 and issue #1313.

<pre>
```js=
const answer = 42
```
</pre>

renders the code with a line-number gutter, while ` ```js ` stays exactly as it is today.

## Why

Requested in #1313 (from discussion #1264). A lightweight, per-block way to show line numbers without a global setting, matching the Otter Wiki behavior the maintainer picked ("I would go with the equal sign").

## How

- **`rehypeCodeLineNumbers`** — a small rehype plugin that runs *before* `rehype-highlight`. react-markdown lowers ` ```js= ` to `<code class="language-js=">`, which `rehype-highlight` can't tokenize (there's no `js=` grammar). The plugin strips the trailing `=` so the real language is highlighted as usual, and tags the `<code>` with a `md-line-numbers` marker class.
- **`MarkdownCodeBlock`** — when it sees the marker, it renders a numbered gutter next to the `<pre>`. The gutter shares the code block's top padding and `line-height`, and fenced code doesn't soft-wrap, so numbers line up 1:1 with their source lines. Non-line-number blocks keep their existing markup untouched.
- Scoped CSS in `markdownPreviewCodeTheme.css` for the three preview surfaces (viewer, editor preview, history preview), using the existing `--hljs-*` theme variables.

## Tests

`MarkdownCodeLineNumbers.test.tsx` renders through the full `MarkdownPreview` pipeline and asserts:

- ` ```js= ` produces a gutter with the correct per-line numbers,
- the `=` is stripped so syntax highlighting still applies (`code.md-line-numbers.hljs` with a `.hljs-keyword`),
- line counting is correct,
- a plain ` ```js ` fence renders **no** line numbers (control case).

Verified locally:

```
eslint .            # clean
prettier --check    # clean (touched files)
tsc -b              # clean
vitest run          # 31 files, 242 tests passed
vite build          # production build OK
```

Closes #1313
