### PR TITLE
refactor(auth): extract SessionManager from AuthService

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ Available since v0.10.0. Use when an upstream proxy authenticates users and forw
 - If the forwarded username doesn't exist in LeafWiki, the request is rejected
 - Do not enable without configuring `--trusted-proxy-ips`
 - `--login-url` and `--logout-url` are independent, optional redirect targets — set either or both to send users to an external IdP instead of the built-in login form / to redirect after logout
-- `--login-url` and `--logout-url` must start with `http://` or `https://`; the server refuses to start otherwise. `--user-management-url` has no such restriction — it's only used as a link, so relative paths work too
+- `--login-url`, `--logout-url`, and `--user-management-url` must all start with `http://` or `https://`; the server refuses to start otherwise (relative paths are not accepted for any of them)
 - ⚠️ `--login-url` takes effect regardless of `--enable-http-remote-user` and has no in-app bypass: once set, *every* unauthenticated visit (including `/login` itself) redirects to it immediately. Double-check the URL before setting it — a wrong or unreachable value locks all users, including admins, out of the built-in login form
 - `--http-remote-user-logout-url` (v0.10.0) is deprecated; use `--logout-url` instead. It still works as a fallback when `--logout-url`/`LEAFWIKI_LOGOUT_URL` isn't set, but a deprecation warning is logged
 

--- a/cmd/leafwiki/main.go
+++ b/cmd/leafwiki/main.go
@@ -213,6 +213,18 @@ func fail(msg string, args ...any) {
 	os.Exit(1)
 }
 
+var errRestoreSnapshotUsage = errors.New("restore-snapshot requires a path to a snapshot zip: leafwiki [--data-dir <DIR>] restore-snapshot <path-to-zip>")
+
+// runRestoreSnapshotCommand implements the `restore-snapshot` subcommand: args
+// is flag.Args() (args[0] == "restore-snapshot"), so a snapshot path is
+// present at args[1].
+func runRestoreSnapshotCommand(dataDir string, args []string) error {
+	if len(args) < 2 {
+		return errRestoreSnapshotUsage
+	}
+	return restore.RestoreOffline(dataDir, args[1])
+}
+
 var gracefulShutdownTimeout = 10 * time.Second
 
 type cliFlags struct {
@@ -418,9 +430,9 @@ func main() {
 	if err := validateRedirectURL("logout-url", logoutURL); err != nil {
 		fail("Invalid logout URL configuration", "error", err)
 	}
-	// --user-management-url is only ever used as a plain <a href> in the frontend
-	// (relative paths and other schemes work fine there), so it isn't restricted
-	// to http(s) like --login-url/--logout-url, which the browser navigates to directly.
+	if err := validateRedirectURL("user-management-url", userManagementURL); err != nil {
+		fail("Invalid user management URL configuration", "error", err)
+	}
 
 	if enableHTTPRemoteUser {
 		slog.Default().Info("Reverse-proxy authentication enabled",
@@ -454,11 +466,12 @@ func main() {
 			fmt.Printf("New password for user %s: %s\n", user.Username, user.Password)
 			return
 		case "restore-snapshot":
-			if len(args) < 2 {
-				fail("restore-snapshot requires a path to a snapshot zip: leafwiki [--data-dir <DIR>] restore-snapshot <path-to-zip>")
-			}
-			if err := restore.RestoreOffline(dataDir, args[1]); err != nil {
-				fail("Restore failed", "error", err)
+			if err := runRestoreSnapshotCommand(dataDir, args); err != nil {
+				if errors.Is(err, errRestoreSnapshotUsage) {
+					fail(err.Error())
+				} else {
+					fail("Restore failed", "error", err)
+				}
 			}
 			fmt.Println("Snapshot restored successfully. Start the server normally to pick up the restored data.")
 			return

--- a/cmd/leafwiki/main_test.go
+++ b/cmd/leafwiki/main_test.go
@@ -154,6 +154,34 @@ func TestValidateRedirectURL(t *testing.T) {
 	}
 }
 
+// TestValidateRedirectURL_UserManagementURL confirms --user-management-url is
+// validated the same way as --login-url/--logout-url (http(s) only, no relative
+// paths or dangerous schemes) — it's rendered as a plain <a href>, but an
+// unsafe scheme there is still attacker-controlled markup.
+func TestValidateRedirectURL_UserManagementURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{"empty", "", false},
+		{"https", "https://idp.example.com/users", false},
+		{"javascript scheme", "javascript:alert(1)", true},
+		{"relative path", "/users", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateRedirectURL("user-management-url", tc.url)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validateRedirectURL(%q) error = %v, wantErr %v", tc.url, err, tc.wantErr)
+			}
+			if err != nil && !strings.Contains(err.Error(), "user-management-url") {
+				t.Fatalf("validateRedirectURL(%q) error = %v, want it to mention the flag name", tc.url, err)
+			}
+		})
+	}
+}
+
 func TestResolveLogoutURL(t *testing.T) {
 	tests := []struct {
 		name               string
@@ -273,6 +301,26 @@ func TestSetupLogger_SelectsHandlerByFormat(t *testing.T) {
 			t.Fatalf("expected valid JSON output, got %q", buf.String())
 		}
 	})
+}
+
+func TestRunRestoreSnapshotCommand_MissingArg_ReturnsUsageError(t *testing.T) {
+	err := runRestoreSnapshotCommand(t.TempDir(), []string{"restore-snapshot"})
+	if !errors.Is(err, errRestoreSnapshotUsage) {
+		t.Fatalf("runRestoreSnapshotCommand() error = %v, want errRestoreSnapshotUsage", err)
+	}
+}
+
+func TestRunRestoreSnapshotCommand_InvalidZipPath_PropagatesError(t *testing.T) {
+	dataDir := t.TempDir()
+	zipPath := filepath.Join(dataDir, "does-not-exist.zip")
+
+	err := runRestoreSnapshotCommand(dataDir, []string{"restore-snapshot", zipPath})
+	if err == nil {
+		t.Fatal("runRestoreSnapshotCommand() expected an error for a non-existent snapshot zip, got nil")
+	}
+	if errors.Is(err, errRestoreSnapshotUsage) {
+		t.Fatalf("runRestoreSnapshotCommand() error = %v, want a restore error, not the usage error", err)
+	}
 }
 
 func TestValidateListenConfig(t *testing.T) {

--- a/internal/core/auth/apikey_service.go
+++ b/internal/core/auth/apikey_service.go
@@ -44,10 +44,11 @@ const apiKeyLastUsedThrottle = 5 * time.Minute
 type APIKeyService struct {
 	store *APIKeyStore
 	users *UserService
+	log   *slog.Logger
 }
 
 func NewAPIKeyService(store *APIKeyStore, users *UserService) *APIKeyService {
-	return &APIKeyService{store: store, users: users}
+	return &APIKeyService{store: store, users: users, log: slog.Default().With("component", "APIKeyService")}
 }
 
 func (s *APIKeyService) Close() error {
@@ -153,7 +154,7 @@ func (s *APIKeyService) Resolve(token string) (*User, error) {
 	key, err := s.store.GetByPrefix(prefix)
 	found := err == nil
 	if err != nil && err != ErrAPIKeyNotFound {
-		slog.Default().Warn("api key resolve: prefix lookup failed", "error", err)
+		s.log.Warn("api key resolve: prefix lookup failed", "error", err)
 	}
 
 	storedHash := dummySecretHash
@@ -175,13 +176,13 @@ func (s *APIKeyService) Resolve(token string) (*User, error) {
 
 	owner, err := s.users.GetUserByID(key.UserID)
 	if err != nil {
-		slog.Default().Warn("api key resolve: owner lookup failed", "error", err, "keyID", key.ID)
+		s.log.Warn("api key resolve: owner lookup failed", "error", err, "keyID", key.ID)
 		return nil, ErrAPIKeyInvalid
 	}
 
 	if key.LastUsedAt == nil || now.Sub(*key.LastUsedAt) > apiKeyLastUsedThrottle {
 		if err := s.store.TouchLastUsed(key.ID, now); err != nil {
-			slog.Default().Warn("failed to update api key last_used_at", "error", err, "keyID", key.ID)
+			s.log.Warn("failed to update api key last_used_at", "error", err, "keyID", key.ID)
 		}
 	}
 

--- a/internal/core/auth/auth_service.go
+++ b/internal/core/auth/auth_service.go
@@ -1,8 +1,6 @@
 package auth
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"errors"
 	"log/slog"
 	"sync"
@@ -22,17 +20,14 @@ const loginChallengeTokenType = "login_challenge"
 
 type AuthService struct {
 	// mu guards only userService — it's the one field ReplaceUserStore swaps
-	// after a restore (users.db is part of the snapshot ZIP). sessionStore
-	// (sessions.db) is never swapped, so it needs no lock.
-	mu                   sync.RWMutex
-	userService          *UserService
-	sessionStore         *SessionStore
-	totp                 *TOTPService
-	secretKey            []byte
-	accessTokenLifetime  time.Duration
-	refreshTokenLifetime time.Duration
-	attempts             *loginAttemptTracker
-	dummyHash            []byte
+	// after a restore (users.db is part of the snapshot ZIP). sessions'
+	// underlying session store is never swapped, so it needs no lock.
+	mu          sync.RWMutex
+	userService *UserService
+	sessions    *SessionManager
+	totp        *TOTPService
+	attempts    *loginAttemptTracker
+	dummyHash   []byte
 }
 
 // users returns the current *UserService under a read lock. Callers use the
@@ -79,33 +74,36 @@ func (a *AuthService) ReplaceUserStore(storageDir string) error {
 // Used after a restore: the restored users.db may have entirely different
 // user IDs/passwords than the sessions currently trusting this process.
 func (a *AuthService) InvalidateAllSessions() error {
-	return a.sessionStore.DeleteAllSessions()
+	return a.sessions.sessionStore.DeleteAllSessions()
 }
 
-func NewAuthService(userService *UserService, sessionStore *SessionStore, totpService *TOTPService, secret string, accessTokenTimeout, refreshTokenTimeout time.Duration) *AuthService {
-	if len(secret) < 32 {
-		slog.Warn("JWT secret is too short; a minimum of 32 characters is strongly recommended", "length", len(secret))
-	}
+func NewAuthService(userService *UserService, sessions *SessionManager, totpService *TOTPService) *AuthService {
 	// Pre-compute a dummy hash to equalize Login() timing for non-existent users,
 	// preventing username enumeration via response-time differences.
 	dummyHash, _ := bcrypt.GenerateFromPassword([]byte("leafwiki-dummy-password"), bcrypt.DefaultCost)
-	return &AuthService{
-		userService:          userService,
-		sessionStore:         sessionStore,
-		totp:                 totpService,
-		secretKey:            []byte(secret),
-		accessTokenLifetime:  accessTokenTimeout,
-		refreshTokenLifetime: refreshTokenTimeout,
-		attempts:             newLoginAttemptTracker(),
-		dummyHash:            dummyHash,
+	a := &AuthService{
+		userService: userService,
+		sessions:    sessions,
+		totp:        totpService,
+		attempts:    newLoginAttemptTracker(),
+		dummyHash:   dummyHash,
 	}
+	// Wired here rather than passed into NewSessionManager: a.users() reads
+	// through the mutex ReplaceUserStore swaps, so RefreshToken/ValidateToken
+	// stay correct across a live-restore hot-swap — this closure calls
+	// a.users() fresh on every invocation rather than capturing one
+	// *UserService at construction time.
+	sessions.resolveUser = func(id string) (*User, error) {
+		return a.users().GetUserByID(id)
+	}
+	return a
 }
 
 func (a *AuthService) Close() error {
 	var errs []error
 
-	if a.sessionStore != nil {
-		if err := a.sessionStore.Close(); err != nil {
+	if a.sessions != nil {
+		if err := a.sessions.Close(); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -178,7 +176,7 @@ func (a *AuthService) Login(identifier, password string) (*AuthToken, error) {
 	}
 
 	a.attempts.reset(user.ID)
-	return a.issueTokens(user)
+	return a.sessions.IssueSession(user)
 }
 
 // CompleteTOTPLogin finishes a login handshake started by Login when a user
@@ -196,7 +194,7 @@ func (a *AuthService) CompleteTOTPLogin(challengeToken, code string) (*AuthToken
 		return nil, err
 	}
 
-	active, err := a.sessionStore.IsActive(jti, userID, loginChallengeTokenType, time.Now())
+	active, err := a.sessions.sessionStore.IsActive(jti, userID, loginChallengeTokenType, time.Now())
 	if err != nil {
 		return nil, err
 	}
@@ -235,12 +233,12 @@ func (a *AuthService) CompleteTOTPLogin(challengeToken, code string) (*AuthToken
 	a.attempts.reset(userID)
 
 	// Single-use: revoke the challenge now that it has been consumed successfully.
-	if err := a.sessionStore.RevokeSession(jti); err != nil {
+	if err := a.sessions.sessionStore.RevokeSession(jti); err != nil {
 		slog.Warn("failed to revoke used login challenge session", "error", err)
 	}
 
 	user.Password = ""
-	return a.issueTokens(user)
+	return a.sessions.IssueSession(user)
 }
 
 // StartTOTPSetup verifies the user's current password, generates a fresh TOTP
@@ -312,7 +310,7 @@ func (a *AuthService) ConfirmTOTPSetup(userID, code, currentRefreshToken string)
 		return nil, err
 	}
 
-	if err := a.RevokeAllUserSessionsExceptCurrent(userID, currentRefreshToken); err != nil {
+	if err := a.sessions.RevokeAllUserSessionsExceptCurrent(userID, currentRefreshToken); err != nil {
 		slog.Warn("failed to revoke other sessions after enabling TOTP", "userID", userID, "error", err)
 	}
 
@@ -350,7 +348,7 @@ func (a *AuthService) DisableTOTP(userID, currentPassword, code, currentRefreshT
 		return err
 	}
 
-	if err := a.RevokeAllUserSessionsExceptCurrent(userID, currentRefreshToken); err != nil {
+	if err := a.sessions.RevokeAllUserSessionsExceptCurrent(userID, currentRefreshToken); err != nil {
 		slog.Warn("failed to revoke other sessions after disabling TOTP", "userID", userID, "error", err)
 	}
 
@@ -375,20 +373,6 @@ func (a *AuthService) GetTOTPStatus(userID string) (*TOTPStatus, error) {
 		Enabled:                user.TOTPEnabled,
 		RecoveryCodesRemaining: len(user.TOTPRecoveryCodeHashes),
 	}, nil
-}
-
-// RevokeAllUserSessionsExceptCurrent revokes every other session for userID,
-// preserving the one identified by currentRefreshToken. If currentRefreshToken
-// cannot be parsed (e.g. missing), every session is revoked — a safe fallback
-// over silently preserving an unidentified session.
-func (a *AuthService) RevokeAllUserSessionsExceptCurrent(userID, currentRefreshToken string) error {
-	var exceptJTI string
-	if claims, err := a.parseClaims(currentRefreshToken); err == nil {
-		if jti, ok := claims["jti"].(string); ok {
-			exceptJTI = jti
-		}
-	}
-	return a.sessionStore.RevokeAllSessionsForUserExcept(userID, exceptJTI)
 }
 
 // maxRecoveryCodeConsumeAttempts bounds the compare-and-swap retry loop in
@@ -523,9 +507,11 @@ func errTOTPVerificationFailed(cause error) error {
 }
 
 // parseLoginChallenge validates challengeToken's signature, type, and required
-// claims, returning the subject user ID and challenge jti.
+// claims, returning the subject user ID and challenge jti. Reuses
+// SessionManager's low-level JWT parsing since login-challenge tokens share
+// the same secret and signing method as access/refresh tokens.
 func (a *AuthService) parseLoginChallenge(challengeToken string) (userID, jti string, err error) {
-	claims, err := a.parseClaims(challengeToken)
+	claims, err := a.sessions.parseClaims(challengeToken)
 	if err != nil {
 		return "", "", errInvalidLoginChallenge()
 	}
@@ -545,7 +531,11 @@ func (a *AuthService) parseLoginChallenge(challengeToken string) (userID, jti st
 }
 
 // beginTOTPChallenge issues a short-lived, single-use login challenge for a
-// user who passed the password check but still needs to prove TOTP.
+// user who passed the password check but still needs to prove TOTP. It signs
+// its own claim shape (no role/email, unlike an access/refresh token) via
+// SessionManager's shared signing key, and records the challenge in the same
+// session store access/refresh sessions live in, disambiguated by
+// loginChallengeTokenType.
 func (a *AuthService) beginTOTPChallenge(user *User) (*AuthToken, error) {
 	jti, err := generateJTI()
 	if err != nil {
@@ -559,13 +549,12 @@ func (a *AuthService) beginTOTPChallenge(user *User) (*AuthToken, error) {
 		"exp": expiresAt.Unix(),
 		"iat": time.Now().Unix(),
 	}
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	signed, err := token.SignedString(a.secretKey)
+	signed, err := a.sessions.signClaims(claims)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := a.sessionStore.CreateSession(jti, user.ID, loginChallengeTokenType, expiresAt); err != nil {
+	if err := a.sessions.sessionStore.CreateSession(jti, user.ID, loginChallengeTokenType, expiresAt); err != nil {
 		return nil, err
 	}
 
@@ -575,204 +564,23 @@ func (a *AuthService) beginTOTPChallenge(user *User) (*AuthToken, error) {
 	}, nil
 }
 
-// issueTokens generates and stores access/refresh tokens for an already fully
-// authenticated user (password-only login, or password + TOTP/recovery code).
-func (a *AuthService) issueTokens(user *User) (*AuthToken, error) {
-	accessToken, _, accessTokenExpiresAt, err := a.generateToken(user, a.accessTokenLifetime, "access")
-	if err != nil {
-		return nil, err
-	}
-
-	refreshToken, refreshJTI, _, err := a.generateToken(user, a.refreshTokenLifetime, "refresh")
-	if err != nil {
-		return nil, err
-	}
-
-	// store refresh token session
-	if err := a.sessionStore.CreateSession(
-		refreshJTI,
-		user.ID,
-		"refresh",
-		time.Now().Add(a.refreshTokenLifetime),
-	); err != nil {
-		return nil, err
-	}
-
-	return &AuthToken{
-		Token:                accessToken,
-		RefreshToken:         refreshToken,
-		AccessTokenExpiresAt: accessTokenExpiresAt,
-		User:                 user.ToPublicUser(),
-	}, nil
-}
+// RefreshToken, RevokeRefreshToken, RevokeAllUserSessions, and ValidateToken
+// delegate to SessionManager, which owns the JWT/session-store mechanics.
+// They stay exposed on AuthService because internal/wiki/auth's use cases and
+// internal/http/middleware/auth call them here, not on SessionManager directly.
 
 func (a *AuthService) RefreshToken(refreshToken string) (*AuthToken, error) {
-	claims, err := a.parseClaims(refreshToken)
-	if err != nil {
-		return nil, ErrInvalidToken
-	}
-
-	typ, ok := claims["typ"].(string)
-	if !ok || typ != "refresh" {
-		return nil, ErrInvalidToken
-	}
-
-	userID, ok := claims["sub"].(string)
-	if !ok {
-		return nil, ErrInvalidToken
-	}
-
-	jti, ok := claims["jti"].(string)
-	if !ok || jti == "" {
-		return nil, ErrInvalidToken
-	}
-
-	// Check if the refresh token session is active
-	active, err := a.sessionStore.IsActive(jti, userID, "refresh", time.Now())
-	if err != nil || !active {
-		return nil, ErrInvalidToken
-	}
-
-	user, err := a.users().GetUserByID(userID)
-	if err != nil {
-		return nil, ErrUserNotFound
-	}
-
-	user.Password = "" // Clear password from user object
-
-	newAccessToken, _, accessTokenExpiresAt, err := a.generateToken(user, a.accessTokenLifetime, "access")
-	if err != nil {
-		return nil, err
-	}
-
-	newRefreshToken, newRefreshJTI, _, err := a.generateToken(user, a.refreshTokenLifetime, "refresh")
-	if err != nil {
-		return nil, err
-	}
-
-	if err := a.sessionStore.CreateSession(
-		newRefreshJTI,
-		user.ID,
-		"refresh",
-		time.Now().Add(a.refreshTokenLifetime),
-	); err != nil {
-		return nil, err
-	}
-
-	// Revoke the old refresh token only after successfully creating the new session.
-	// This ensures that if token generation or session creation fails, the old token
-	// remains valid and the user can retry. If revocation fails, we log a warning but
-	// don't fail the refresh operation - the old token will expire naturally, and
-	// having two valid tokens temporarily is safer than logging the user out.
-	err = a.sessionStore.RevokeSession(jti)
-	if err != nil {
-		slog.Warn("failed to revoke used refresh token session", "error", err)
-	}
-
-	return &AuthToken{
-		Token:                newAccessToken,
-		RefreshToken:         newRefreshToken,
-		AccessTokenExpiresAt: accessTokenExpiresAt,
-		User:                 user.ToPublicUser(),
-	}, nil
+	return a.sessions.RefreshToken(refreshToken)
 }
 
 func (a *AuthService) RevokeRefreshToken(tokenString string) error {
-	claims, err := a.parseClaims(tokenString)
-	if err != nil {
-		return ErrInvalidToken
-	}
-
-	typ, ok := claims["typ"].(string)
-	if !ok || typ != "refresh" {
-		return ErrInvalidToken
-	}
-
-	jti, ok := claims["jti"].(string)
-	if !ok || jti == "" {
-		return ErrInvalidToken
-	}
-
-	return a.sessionStore.RevokeSession(jti)
+	return a.sessions.RevokeRefreshToken(tokenString)
 }
 
 func (a *AuthService) RevokeAllUserSessions(userID string) error {
-	return a.sessionStore.RevokeAllSessionsForUser(userID)
-}
-
-func generateJTI() (string, error) {
-	b := make([]byte, 16)
-	if _, err := rand.Read(b); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(b), nil
-}
-
-func (a *AuthService) parseClaims(tokenString string) (jwt.MapClaims, error) {
-	token, err := jwt.Parse(tokenString, func(t *jwt.Token) (interface{}, error) {
-		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, errors.New("unexpected signing method")
-		}
-		return a.secretKey, nil
-	})
-
-	if err != nil || !token.Valid {
-		return nil, ErrInvalidToken
-	}
-
-	claims, ok := token.Claims.(jwt.MapClaims)
-	if !ok {
-		return nil, ErrInvalidToken
-	}
-
-	return claims, nil
-}
-
-func (a *AuthService) generateToken(user *User, duration time.Duration, typ string) (string, string, int64, error) {
-	jti, err := generateJTI()
-	if err != nil {
-		return "", "", 0, err
-	}
-	expiresAt := time.Now().Add(duration).Unix()
-	claims := jwt.MapClaims{
-		"sub":   user.ID,
-		"role":  user.Role,
-		"email": user.Email,
-		"exp":   expiresAt,
-		"iat":   time.Now().Unix(),
-		"typ":   typ,
-		"jti":   jti, // Unique identifier for the token
-	}
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	signed, err := token.SignedString(a.secretKey)
-	if err != nil {
-		return "", "", 0, err
-	}
-	return signed, jti, expiresAt, nil
+	return a.sessions.RevokeAllUserSessions(userID)
 }
 
 func (a *AuthService) ValidateToken(tokenString string) (*User, error) {
-	token, err := jwt.Parse(tokenString, func(t *jwt.Token) (interface{}, error) {
-		// Ensure signing method is correct
-		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, errors.New("unexpected signing method")
-		}
-		return a.secretKey, nil
-	})
-
-	if err != nil || !token.Valid {
-		return nil, ErrInvalidToken
-	}
-
-	claims, ok := token.Claims.(jwt.MapClaims)
-	if !ok {
-		return nil, ErrInvalidToken
-	}
-
-	userID, ok := claims["sub"].(string)
-	if !ok {
-		return nil, ErrInvalidToken
-	}
-
-	return a.users().GetUserByID(userID)
+	return a.sessions.ValidateToken(tokenString)
 }

--- a/internal/core/auth/auth_service.go
+++ b/internal/core/auth/auth_service.go
@@ -144,7 +144,7 @@ func (a *AuthService) Login(identifier, password string) (*AuthToken, error) {
 	user, err := a.users().GetUserByIdentifier(identifier)
 	if err != nil {
 		_ = bcrypt.CompareHashAndPassword(a.dummyHash, []byte(password))
-		a.log.Warn("login failed: invalid credentials", "identifier", identifier)
+		a.log.Warn("login failed: invalid credentials")
 		return nil, ErrUserInvalidCredentials
 	}
 
@@ -154,7 +154,7 @@ func (a *AuthService) Login(identifier, password string) (*AuthToken, error) {
 	}
 
 	if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password)); err != nil {
-		a.log.Warn("login failed: invalid credentials", "identifier", identifier)
+		a.log.Warn("login failed: invalid credentials")
 		return nil, ErrUserInvalidCredentials
 	}
 

--- a/internal/core/auth/auth_service.go
+++ b/internal/core/auth/auth_service.go
@@ -28,6 +28,7 @@ type AuthService struct {
 	totp        *TOTPService
 	attempts    *loginAttemptTracker
 	dummyHash   []byte
+	log         *slog.Logger
 }
 
 // users returns the current *UserService under a read lock. Callers use the
@@ -63,7 +64,7 @@ func (a *AuthService) ReplaceUserStore(storageDir string) error {
 
 	if old != nil {
 		if err := old.Close(); err != nil {
-			slog.Warn("failed to close previous user store after restore", "error", err)
+			a.log.Warn("failed to close previous user store after restore", "error", err)
 		}
 	}
 	return nil
@@ -87,6 +88,7 @@ func NewAuthService(userService *UserService, sessions *SessionManager, totpServ
 		totp:        totpService,
 		attempts:    newLoginAttemptTracker(),
 		dummyHash:   dummyHash,
+		log:         slog.Default().With("component", "AuthService"),
 	}
 	// Wired here rather than passed into NewSessionManager: a.users() reads
 	// through the mutex ReplaceUserStore swaps, so RefreshToken/ValidateToken
@@ -142,14 +144,17 @@ func (a *AuthService) Login(identifier, password string) (*AuthToken, error) {
 	user, err := a.users().GetUserByIdentifier(identifier)
 	if err != nil {
 		_ = bcrypt.CompareHashAndPassword(a.dummyHash, []byte(password))
+		a.log.Warn("login failed: invalid credentials", "identifier", identifier)
 		return nil, ErrUserInvalidCredentials
 	}
 
 	if !a.attempts.recordAttempt(user.ID) {
+		a.log.Warn("login rejected: account locked", "userID", user.ID)
 		return nil, ErrUserAccountLocked
 	}
 
 	if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password)); err != nil {
+		a.log.Warn("login failed: invalid credentials", "identifier", identifier)
 		return nil, ErrUserInvalidCredentials
 	}
 
@@ -176,6 +181,7 @@ func (a *AuthService) Login(identifier, password string) (*AuthToken, error) {
 	}
 
 	a.attempts.reset(user.ID)
+	a.log.Info("login succeeded", "userID", user.ID)
 	return a.sessions.IssueSession(user)
 }
 
@@ -203,6 +209,7 @@ func (a *AuthService) CompleteTOTPLogin(challengeToken, code string) (*AuthToken
 	}
 
 	if !a.attempts.recordAttempt(userID) {
+		a.log.Warn("totp login rejected: account locked", "userID", userID)
 		return nil, ErrUserAccountLocked
 	}
 
@@ -222,11 +229,12 @@ func (a *AuthService) CompleteTOTPLogin(challengeToken, code string) (*AuthToken
 		return nil, errInvalidLoginChallenge()
 	}
 
-	valid, err := a.verifyTOTPOrRecoveryCode(users, user, code)
+	valid, viaRecoveryCode, err := a.verifyTOTPOrRecoveryCode(users, user, code)
 	if err != nil {
 		return nil, err
 	}
 	if !valid {
+		a.log.Warn("totp verification failed", "userID", userID)
 		return nil, errTOTPInvalidCode()
 	}
 
@@ -234,7 +242,13 @@ func (a *AuthService) CompleteTOTPLogin(challengeToken, code string) (*AuthToken
 
 	// Single-use: revoke the challenge now that it has been consumed successfully.
 	if err := a.sessions.sessionStore.RevokeSession(jti); err != nil {
-		slog.Warn("failed to revoke used login challenge session", "error", err)
+		a.log.Warn("failed to revoke used login challenge session", "error", err)
+	}
+
+	if viaRecoveryCode {
+		a.log.Warn("login completed via recovery code (consumed)", "userID", userID)
+	} else {
+		a.log.Info("totp login succeeded", "userID", userID)
 	}
 
 	user.Password = ""
@@ -311,9 +325,10 @@ func (a *AuthService) ConfirmTOTPSetup(userID, code, currentRefreshToken string)
 	}
 
 	if err := a.sessions.RevokeAllUserSessionsExceptCurrent(userID, currentRefreshToken); err != nil {
-		slog.Warn("failed to revoke other sessions after enabling TOTP", "userID", userID, "error", err)
+		a.log.Warn("failed to revoke other sessions after enabling TOTP", "userID", userID, "error", err)
 	}
 
+	a.log.Info("totp enabled", "userID", userID)
 	return codes, nil
 }
 
@@ -336,7 +351,7 @@ func (a *AuthService) DisableTOTP(userID, currentPassword, code, currentRefreshT
 		return errTOTPNotEnabled()
 	}
 
-	valid, err := a.verifyTOTPOrRecoveryCode(users, user, code)
+	valid, viaRecoveryCode, err := a.verifyTOTPOrRecoveryCode(users, user, code)
 	if err != nil {
 		return err
 	}
@@ -349,7 +364,13 @@ func (a *AuthService) DisableTOTP(userID, currentPassword, code, currentRefreshT
 	}
 
 	if err := a.sessions.RevokeAllUserSessionsExceptCurrent(userID, currentRefreshToken); err != nil {
-		slog.Warn("failed to revoke other sessions after disabling TOTP", "userID", userID, "error", err)
+		a.log.Warn("failed to revoke other sessions after disabling TOTP", "userID", userID, "error", err)
+	}
+
+	if viaRecoveryCode {
+		a.log.Warn("totp disabled via recovery code (consumed)", "userID", userID)
+	} else {
+		a.log.Info("totp disabled", "userID", userID)
 	}
 
 	return nil
@@ -384,7 +405,9 @@ const maxRecoveryCodeConsumeAttempts = 3
 // verifyTOTPOrRecoveryCode checks code against user's current TOTP secret or,
 // failing that, their remaining recovery codes — consuming (removing) a
 // matched recovery code so it cannot be reused. Shared by the login handshake
-// and the self-service disable flow.
+// and the self-service disable flow. viaRecoveryCode reports which of the two
+// matched, so callers can log recovery-code consumption distinctly (it burns
+// one of a finite set of codes, unlike an ordinary TOTP code).
 //
 // users is the *UserService the caller already fetched user from — threaded
 // through explicitly (rather than calling a.users() again in here) so the
@@ -397,20 +420,20 @@ const maxRecoveryCodeConsumeAttempts = 3
 // concurrent requests presenting the same recovery code cannot both succeed:
 // only the first writer's compare-and-swap can match the row's current state;
 // the loser re-reads the now-current hashes and retries against those.
-func (a *AuthService) verifyTOTPOrRecoveryCode(users *UserService, user *User, code string) (bool, error) {
-	valid, err := a.totp.VerifyCode(user.TOTPSecretEncrypted, code)
+func (a *AuthService) verifyTOTPOrRecoveryCode(users *UserService, user *User, code string) (valid, viaRecoveryCode bool, err error) {
+	valid, err = a.totp.VerifyCode(user.TOTPSecretEncrypted, code)
 	if err != nil {
-		return false, errTOTPVerificationFailed(err)
+		return false, false, errTOTPVerificationFailed(err)
 	}
 	if valid {
-		return true, nil
+		return true, false, nil
 	}
 
 	hashes := user.TOTPRecoveryCodeHashes
 	for attempt := 0; attempt < maxRecoveryCodeConsumeAttempts; attempt++ {
 		idx, matched := VerifyRecoveryCode(code, hashes)
 		if !matched {
-			return false, nil
+			return false, false, nil
 		}
 
 		remaining := make([]string, 0, len(hashes)-1)
@@ -419,10 +442,10 @@ func (a *AuthService) verifyTOTPOrRecoveryCode(users *UserService, user *User, c
 
 		swapped, err := users.ConsumeRecoveryCodeHash(user.ID, hashes, remaining)
 		if err != nil {
-			return false, err
+			return false, false, err
 		}
 		if swapped {
-			return true, nil
+			return true, true, nil
 		}
 
 		// Lost the race: a concurrent request already changed the stored
@@ -430,12 +453,12 @@ func (a *AuthService) verifyTOTPOrRecoveryCode(users *UserService, user *User, c
 		// Re-read the current state and retry against it.
 		refreshed, err := users.GetUserByID(user.ID)
 		if err != nil {
-			return false, err
+			return false, false, err
 		}
 		hashes = refreshed.TOTPRecoveryCodeHashes
 	}
 
-	return false, nil
+	return false, false, nil
 }
 
 func errInvalidLoginChallenge() error {

--- a/internal/core/auth/auth_service_replace_test.go
+++ b/internal/core/auth/auth_service_replace_test.go
@@ -19,7 +19,9 @@ func TestAuthService_ReplaceUserStore_SwapsToNewUsers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	authService := NewAuthService(NewUserService(oldStore), sessionStore, nil, "test-secret-key-for-unit-tests-1", time.Hour, 24*time.Hour)
+	oldUserService := NewUserService(oldStore)
+	sessions := NewSessionManager(sessionStore, "test-secret-key-for-unit-tests-1", time.Hour, 24*time.Hour)
+	authService := NewAuthService(oldUserService, sessions, nil)
 	t.Cleanup(func() { _ = authService.Close() })
 
 	if _, err := authService.Login("old-user", "old-password"); err != nil {
@@ -90,7 +92,9 @@ func TestAuthService_ReplaceUserStore_ConcurrentLoginsDuringSwap(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	authService := NewAuthService(NewUserService(oldStore), sessionStore, nil, "test-secret-key-for-unit-tests-1", time.Hour, 24*time.Hour)
+	sharedUserService := NewUserService(oldStore)
+	sharedSessions := NewSessionManager(sessionStore, "test-secret-key-for-unit-tests-1", time.Hour, 24*time.Hour)
+	authService := NewAuthService(sharedUserService, sharedSessions, nil)
 	t.Cleanup(func() { _ = authService.Close() })
 
 	newDir := t.TempDir()
@@ -150,10 +154,10 @@ func TestAuthService_InvalidateAllSessions_RevokesActiveSessions(t *testing.T) {
 	f := setupTestAuthService(t)
 	t.Cleanup(func() { _ = f.Close() })
 
-	if err := f.sessionStore.CreateSession("jti-a", "user-a", "refresh", time.Now().Add(time.Hour)); err != nil {
+	if err := f.sessions.sessionStore.CreateSession("jti-a", "user-a", "refresh", time.Now().Add(time.Hour)); err != nil {
 		t.Fatal(err)
 	}
-	if err := f.sessionStore.CreateSession("jti-b", "user-b", "refresh", time.Now().Add(time.Hour)); err != nil {
+	if err := f.sessions.sessionStore.CreateSession("jti-b", "user-b", "refresh", time.Now().Add(time.Hour)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -162,7 +166,7 @@ func TestAuthService_InvalidateAllSessions_RevokesActiveSessions(t *testing.T) {
 	}
 
 	for _, s := range []struct{ jti, userID string }{{"jti-a", "user-a"}, {"jti-b", "user-b"}} {
-		active, err := f.sessionStore.IsActive(s.jti, s.userID, "refresh", time.Now())
+		active, err := f.sessions.sessionStore.IsActive(s.jti, s.userID, "refresh", time.Now())
 		if err != nil {
 			t.Fatalf("IsActive failed: %v", err)
 		}

--- a/internal/core/auth/auth_service_test.go
+++ b/internal/core/auth/auth_service_test.go
@@ -30,7 +30,8 @@ func setupTestAuthService(t *testing.T) *AuthService {
 		t.Fatal(err)
 	}
 
-	authService := NewAuthService(userService, sessionStore, nil, "test-secret-key-for-unit-tests-1", 1*time.Hour, 24*time.Hour*7)
+	sessions := NewSessionManager(sessionStore, "test-secret-key-for-unit-tests-1", 1*time.Hour, 24*time.Hour*7)
+	authService := NewAuthService(userService, sessions, nil)
 	return authService
 }
 
@@ -86,7 +87,8 @@ func setupTOTPTestFixture(t *testing.T) *totpTestFixture {
 		t.Fatal(err)
 	}
 
-	authService := NewAuthService(userService, sessionStore, totpService, "test-secret-key-for-unit-tests-1", 1*time.Hour, 24*time.Hour*7)
+	sessions := NewSessionManager(sessionStore, "test-secret-key-for-unit-tests-1", 1*time.Hour, 24*time.Hour*7)
+	authService := NewAuthService(userService, sessions, totpService)
 
 	return &totpTestFixture{
 		authService:  authService,
@@ -319,7 +321,9 @@ func TestAuthService_CompleteTOTPLogin_NotConfiguredWhenNoEncryptionKey(t *testi
 
 	// Simulate an operator unsetting --totp-encryption-key after TOTP was
 	// already enabled for this user: rebuild the AuthService without a TOTPService.
-	authServiceNoTOTP := NewAuthService(NewUserService(f.store), mustNewSessionStore(t), nil, "test-secret-key-for-unit-tests-1", 1*time.Hour, 24*time.Hour*7)
+	noTOTPUserService := NewUserService(f.store)
+	noTOTPSessions := NewSessionManager(mustNewSessionStore(t), "test-secret-key-for-unit-tests-1", 1*time.Hour, 24*time.Hour*7)
+	authServiceNoTOTP := NewAuthService(noTOTPUserService, noTOTPSessions, nil)
 
 	// Login itself must fail fast with a clear error here, rather than issuing
 	// a challenge CompleteTOTPLogin could never redeem (which would strand the
@@ -377,7 +381,8 @@ func setupTOTPSetupFixture(t *testing.T) *totpSetupFixture {
 		t.Fatal(err)
 	}
 
-	authService := NewAuthService(userService, sessionStore, totpService, "test-secret-key-for-unit-tests-1", 1*time.Hour, 24*time.Hour*7)
+	sessions := NewSessionManager(sessionStore, "test-secret-key-for-unit-tests-1", 1*time.Hour, 24*time.Hour*7)
+	authService := NewAuthService(userService, sessions, totpService)
 
 	return &totpSetupFixture{
 		authService: authService,
@@ -513,7 +518,7 @@ func TestAuthService_ConfirmTOTPSetup_RevokesOtherSessionsButKeepsCurrent(t *tes
 	if err := f.sessionStr.CreateSession("other-device", f.userID, "refresh", time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("failed to seed other-device session: %v", err)
 	}
-	currentRefreshToken, currentJTI, _, err := f.authService.generateToken(&User{ID: f.userID}, time.Hour, "refresh")
+	currentRefreshToken, currentJTI, _, err := f.authService.sessions.generateToken(&User{ID: f.userID}, time.Hour, "refresh")
 	if err != nil {
 		t.Fatalf("failed to generate current refresh token: %v", err)
 	}
@@ -584,7 +589,9 @@ func TestAuthService_DisableTOTP_WrongCodeRejected(t *testing.T) {
 func TestAuthService_DisableTOTP_NotConfiguredWhenNoEncryptionKey(t *testing.T) {
 	f := setupTOTPTestFixture(t)
 
-	authServiceNoTOTP := NewAuthService(NewUserService(f.store), mustNewSessionStore(t), nil, "test-secret-key-for-unit-tests-1", 1*time.Hour, 24*time.Hour*7)
+	noTOTPUserService := NewUserService(f.store)
+	noTOTPSessions := NewSessionManager(mustNewSessionStore(t), "test-secret-key-for-unit-tests-1", 1*time.Hour, 24*time.Hour*7)
+	authServiceNoTOTP := NewAuthService(noTOTPUserService, noTOTPSessions, nil)
 
 	err := authServiceNoTOTP.DisableTOTP(f.userID, "securepass", "000000", "")
 	if err == nil {
@@ -612,7 +619,7 @@ func TestAuthService_DisableTOTP_NotEnabledRejected(t *testing.T) {
 func TestAuthService_DisableTOTP_ValidCodeDisablesAndRevokesOtherSessions(t *testing.T) {
 	f := setupTOTPTestFixture(t)
 
-	if err := f.authService.sessionStore.CreateSession("other-device", f.userID, "refresh", time.Now().Add(time.Hour)); err != nil {
+	if err := f.authService.sessions.sessionStore.CreateSession("other-device", f.userID, "refresh", time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("failed to seed other-device session: %v", err)
 	}
 
@@ -633,7 +640,7 @@ func TestAuthService_DisableTOTP_ValidCodeDisablesAndRevokesOtherSessions(t *tes
 	if len(user.TOTPRecoveryCodeHashes) != 0 {
 		t.Fatal("expected recovery codes cleared")
 	}
-	if active, _ := f.authService.sessionStore.IsActive("other-device", f.userID, "refresh", time.Now()); active {
+	if active, _ := f.authService.sessions.sessionStore.IsActive("other-device", f.userID, "refresh", time.Now()); active {
 		t.Fatal("expected other-device session to be revoked after disabling TOTP")
 	}
 }
@@ -878,10 +885,10 @@ func TestAuthService_RevokeAllUserSessions_MultipleUsers(t *testing.T) {
 func TestAuthService_Close_ClosesSessionAndUserStores(t *testing.T) {
 	authService := setupTestAuthService(t)
 
-	if authService.sessionStore == nil {
+	if authService.sessions == nil || authService.sessions.sessionStore == nil {
 		t.Fatal("expected session store to be initialized")
 	}
-	if authService.sessionStore.db == nil {
+	if authService.sessions.sessionStore.db == nil {
 		t.Fatal("expected session store db to be initialized")
 	}
 	if authService.userService == nil || authService.userService.store == nil {
@@ -895,7 +902,7 @@ func TestAuthService_Close_ClosesSessionAndUserStores(t *testing.T) {
 		t.Fatalf("Close failed: %v", err)
 	}
 
-	if authService.sessionStore.db != nil {
+	if authService.sessions.sessionStore.db != nil {
 		t.Fatal("expected session store db to be closed")
 	}
 	if authService.userService.store.db != nil {

--- a/internal/core/auth/auth_service_test.go
+++ b/internal/core/auth/auth_service_test.go
@@ -511,6 +511,47 @@ func TestAuthService_ConfirmTOTPSetup_ValidCodeEnablesAndReturnsRecoveryCodes(t 
 	}
 }
 
+// TestAuthService_ConfirmTOTPSetup_RecoveryCodesOnlyStoredAsHashesNotPlaintext
+// guards against recovery codes becoming re-fetchable: ConfirmTOTPSetup must
+// be the only place the plaintext codes are ever visible. Once persisted,
+// only irreversible hashes are stored, so no later read (GetTOTPStatus,
+// GetUserByID, admin user list, etc.) can ever reconstruct or re-display them.
+func TestAuthService_ConfirmTOTPSetup_RecoveryCodesOnlyStoredAsHashesNotPlaintext(t *testing.T) {
+	f := setupTOTPSetupFixture(t)
+
+	generated, err := f.authService.StartTOTPSetup(f.userID, "securepass")
+	if err != nil {
+		t.Fatalf("StartTOTPSetup failed: %v", err)
+	}
+	plainSecret, err := f.totpService.decrypt(generated.EncryptedSecret)
+	if err != nil {
+		t.Fatalf("failed to decrypt secret: %v", err)
+	}
+	code, err := totp.GenerateCode(plainSecret, time.Now())
+	if err != nil {
+		t.Fatalf("failed to generate reference TOTP code: %v", err)
+	}
+	codes, err := f.authService.ConfirmTOTPSetup(f.userID, code, "")
+	if err != nil {
+		t.Fatalf("ConfirmTOTPSetup failed: %v", err)
+	}
+
+	user, err := f.store.GetUserByID(f.userID)
+	if err != nil {
+		t.Fatalf("failed to reload user: %v", err)
+	}
+	if len(user.TOTPRecoveryCodeHashes) != len(codes) {
+		t.Fatalf("expected %d stored hashes, got %d", len(codes), len(user.TOTPRecoveryCodeHashes))
+	}
+	for i, plaintext := range codes {
+		for _, stored := range user.TOTPRecoveryCodeHashes {
+			if stored == plaintext {
+				t.Fatalf("recovery code %d is stored in plaintext (%q) — it would be re-fetchable via GetUserByID", i, plaintext)
+			}
+		}
+	}
+}
+
 func TestAuthService_ConfirmTOTPSetup_RevokesOtherSessionsButKeepsCurrent(t *testing.T) {
 	f := setupTOTPSetupFixture(t)
 
@@ -688,6 +729,57 @@ func TestAuthService_GetTOTPStatus_NotEnabled(t *testing.T) {
 	}
 	if status.RecoveryCodesRemaining != 0 {
 		t.Fatalf("expected 0 remaining recovery codes, got %d", status.RecoveryCodesRemaining)
+	}
+}
+
+func TestAuthService_GetTOTPStatus_RecoveryCodesRemainingReachesZeroAfterAllConsumed(t *testing.T) {
+	f := setupTOTPSetupFixture(t)
+
+	generated, err := f.authService.StartTOTPSetup(f.userID, "securepass")
+	if err != nil {
+		t.Fatalf("StartTOTPSetup failed: %v", err)
+	}
+	plainSecret, err := f.totpService.decrypt(generated.EncryptedSecret)
+	if err != nil {
+		t.Fatalf("failed to decrypt secret: %v", err)
+	}
+	code, err := totp.GenerateCode(plainSecret, time.Now())
+	if err != nil {
+		t.Fatalf("failed to generate reference TOTP code: %v", err)
+	}
+	codes, err := f.authService.ConfirmTOTPSetup(f.userID, code, "")
+	if err != nil {
+		t.Fatalf("ConfirmTOTPSetup failed: %v", err)
+	}
+
+	for i, recoveryCode := range codes {
+		challenge, err := f.authService.Login("testuser", "securepass")
+		if err != nil {
+			t.Fatalf("Login failed on iteration %d: %v", i, err)
+		}
+		if _, err := f.authService.CompleteTOTPLogin(challenge.LoginChallengeToken, recoveryCode); err != nil {
+			t.Fatalf("CompleteTOTPLogin with recovery code failed on iteration %d: %v", i, err)
+		}
+
+		status, err := f.authService.GetTOTPStatus(f.userID)
+		if err != nil {
+			t.Fatalf("GetTOTPStatus failed on iteration %d: %v", i, err)
+		}
+		wantRemaining := len(codes) - i - 1
+		if status.RecoveryCodesRemaining != wantRemaining {
+			t.Fatalf("iteration %d: expected %d remaining recovery codes, got %d", i, wantRemaining, status.RecoveryCodesRemaining)
+		}
+	}
+
+	status, err := f.authService.GetTOTPStatus(f.userID)
+	if err != nil {
+		t.Fatalf("GetTOTPStatus failed: %v", err)
+	}
+	if status.RecoveryCodesRemaining != 0 {
+		t.Fatalf("expected 0 remaining recovery codes after consuming all of them, got %d", status.RecoveryCodesRemaining)
+	}
+	if !status.Enabled {
+		t.Fatal("expected TOTP to remain enabled after exhausting recovery codes")
 	}
 }
 

--- a/internal/core/auth/errors.go
+++ b/internal/core/auth/errors.go
@@ -9,6 +9,7 @@ var ErrUserInvalidRole = errors.New("invalid role")
 var ErrUserAdminCannotBeDeleted = errors.New("admin user cannot be deleted; change role before deletion")
 var ErrLastAdminCannotBeDemoted = errors.New("cannot remove admin role from the last admin user")
 var ErrInvalidToken = errors.New("invalid token")
+var ErrSessionManagerNotWired = errors.New("session manager: resolveUser not configured (NewAuthService wires this; a SessionManager built directly must set it before use)")
 var ErrUserAccountLocked = errors.New("account temporarily locked due to too many failed login attempts")
 
 var ErrAPIKeyNotFound = errors.New("api key not found")

--- a/internal/core/auth/session_manager.go
+++ b/internal/core/auth/session_manager.go
@@ -1,0 +1,272 @@
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// SessionManager owns everything needed to turn an already-identified *User
+// into a LeafWiki session (JWT access+refresh tokens) and to manage that
+// session afterward (refresh, revoke, validate) — independent of how the
+// user was authenticated. Local password+TOTP login (AuthService) is the
+// only caller today; any future non-password identity provider (e.g. an
+// OIDC callback handler) would call IssueSession the same way, reusing this
+// component rather than reimplementing session handling.
+type SessionManager struct {
+	sessionStore         *SessionStore
+	secretKey            []byte
+	accessTokenLifetime  time.Duration
+	refreshTokenLifetime time.Duration
+
+	// resolveUser fetches the current *User for a subject ID. It is called
+	// fresh on every RefreshToken/ValidateToken (never cached here) and is
+	// wired up by NewAuthService (to its own hot-swap-safe a.users, see
+	// AuthService.ReplaceUserStore) rather than passed in here — at
+	// construction time there is no AuthService yet for it to read through.
+	resolveUser func(id string) (*User, error)
+}
+
+// NewSessionManager constructs a SessionManager backed by sessionStore.
+// resolveUser is not set yet at this point — see the field comment; callers
+// must arrange for it to be assigned (NewAuthService does this) before
+// RefreshToken/ValidateToken are used.
+func NewSessionManager(sessionStore *SessionStore, secret string, accessTokenTimeout, refreshTokenTimeout time.Duration) *SessionManager {
+	if len(secret) < 32 {
+		slog.Warn("JWT secret is too short; a minimum of 32 characters is strongly recommended", "length", len(secret))
+	}
+	return &SessionManager{
+		sessionStore:         sessionStore,
+		secretKey:            []byte(secret),
+		accessTokenLifetime:  accessTokenTimeout,
+		refreshTokenLifetime: refreshTokenTimeout,
+	}
+}
+
+func (s *SessionManager) Close() error {
+	if s.sessionStore == nil {
+		return nil
+	}
+	return s.sessionStore.Close()
+}
+
+// IssueSession generates and stores access/refresh tokens for an
+// already-authenticated user.
+func (s *SessionManager) IssueSession(user *User) (*AuthToken, error) {
+	accessToken, _, accessTokenExpiresAt, err := s.generateToken(user, s.accessTokenLifetime, "access")
+	if err != nil {
+		return nil, err
+	}
+
+	refreshToken, refreshJTI, _, err := s.generateToken(user, s.refreshTokenLifetime, "refresh")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.sessionStore.CreateSession(
+		refreshJTI,
+		user.ID,
+		"refresh",
+		time.Now().Add(s.refreshTokenLifetime),
+	); err != nil {
+		return nil, err
+	}
+
+	return &AuthToken{
+		Token:                accessToken,
+		RefreshToken:         refreshToken,
+		AccessTokenExpiresAt: accessTokenExpiresAt,
+		User:                 user.ToPublicUser(),
+	}, nil
+}
+
+// RefreshToken validates refreshToken, resolves the current user, and issues
+// a fresh access/refresh token pair. The old refresh token is only revoked
+// after the new session has been created successfully: if token generation
+// or session creation fails, the old token remains valid and the caller can
+// retry. A failure to revoke the old token afterward is logged but does not
+// fail the refresh — the old token expires naturally, and having two valid
+// tokens briefly is safer than logging the user out.
+func (s *SessionManager) RefreshToken(refreshToken string) (*AuthToken, error) {
+	claims, err := s.parseClaims(refreshToken)
+	if err != nil {
+		return nil, ErrInvalidToken
+	}
+
+	typ, ok := claims["typ"].(string)
+	if !ok || typ != "refresh" {
+		return nil, ErrInvalidToken
+	}
+
+	userID, ok := claims["sub"].(string)
+	if !ok {
+		return nil, ErrInvalidToken
+	}
+
+	jti, ok := claims["jti"].(string)
+	if !ok || jti == "" {
+		return nil, ErrInvalidToken
+	}
+
+	active, err := s.sessionStore.IsActive(jti, userID, "refresh", time.Now())
+	if err != nil || !active {
+		return nil, ErrInvalidToken
+	}
+
+	user, err := s.resolveUser(userID)
+	if err != nil {
+		return nil, ErrUserNotFound
+	}
+	user.Password = ""
+
+	newAccessToken, _, accessTokenExpiresAt, err := s.generateToken(user, s.accessTokenLifetime, "access")
+	if err != nil {
+		return nil, err
+	}
+
+	newRefreshToken, newRefreshJTI, _, err := s.generateToken(user, s.refreshTokenLifetime, "refresh")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.sessionStore.CreateSession(
+		newRefreshJTI,
+		user.ID,
+		"refresh",
+		time.Now().Add(s.refreshTokenLifetime),
+	); err != nil {
+		return nil, err
+	}
+
+	if err := s.sessionStore.RevokeSession(jti); err != nil {
+		slog.Warn("failed to revoke used refresh token session", "error", err)
+	}
+
+	return &AuthToken{
+		Token:                newAccessToken,
+		RefreshToken:         newRefreshToken,
+		AccessTokenExpiresAt: accessTokenExpiresAt,
+		User:                 user.ToPublicUser(),
+	}, nil
+}
+
+func (s *SessionManager) RevokeRefreshToken(tokenString string) error {
+	claims, err := s.parseClaims(tokenString)
+	if err != nil {
+		return ErrInvalidToken
+	}
+
+	typ, ok := claims["typ"].(string)
+	if !ok || typ != "refresh" {
+		return ErrInvalidToken
+	}
+
+	jti, ok := claims["jti"].(string)
+	if !ok || jti == "" {
+		return ErrInvalidToken
+	}
+
+	return s.sessionStore.RevokeSession(jti)
+}
+
+func (s *SessionManager) RevokeAllUserSessions(userID string) error {
+	return s.sessionStore.RevokeAllSessionsForUser(userID)
+}
+
+// RevokeAllUserSessionsExceptCurrent revokes every other session for userID,
+// preserving the one identified by currentRefreshToken. If currentRefreshToken
+// cannot be parsed (e.g. missing), every session is revoked — a safe fallback
+// over silently preserving an unidentified session.
+func (s *SessionManager) RevokeAllUserSessionsExceptCurrent(userID, currentRefreshToken string) error {
+	var exceptJTI string
+	if claims, err := s.parseClaims(currentRefreshToken); err == nil {
+		if jti, ok := claims["jti"].(string); ok {
+			exceptJTI = jti
+		}
+	}
+	return s.sessionStore.RevokeAllSessionsForUserExcept(userID, exceptJTI)
+}
+
+// ValidateToken validates tokenString and re-resolves the current user for
+// its subject on every call (rather than trusting the role/email baked into
+// the claims), so a role change or hot-swapped user store takes effect
+// immediately instead of waiting for the access token to expire.
+func (s *SessionManager) ValidateToken(tokenString string) (*User, error) {
+	claims, err := s.parseClaims(tokenString)
+	if err != nil {
+		return nil, ErrInvalidToken
+	}
+
+	userID, ok := claims["sub"].(string)
+	if !ok {
+		return nil, ErrInvalidToken
+	}
+
+	return s.resolveUser(userID)
+}
+
+func generateJTI() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// signClaims signs an arbitrary claim set with the session secret. Used by
+// generateToken below for access/refresh tokens, and directly by
+// AuthService's login-challenge (TOTP handshake) tokens, which share the
+// same secret and signing method but a different claim shape.
+func (s *SessionManager) signClaims(claims jwt.MapClaims) (string, error) {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString(s.secretKey)
+}
+
+// parseClaims validates tokenString's signature and signing method and
+// returns its claims. Used for access/refresh tokens here, and directly by
+// AuthService for login-challenge tokens, which share the same secret.
+func (s *SessionManager) parseClaims(tokenString string) (jwt.MapClaims, error) {
+	token, err := jwt.Parse(tokenString, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, errors.New("unexpected signing method")
+		}
+		return s.secretKey, nil
+	})
+
+	if err != nil || !token.Valid {
+		return nil, ErrInvalidToken
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, ErrInvalidToken
+	}
+
+	return claims, nil
+}
+
+func (s *SessionManager) generateToken(user *User, duration time.Duration, typ string) (string, string, int64, error) {
+	jti, err := generateJTI()
+	if err != nil {
+		return "", "", 0, err
+	}
+	expiresAt := time.Now().Add(duration).Unix()
+	claims := jwt.MapClaims{
+		"sub":   user.ID,
+		"role":  user.Role,
+		"email": user.Email,
+		"exp":   expiresAt,
+		"iat":   time.Now().Unix(),
+		"typ":   typ,
+		"jti":   jti, // Unique identifier for the token
+	}
+	signed, err := s.signClaims(claims)
+	if err != nil {
+		return "", "", 0, err
+	}
+	return signed, jti, expiresAt, nil
+}

--- a/internal/core/auth/session_manager.go
+++ b/internal/core/auth/session_manager.go
@@ -29,6 +29,10 @@ type SessionManager struct {
 	// AuthService.ReplaceUserStore) rather than passed in here — at
 	// construction time there is no AuthService yet for it to read through.
 	resolveUser func(id string) (*User, error)
+
+	// now is a test seam (defaults to time.Now); tests in this package may
+	// override it with a fake clock.
+	now func() time.Time
 }
 
 // NewSessionManager constructs a SessionManager backed by sessionStore.
@@ -44,6 +48,7 @@ func NewSessionManager(sessionStore *SessionStore, secret string, accessTokenTim
 		secretKey:            []byte(secret),
 		accessTokenLifetime:  accessTokenTimeout,
 		refreshTokenLifetime: refreshTokenTimeout,
+		now:                  time.Now,
 	}
 }
 
@@ -62,16 +67,21 @@ func (s *SessionManager) IssueSession(user *User) (*AuthToken, error) {
 		return nil, err
 	}
 
-	refreshToken, refreshJTI, _, err := s.generateToken(user, s.refreshTokenLifetime, "refresh")
+	refreshToken, refreshJTI, refreshExpiresAt, err := s.generateToken(user, s.refreshTokenLifetime, "refresh")
 	if err != nil {
 		return nil, err
 	}
 
+	// Reuse the exact exp timestamp already embedded in the refresh token's
+	// claims for the session-store row, rather than computing a second,
+	// independent now().Add(lifetime) here — two separate calls could drift
+	// by up to a second, leaving the token still cryptographically valid
+	// while IsActive already treats its session row as expired (or vice versa).
 	if err := s.sessionStore.CreateSession(
 		refreshJTI,
 		user.ID,
 		"refresh",
-		time.Now().Add(s.refreshTokenLifetime),
+		time.Unix(refreshExpiresAt, 0),
 	); err != nil {
 		return nil, err
 	}
@@ -112,11 +122,14 @@ func (s *SessionManager) RefreshToken(refreshToken string) (*AuthToken, error) {
 		return nil, ErrInvalidToken
 	}
 
-	active, err := s.sessionStore.IsActive(jti, userID, "refresh", time.Now())
+	active, err := s.sessionStore.IsActive(jti, userID, "refresh", s.now())
 	if err != nil || !active {
 		return nil, ErrInvalidToken
 	}
 
+	if s.resolveUser == nil {
+		return nil, ErrSessionManagerNotWired
+	}
 	user, err := s.resolveUser(userID)
 	if err != nil {
 		return nil, ErrUserNotFound
@@ -128,16 +141,18 @@ func (s *SessionManager) RefreshToken(refreshToken string) (*AuthToken, error) {
 		return nil, err
 	}
 
-	newRefreshToken, newRefreshJTI, _, err := s.generateToken(user, s.refreshTokenLifetime, "refresh")
+	newRefreshToken, newRefreshJTI, newRefreshExpiresAt, err := s.generateToken(user, s.refreshTokenLifetime, "refresh")
 	if err != nil {
 		return nil, err
 	}
 
+	// See IssueSession's comment: reuse the token's own exp rather than a
+	// second, independently-computed now().Add(lifetime).
 	if err := s.sessionStore.CreateSession(
 		newRefreshJTI,
 		user.ID,
 		"refresh",
-		time.Now().Add(s.refreshTokenLifetime),
+		time.Unix(newRefreshExpiresAt, 0),
 	); err != nil {
 		return nil, err
 	}
@@ -201,11 +216,19 @@ func (s *SessionManager) ValidateToken(tokenString string) (*User, error) {
 		return nil, ErrInvalidToken
 	}
 
+	typ, ok := claims["typ"].(string)
+	if !ok || typ != "access" {
+		return nil, ErrInvalidToken
+	}
+
 	userID, ok := claims["sub"].(string)
 	if !ok {
 		return nil, ErrInvalidToken
 	}
 
+	if s.resolveUser == nil {
+		return nil, ErrSessionManagerNotWired
+	}
 	return s.resolveUser(userID)
 }
 
@@ -254,13 +277,13 @@ func (s *SessionManager) generateToken(user *User, duration time.Duration, typ s
 	if err != nil {
 		return "", "", 0, err
 	}
-	expiresAt := time.Now().Add(duration).Unix()
+	expiresAt := s.now().Add(duration).Unix()
 	claims := jwt.MapClaims{
 		"sub":   user.ID,
 		"role":  user.Role,
 		"email": user.Email,
 		"exp":   expiresAt,
-		"iat":   time.Now().Unix(),
+		"iat":   s.now().Unix(),
 		"typ":   typ,
 		"jti":   jti, // Unique identifier for the token
 	}

--- a/internal/core/auth/session_manager.go
+++ b/internal/core/auth/session_manager.go
@@ -22,6 +22,7 @@ type SessionManager struct {
 	secretKey            []byte
 	accessTokenLifetime  time.Duration
 	refreshTokenLifetime time.Duration
+	log                  *slog.Logger
 
 	// resolveUser fetches the current *User for a subject ID. It is called
 	// fresh on every RefreshToken/ValidateToken (never cached here) and is
@@ -40,8 +41,9 @@ type SessionManager struct {
 // must arrange for it to be assigned (NewAuthService does this) before
 // RefreshToken/ValidateToken are used.
 func NewSessionManager(sessionStore *SessionStore, secret string, accessTokenTimeout, refreshTokenTimeout time.Duration) *SessionManager {
+	log := slog.Default().With("component", "SessionManager")
 	if len(secret) < 32 {
-		slog.Warn("JWT secret is too short; a minimum of 32 characters is strongly recommended", "length", len(secret))
+		log.Warn("JWT secret is too short; a minimum of 32 characters is strongly recommended", "length", len(secret))
 	}
 	return &SessionManager{
 		sessionStore:         sessionStore,
@@ -49,6 +51,7 @@ func NewSessionManager(sessionStore *SessionStore, secret string, accessTokenTim
 		accessTokenLifetime:  accessTokenTimeout,
 		refreshTokenLifetime: refreshTokenTimeout,
 		now:                  time.Now,
+		log:                  log,
 	}
 }
 
@@ -86,6 +89,7 @@ func (s *SessionManager) IssueSession(user *User) (*AuthToken, error) {
 		return nil, err
 	}
 
+	s.log.Info("session issued", "userID", user.ID)
 	return &AuthToken{
 		Token:                accessToken,
 		RefreshToken:         refreshToken,
@@ -158,9 +162,10 @@ func (s *SessionManager) RefreshToken(refreshToken string) (*AuthToken, error) {
 	}
 
 	if err := s.sessionStore.RevokeSession(jti); err != nil {
-		slog.Warn("failed to revoke used refresh token session", "error", err)
+		s.log.Warn("failed to revoke used refresh token session", "error", err)
 	}
 
+	s.log.Info("session refreshed", "userID", user.ID)
 	return &AuthToken{
 		Token:                newAccessToken,
 		RefreshToken:         newRefreshToken,
@@ -185,7 +190,13 @@ func (s *SessionManager) RevokeRefreshToken(tokenString string) error {
 		return ErrInvalidToken
 	}
 
-	return s.sessionStore.RevokeSession(jti)
+	userID, _ := claims["sub"].(string)
+
+	err = s.sessionStore.RevokeSession(jti)
+	if err == nil {
+		s.log.Info("session revoked", "userID", userID)
+	}
+	return err
 }
 
 func (s *SessionManager) RevokeAllUserSessions(userID string) error {

--- a/internal/core/auth/session_manager_test.go
+++ b/internal/core/auth/session_manager_test.go
@@ -1,0 +1,257 @@
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+// setupTestSessionManager builds a SessionManager backed by a real (temp-dir)
+// SessionStore and an in-memory resolver over users, so tests can exercise
+// session issuance/refresh/revocation/validation in isolation from password
+// or TOTP login.
+func setupTestSessionManager(t *testing.T, users map[string]*User) *SessionManager {
+	t.Helper()
+	store, err := NewSessionStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	sm := NewSessionManager(store, "test-secret-key-for-unit-tests-1", time.Hour, 24*time.Hour*7)
+	// Production code wires this up via NewAuthService (bound to its
+	// hot-swap-safe a.users); tests exercising SessionManager in isolation
+	// wire a plain in-memory lookup directly since it's the same package.
+	sm.resolveUser = func(id string) (*User, error) {
+		u, ok := users[id]
+		if !ok {
+			return nil, ErrUserNotFound
+		}
+		return u, nil
+	}
+	return sm
+}
+
+func TestSessionManager_IssueSession_ReturnsAccessAndRefreshTokens(t *testing.T) {
+	user := &User{ID: "u1", Username: "alice", Email: "alice@example.com", Role: RoleAdmin}
+	sm := setupTestSessionManager(t, map[string]*User{user.ID: user})
+
+	tokens, err := sm.IssueSession(user)
+	if err != nil {
+		t.Fatalf("IssueSession failed: %v", err)
+	}
+	if tokens.Token == "" || tokens.RefreshToken == "" {
+		t.Fatal("expected access and refresh token")
+	}
+	if tokens.User == nil || tokens.User.Username != "alice" {
+		t.Fatalf("expected public user alice in response, got %+v", tokens.User)
+	}
+}
+
+func TestSessionManager_ValidateToken_ReturnsCurrentUser(t *testing.T) {
+	user := &User{ID: "u1", Username: "alice", Role: RoleEditor}
+	sm := setupTestSessionManager(t, map[string]*User{user.ID: user})
+
+	tokens, err := sm.IssueSession(user)
+	if err != nil {
+		t.Fatalf("IssueSession failed: %v", err)
+	}
+
+	got, err := sm.ValidateToken(tokens.Token)
+	if err != nil {
+		t.Fatalf("ValidateToken failed: %v", err)
+	}
+	if got.ID != "u1" || got.Username != "alice" {
+		t.Fatalf("unexpected user from ValidateToken: %+v", got)
+	}
+}
+
+func TestSessionManager_ValidateToken_InvalidTokenRejected(t *testing.T) {
+	sm := setupTestSessionManager(t, nil)
+	if _, err := sm.ValidateToken("not-a-token"); err != ErrInvalidToken {
+		t.Fatalf("expected ErrInvalidToken, got %v", err)
+	}
+}
+
+// ValidateToken must re-resolve the user on every call rather than trusting
+// the role/email baked into the token's claims, so a role change takes
+// effect immediately instead of waiting for the access token to expire.
+func TestSessionManager_ValidateToken_ReflectsCurrentResolvedUser(t *testing.T) {
+	user := &User{ID: "u1", Username: "alice", Role: RoleViewer}
+	users := map[string]*User{user.ID: user}
+	sm := setupTestSessionManager(t, users)
+
+	tokens, err := sm.IssueSession(user)
+	if err != nil {
+		t.Fatalf("IssueSession failed: %v", err)
+	}
+
+	users["u1"] = &User{ID: "u1", Username: "alice", Role: RoleAdmin}
+
+	got, err := sm.ValidateToken(tokens.Token)
+	if err != nil {
+		t.Fatalf("ValidateToken failed: %v", err)
+	}
+	if got.Role != RoleAdmin {
+		t.Fatalf("expected freshly resolved role %q, got %q", RoleAdmin, got.Role)
+	}
+}
+
+func TestSessionManager_RefreshToken_IssuesNewTokensAndRevokesOld(t *testing.T) {
+	user := &User{ID: "u1", Username: "alice", Role: RoleAdmin}
+	sm := setupTestSessionManager(t, map[string]*User{user.ID: user})
+
+	tokens, err := sm.IssueSession(user)
+	if err != nil {
+		t.Fatalf("IssueSession failed: %v", err)
+	}
+
+	newTokens, err := sm.RefreshToken(tokens.RefreshToken)
+	if err != nil {
+		t.Fatalf("RefreshToken failed: %v", err)
+	}
+	if newTokens.Token == "" || newTokens.RefreshToken == "" {
+		t.Fatal("expected new access and refresh tokens")
+	}
+
+	if _, err := sm.RefreshToken(tokens.RefreshToken); err == nil {
+		t.Fatal("expected the old refresh token to be revoked after use")
+	}
+}
+
+func TestSessionManager_RefreshToken_RevokedTokenRejected(t *testing.T) {
+	user := &User{ID: "u1", Username: "alice", Role: RoleAdmin}
+	sm := setupTestSessionManager(t, map[string]*User{user.ID: user})
+
+	tokens, err := sm.IssueSession(user)
+	if err != nil {
+		t.Fatalf("IssueSession failed: %v", err)
+	}
+	if err := sm.RevokeRefreshToken(tokens.RefreshToken); err != nil {
+		t.Fatalf("RevokeRefreshToken failed: %v", err)
+	}
+	if _, err := sm.RefreshToken(tokens.RefreshToken); err != ErrInvalidToken {
+		t.Fatalf("expected ErrInvalidToken, got %v", err)
+	}
+}
+
+func TestSessionManager_RefreshToken_AccessTokenRejected(t *testing.T) {
+	user := &User{ID: "u1", Username: "alice", Role: RoleAdmin}
+	sm := setupTestSessionManager(t, map[string]*User{user.ID: user})
+
+	tokens, err := sm.IssueSession(user)
+	if err != nil {
+		t.Fatalf("IssueSession failed: %v", err)
+	}
+	if _, err := sm.RefreshToken(tokens.Token); err != ErrInvalidToken {
+		t.Fatalf("expected ErrInvalidToken when refreshing with an access token, got %v", err)
+	}
+}
+
+func TestSessionManager_RefreshToken_InvalidTokenRejected(t *testing.T) {
+	sm := setupTestSessionManager(t, nil)
+	if _, err := sm.RefreshToken("invalid"); err != ErrInvalidToken {
+		t.Fatalf("expected ErrInvalidToken, got %v", err)
+	}
+}
+
+func TestSessionManager_RevokeRefreshToken_InvalidToken(t *testing.T) {
+	sm := setupTestSessionManager(t, nil)
+	if err := sm.RevokeRefreshToken("invalid"); err != ErrInvalidToken {
+		t.Fatalf("expected ErrInvalidToken, got %v", err)
+	}
+}
+
+func TestSessionManager_RevokeRefreshToken_AccessTokenRejected(t *testing.T) {
+	user := &User{ID: "u1", Username: "alice", Role: RoleAdmin}
+	sm := setupTestSessionManager(t, map[string]*User{user.ID: user})
+	tokens, err := sm.IssueSession(user)
+	if err != nil {
+		t.Fatalf("IssueSession failed: %v", err)
+	}
+	if err := sm.RevokeRefreshToken(tokens.Token); err != ErrInvalidToken {
+		t.Fatalf("expected ErrInvalidToken, got %v", err)
+	}
+}
+
+func TestSessionManager_RevokeAllUserSessions(t *testing.T) {
+	user := &User{ID: "u1", Username: "alice", Role: RoleAdmin}
+	sm := setupTestSessionManager(t, map[string]*User{user.ID: user})
+
+	tokens1, err := sm.IssueSession(user)
+	if err != nil {
+		t.Fatalf("IssueSession failed: %v", err)
+	}
+	tokens2, err := sm.IssueSession(user)
+	if err != nil {
+		t.Fatalf("IssueSession failed: %v", err)
+	}
+
+	if err := sm.RevokeAllUserSessions(user.ID); err != nil {
+		t.Fatalf("RevokeAllUserSessions failed: %v", err)
+	}
+
+	if _, err := sm.RefreshToken(tokens1.RefreshToken); err == nil {
+		t.Fatal("expected first session to be revoked")
+	}
+	if _, err := sm.RefreshToken(tokens2.RefreshToken); err == nil {
+		t.Fatal("expected second session to be revoked")
+	}
+}
+
+func TestSessionManager_RevokeAllUserSessionsExceptCurrent_PreservesCallersSession(t *testing.T) {
+	user := &User{ID: "u1", Username: "alice", Role: RoleAdmin}
+	sm := setupTestSessionManager(t, map[string]*User{user.ID: user})
+
+	current, err := sm.IssueSession(user)
+	if err != nil {
+		t.Fatalf("IssueSession failed: %v", err)
+	}
+	other, err := sm.IssueSession(user)
+	if err != nil {
+		t.Fatalf("IssueSession failed: %v", err)
+	}
+
+	if err := sm.RevokeAllUserSessionsExceptCurrent(user.ID, current.RefreshToken); err != nil {
+		t.Fatalf("RevokeAllUserSessionsExceptCurrent failed: %v", err)
+	}
+
+	if _, err := sm.RefreshToken(current.RefreshToken); err != nil {
+		t.Fatalf("expected the current session to survive: %v", err)
+	}
+	if _, err := sm.RefreshToken(other.RefreshToken); err == nil {
+		t.Fatal("expected the other session to be revoked")
+	}
+}
+
+func TestSessionManager_RevokeAllUserSessionsExceptCurrent_UnparsableCurrentRevokesEverything(t *testing.T) {
+	user := &User{ID: "u1", Username: "alice", Role: RoleAdmin}
+	sm := setupTestSessionManager(t, map[string]*User{user.ID: user})
+
+	tokens, err := sm.IssueSession(user)
+	if err != nil {
+		t.Fatalf("IssueSession failed: %v", err)
+	}
+
+	if err := sm.RevokeAllUserSessionsExceptCurrent(user.ID, "not-a-token"); err != nil {
+		t.Fatalf("RevokeAllUserSessionsExceptCurrent failed: %v", err)
+	}
+
+	if _, err := sm.RefreshToken(tokens.RefreshToken); err == nil {
+		t.Fatal("expected every session to be revoked when the current token can't be identified")
+	}
+}
+
+func TestSessionManager_Close_ClosesSessionStore(t *testing.T) {
+	store, err := NewSessionStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sm := NewSessionManager(store, "test-secret-key-for-unit-tests-1", time.Hour, 24*time.Hour)
+
+	if err := sm.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+	if store.db != nil {
+		t.Fatal("expected session store db to be closed")
+	}
+}

--- a/internal/core/auth/session_manager_test.go
+++ b/internal/core/auth/session_manager_test.go
@@ -1,9 +1,24 @@
 package auth
 
 import (
+	"database/sql"
 	"testing"
 	"time"
 )
+
+// readSessionExpiresAt reads back the raw expires_at column stored for jti,
+// so tests can compare it exactly against a token's own exp claim.
+func readSessionExpiresAt(t *testing.T, store *SessionStore, jti string) int64 {
+	t.Helper()
+	var expiresAt int64
+	err := store.withDB(func(db *sql.DB) error {
+		return db.QueryRow(`SELECT expires_at FROM sessions WHERE id = ?`, jti).Scan(&expiresAt)
+	})
+	if err != nil {
+		t.Fatalf("failed to read session expires_at: %v", err)
+	}
+	return expiresAt
+}
 
 // setupTestSessionManager builds a SessionManager backed by a real (temp-dir)
 // SessionStore and an in-memory resolver over users, so tests can exercise
@@ -69,6 +84,69 @@ func TestSessionManager_ValidateToken_InvalidTokenRejected(t *testing.T) {
 	sm := setupTestSessionManager(t, nil)
 	if _, err := sm.ValidateToken("not-a-token"); err != ErrInvalidToken {
 		t.Fatalf("expected ErrInvalidToken, got %v", err)
+	}
+}
+
+// Regression test: ValidateToken must only accept typ=="access" tokens. It
+// previously accepted any validly-signed token regardless of typ, meaning a
+// refresh token (long-lived, and not checked against the session store here)
+// could be used as an access token.
+func TestSessionManager_ValidateToken_RejectsRefreshToken(t *testing.T) {
+	user := &User{ID: "u1", Username: "alice", Role: RoleAdmin}
+	sm := setupTestSessionManager(t, map[string]*User{user.ID: user})
+
+	tokens, err := sm.IssueSession(user)
+	if err != nil {
+		t.Fatalf("IssueSession failed: %v", err)
+	}
+
+	if _, err := sm.ValidateToken(tokens.RefreshToken); err != ErrInvalidToken {
+		t.Fatalf("expected ErrInvalidToken when validating a refresh token as an access token, got %v", err)
+	}
+}
+
+// A SessionManager constructed directly (not via NewAuthService, which wires
+// resolveUser) must fail loudly rather than panic on a nil call.
+func TestSessionManager_ValidateToken_ResolveUserNotWired_ReturnsErrorInsteadOfPanicking(t *testing.T) {
+	store, err := NewSessionStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sm := NewSessionManager(store, "test-secret-key-for-unit-tests-1", time.Hour, 24*time.Hour)
+
+	user := &User{ID: "u1", Username: "alice", Role: RoleAdmin}
+	sm.resolveUser = func(id string) (*User, error) { return user, nil }
+	tokens, err := sm.IssueSession(user)
+	if err != nil {
+		t.Fatalf("IssueSession failed: %v", err)
+	}
+
+	// Simulate the not-yet-wired state ValidateToken/RefreshToken must guard against.
+	sm.resolveUser = nil
+
+	if _, err := sm.ValidateToken(tokens.Token); err == nil {
+		t.Fatal("expected an error, not a panic or nil, when resolveUser is unset")
+	}
+}
+
+func TestSessionManager_RefreshToken_ResolveUserNotWired_ReturnsErrorInsteadOfPanicking(t *testing.T) {
+	store, err := NewSessionStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sm := NewSessionManager(store, "test-secret-key-for-unit-tests-1", time.Hour, 24*time.Hour)
+
+	user := &User{ID: "u1", Username: "alice", Role: RoleAdmin}
+	sm.resolveUser = func(id string) (*User, error) { return user, nil }
+	tokens, err := sm.IssueSession(user)
+	if err != nil {
+		t.Fatalf("IssueSession failed: %v", err)
+	}
+
+	sm.resolveUser = nil
+
+	if _, err := sm.RefreshToken(tokens.RefreshToken); err == nil {
+		t.Fatal("expected an error, not a panic or nil, when resolveUser is unset")
 	}
 }
 
@@ -238,6 +316,99 @@ func TestSessionManager_RevokeAllUserSessionsExceptCurrent_UnparsableCurrentRevo
 
 	if _, err := sm.RefreshToken(tokens.RefreshToken); err == nil {
 		t.Fatal("expected every session to be revoked when the current token can't be identified")
+	}
+}
+
+// fakeAdvancingClock returns a clock that moves forward by step on every
+// call, so a bug that recomputes an expiry from a second, independent now()
+// call (instead of reusing an already-computed one) produces a deterministic,
+// detectable drift instead of an unreliable real-time race.
+func fakeAdvancingClock(step time.Duration) func() time.Time {
+	base := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	calls := 0
+	return func() time.Time {
+		now := base.Add(time.Duration(calls) * step)
+		calls++
+		return now
+	}
+}
+
+// Regression test: IssueSession previously stored the refresh session's
+// expiry via its own now().Add(lifetime) call, separate from the exp already
+// embedded in the refresh token's claims moments earlier — the two could
+// drift, leaving a token still cryptographically valid while its session row
+// was already (or not yet) considered expired.
+func TestSessionManager_IssueSession_SessionExpiryMatchesRefreshTokenExp(t *testing.T) {
+	user := &User{ID: "u1", Username: "alice", Role: RoleAdmin}
+	store, err := NewSessionStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sm := NewSessionManager(store, "test-secret-key-for-unit-tests-1", time.Hour, 24*time.Hour)
+	sm.resolveUser = func(id string) (*User, error) { return user, nil }
+	sm.now = fakeAdvancingClock(3 * time.Second)
+
+	tokens, err := sm.IssueSession(user)
+	if err != nil {
+		t.Fatalf("IssueSession failed: %v", err)
+	}
+
+	claims, err := sm.parseClaims(tokens.RefreshToken)
+	if err != nil {
+		t.Fatalf("failed to parse refresh token claims: %v", err)
+	}
+	tokenExp, ok := claims["exp"].(float64)
+	if !ok {
+		t.Fatalf("expected exp claim, got %#v", claims["exp"])
+	}
+	jti, ok := claims["jti"].(string)
+	if !ok {
+		t.Fatalf("expected jti claim, got %#v", claims["jti"])
+	}
+
+	storedExpiresAt := readSessionExpiresAt(t, store, jti)
+	if int64(tokenExp) != storedExpiresAt {
+		t.Fatalf("session-store expiry (%d) does not match refresh token's own exp claim (%d)", storedExpiresAt, int64(tokenExp))
+	}
+}
+
+// Same regression, exercised via RefreshToken's newly-issued refresh session.
+func TestSessionManager_RefreshToken_SessionExpiryMatchesNewRefreshTokenExp(t *testing.T) {
+	user := &User{ID: "u1", Username: "alice", Role: RoleAdmin}
+	store, err := NewSessionStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sm := NewSessionManager(store, "test-secret-key-for-unit-tests-1", time.Hour, 24*time.Hour)
+	sm.resolveUser = func(id string) (*User, error) { return user, nil }
+	sm.now = fakeAdvancingClock(3 * time.Second)
+
+	initial, err := sm.IssueSession(user)
+	if err != nil {
+		t.Fatalf("IssueSession failed: %v", err)
+	}
+
+	refreshed, err := sm.RefreshToken(initial.RefreshToken)
+	if err != nil {
+		t.Fatalf("RefreshToken failed: %v", err)
+	}
+
+	claims, err := sm.parseClaims(refreshed.RefreshToken)
+	if err != nil {
+		t.Fatalf("failed to parse refresh token claims: %v", err)
+	}
+	tokenExp, ok := claims["exp"].(float64)
+	if !ok {
+		t.Fatalf("expected exp claim, got %#v", claims["exp"])
+	}
+	jti, ok := claims["jti"].(string)
+	if !ok {
+		t.Fatalf("expected jti claim, got %#v", claims["jti"])
+	}
+
+	storedExpiresAt := readSessionExpiresAt(t, store, jti)
+	if int64(tokenExp) != storedExpiresAt {
+		t.Fatalf("session-store expiry (%d) does not match refresh token's own exp claim (%d)", storedExpiresAt, int64(tokenExp))
 	}
 }
 

--- a/internal/core/auth/session_store.go
+++ b/internal/core/auth/session_store.go
@@ -3,7 +3,7 @@ package auth
 import (
 	"context"
 	"database/sql"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -20,6 +20,7 @@ type SessionStore struct {
 	db         *sql.DB
 	cancel     context.CancelFunc
 	done       chan struct{}
+	log        *slog.Logger
 }
 
 func sessionDatabasePath(storageDir string, filename string) string {
@@ -34,6 +35,7 @@ func NewSessionStore(storageDir string) (*SessionStore, error) {
 		filename:   "sessions.db",
 		cancel:     cancel,
 		done:       make(chan struct{}),
+		log:        slog.Default().With("component", "SessionStore"),
 	}
 
 	err := sqliteutil.RetryOnCorruption(sessionDatabasePath(s.storageDir, s.filename), func() error {
@@ -62,7 +64,7 @@ func NewSessionStore(storageDir string) (*SessionStore, error) {
 				return
 			case <-ticker.C:
 				if err := s.CleanupExpiredSessions(); err != nil {
-					log.Printf("failed to cleanup expired sessions: %v", err)
+					s.log.Warn("failed to cleanup expired sessions", "error", err)
 				}
 			}
 		}

--- a/internal/core/auth/user_resolver.go
+++ b/internal/core/auth/user_resolver.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"log"
 	"sync"
 )
 
@@ -19,7 +18,10 @@ type UserResolver struct {
 func NewUserResolver(userService *UserService) (*UserResolver, error) {
 	users, err := userService.GetUsers() // preload users
 	if err != nil {
-		log.Println("Failed to preload users for UserResolver:", err)
+		// Not logged here: the error is returned to the caller (wiki.go's
+		// NewWiki), which propagates it up to main.go's own top-level
+		// fatal-error logging — logging here too would double-log the same
+		// failure (ADR-0008's "log once, at the swallow point" rule).
 		return nil, err
 	}
 	r := &UserResolver{

--- a/internal/core/auth/user_service.go
+++ b/internal/core/auth/user_service.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/perber/wiki/internal/core/shared"
@@ -15,11 +16,13 @@ const (
 
 type UserService struct {
 	store *UserStore
+	log   *slog.Logger
 }
 
 func NewUserService(store *UserStore) *UserService {
 	return &UserService{
 		store: store,
+		log:   slog.Default().With("component", "UserService"),
 	}
 }
 
@@ -95,6 +98,7 @@ func (s *UserService) CreateUser(username, email, password, role string) (*User,
 		return nil, err
 	}
 
+	s.log.Info("user created", "userID", user.ID, "role", user.Role)
 	return user, nil
 }
 
@@ -147,6 +151,7 @@ func (s *UserService) UpdateUser(id, username, email, password, role string) (*U
 	}
 
 	// Update user fields
+	oldRole := user.Role
 	user.Username = username
 	user.Email = email
 	user.Role = role
@@ -165,6 +170,11 @@ func (s *UserService) UpdateUser(id, username, email, password, role string) (*U
 		return nil, err
 	}
 
+	if oldRole != user.Role {
+		s.log.Info("user role changed", "userID", user.ID, "oldRole", oldRole, "newRole", user.Role)
+	} else {
+		s.log.Info("user updated", "userID", user.ID)
+	}
 	return user, nil
 }
 
@@ -221,6 +231,7 @@ func (s *UserService) DeleteUser(id string) error {
 	if err != nil {
 		return err
 	}
+	s.log.Info("user deleted", "userID", id)
 	return nil
 }
 
@@ -293,6 +304,7 @@ func (s *UserService) ChangeOwnPassword(id, oldPassword, newPassword string) err
 		return err
 	}
 
+	s.log.Info("password changed", "userID", id)
 	return nil
 }
 
@@ -329,6 +341,7 @@ func (s *UserService) ResetAdminUserPassword(username, email string) (*User, err
 	// Note: I need to return the user with the new password, because the user lost his password
 	adminUser.Password = password // Set the password to the generated one
 
+	s.log.Info("admin password reset", "userID", adminUser.ID)
 	return adminUser, nil
 }
 

--- a/internal/http/metrics/metrics.go
+++ b/internal/http/metrics/metrics.go
@@ -30,6 +30,10 @@ type HTTPMetrics struct {
 	resyncDuration        *prometheus.HistogramVec
 	resyncRuns            *prometheus.CounterVec
 	resyncFailures        *prometheus.CounterVec
+	authLoginAttempts     *prometheus.CounterVec
+	authTOTPVerifications *prometheus.CounterVec
+	authSessions          *prometheus.CounterVec
+	authTOTPEnrollment    *prometheus.CounterVec
 	handler               http.Handler
 }
 
@@ -168,6 +172,42 @@ func NewHTTPMetrics() *HTTPMetrics {
 		[]string{"result"},
 	)
 
+	authLoginAttempts := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "leafwiki",
+			Name:      "auth_login_attempts_total",
+			Help:      "Total number of login attempts by outcome.",
+		},
+		[]string{"outcome"},
+	)
+
+	authTOTPVerifications := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "leafwiki",
+			Name:      "auth_totp_verifications_total",
+			Help:      "Total number of TOTP/recovery-code verifications during login by result.",
+		},
+		[]string{"result"},
+	)
+
+	authSessions := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "leafwiki",
+			Name:      "auth_sessions_total",
+			Help:      "Total number of session lifecycle events by event type.",
+		},
+		[]string{"event"},
+	)
+
+	authTOTPEnrollment := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "leafwiki",
+			Name:      "auth_totp_enrollment_total",
+			Help:      "Total number of TOTP enrollment changes by event type.",
+		},
+		[]string{"event"},
+	)
+
 	registry.MustRegister(
 		requestsTotal,
 		requestDuration,
@@ -183,6 +223,10 @@ func NewHTTPMetrics() *HTTPMetrics {
 		resyncDuration,
 		resyncRuns,
 		resyncFailures,
+		authLoginAttempts,
+		authTOTPVerifications,
+		authSessions,
+		authTOTPEnrollment,
 	)
 
 	return &HTTPMetrics{
@@ -201,6 +245,10 @@ func NewHTTPMetrics() *HTTPMetrics {
 		resyncDuration:        resyncDuration,
 		resyncRuns:            resyncRuns,
 		resyncFailures:        resyncFailures,
+		authLoginAttempts:     authLoginAttempts,
+		authTOTPVerifications: authTOTPVerifications,
+		authSessions:          authSessions,
+		authTOTPEnrollment:    authTOTPEnrollment,
 		handler:               promhttp.HandlerFor(registry, promhttp.HandlerOpts{}),
 	}
 }
@@ -284,6 +332,34 @@ func (m *HTTPMetrics) ObserveResyncRun(err error, started time.Time) {
 	if err != nil {
 		m.resyncFailures.WithLabelValues(result).Inc()
 	}
+}
+
+func (m *HTTPMetrics) IncAuthLoginAttempt(outcome string) {
+	if m == nil {
+		return
+	}
+	m.authLoginAttempts.WithLabelValues(outcome).Inc()
+}
+
+func (m *HTTPMetrics) IncAuthTOTPVerification(result string) {
+	if m == nil {
+		return
+	}
+	m.authTOTPVerifications.WithLabelValues(result).Inc()
+}
+
+func (m *HTTPMetrics) IncAuthSession(event string) {
+	if m == nil {
+		return
+	}
+	m.authSessions.WithLabelValues(event).Inc()
+}
+
+func (m *HTTPMetrics) IncAuthTOTPEnrollment(event string) {
+	if m == nil {
+		return
+	}
+	m.authTOTPEnrollment.WithLabelValues(event).Inc()
 }
 
 func resultLabel(err error) string {

--- a/internal/http/middleware/auth/apikey_test.go
+++ b/internal/http/middleware/auth/apikey_test.go
@@ -278,7 +278,8 @@ func TestInjectAPIKeyUser_WithRequireAuth(t *testing.T) {
 	}
 	cleanupWithErrorCheck(t, "session store", sessionStore.Close)
 
-	authService := coreauth.NewAuthService(f.userService, sessionStore, nil, "test-secret-key-for-unit-tests-1", 0, 0)
+	sessions := coreauth.NewSessionManager(sessionStore, "test-secret-key-for-unit-tests-1", 0, 0)
+	authService := coreauth.NewAuthService(f.userService, sessions, nil)
 	authCookies := authmw.NewAuthCookies(true, 0, 0)
 
 	_, token, err := f.keyService.CreateAPIKey(coreauth.CreateAPIKeyParams{

--- a/internal/http/middleware/auth/auth_test.go
+++ b/internal/http/middleware/auth/auth_test.go
@@ -37,8 +37,9 @@ func createTestAuthFixture(t *testing.T) *authFixture {
 		t.Fatalf("Failed to init default admin: %v", err)
 	}
 
+	sessions := coreauth.NewSessionManager(sessionStore, "test-secret-key-for-unit-tests-1", 15*time.Minute, 7*24*time.Hour)
 	return &authFixture{
-		auth: coreauth.NewAuthService(userService, sessionStore, nil, "test-secret-key-for-unit-tests-1", 15*time.Minute, 7*24*time.Hour),
+		auth: coreauth.NewAuthService(userService, sessions, nil),
 		close: func() error {
 			if err := sessionStore.Close(); err != nil {
 				_ = userStore.Close()

--- a/internal/http/middleware/auth/reverse_proxy_test.go
+++ b/internal/http/middleware/auth/reverse_proxy_test.go
@@ -300,7 +300,8 @@ func TestInjectRemoteUser_WithRequireAuth(t *testing.T) {
 	}
 	cleanupWithErrorCheck(t, "session store", sessionStore.Close)
 
-	authService := coreauth.NewAuthService(f.userService, sessionStore, nil, "test-secret-key-for-unit-tests-1", 0, 0)
+	sessions := coreauth.NewSessionManager(sessionStore, "test-secret-key-for-unit-tests-1", 0, 0)
+	authService := coreauth.NewAuthService(f.userService, sessions, nil)
 	authCookies := authmw.NewAuthCookies(true, 0, 0)
 
 	cfg := authmw.RemoteUserConfig{

--- a/internal/http/router_test.go
+++ b/internal/http/router_test.go
@@ -3466,6 +3466,53 @@ func TestViewer_CannotDeletePage(t *testing.T) {
 	}
 }
 
+func TestViewer_CannotMovePage(t *testing.T) {
+	w := createWikiTestInstance(t)
+	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
+	router := createRouterTestInstance(w, t)
+
+	// Create a viewer user
+	createUserBody := `{"username": "vieweruser5", "email": "viewer5@example.com", "password": "viewerpass5", "role": "viewer"}`
+	authenticatedRequest(t, router, http.MethodPost, "/api/users", strings.NewReader(createUserBody))
+
+	// Create two pages as admin
+	a := createPageViaAPI(t, router, "Section A", "section-a", nil, pageNodeKind())
+	b := createPageViaAPI(t, router, "Section B", "section-b", nil, pageNodeKind())
+
+	// Try to move a under b as viewer
+	rec := authenticatedRequestAs(t, router, "vieweruser5", "viewerpass5", http.MethodPut, "/api/pages/"+a.ID+"/move", strings.NewReader(`{"version":"`+a.Version+`","parentId":"`+b.ID+`"}`))
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("Expected 403 Forbidden for viewer moving page, got %d", rec.Code)
+	}
+}
+
+func TestViewer_CannotSortPages(t *testing.T) {
+	w := createWikiTestInstance(t)
+	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
+	router := createRouterTestInstance(w, t)
+
+	// Create a viewer user
+	createUserBody := `{"username": "vieweruser6", "email": "viewer6@example.com", "password": "viewerpass6", "role": "viewer"}`
+	authenticatedRequest(t, router, http.MethodPost, "/api/users", strings.NewReader(createUserBody))
+
+	// Create pages as admin
+	page1 := createPageViaAPI(t, router, "Page 1", "page-1", nil, pageNodeKind())
+	page2 := createPageViaAPI(t, router, "Page 2", "page-2", nil, pageNodeKind())
+
+	// Try to sort pages as viewer
+	payload := map[string]interface{}{
+		"orderedIds": []string{page2.ID, page1.ID},
+	}
+	body, _ := json.Marshal(payload)
+
+	rec := authenticatedRequestAs(t, router, "vieweruser6", "viewerpass6", http.MethodPut, "/api/pages/root/sort", strings.NewReader(string(body)))
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("Expected 403 Forbidden for viewer sorting pages, got %d", rec.Code)
+	}
+}
+
 func TestGetUsersEndpoint(t *testing.T) {
 	w := createWikiTestInstance(t)
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)

--- a/internal/restore/manager_test.go
+++ b/internal/restore/manager_test.go
@@ -48,7 +48,8 @@ func newManagerFixtureWithBranding(t *testing.T, wikiVersion, brandingJSON strin
 	if err != nil {
 		t.Fatalf("NewUserStore failed: %v", err)
 	}
-	authService := auth.NewAuthService(auth.NewUserService(userStore), sessionStore, nil, "test-secret-key-for-unit-tests-1", time.Hour, 24*time.Hour)
+	sessions := auth.NewSessionManager(sessionStore, "test-secret-key-for-unit-tests-1", time.Hour, 24*time.Hour)
+	authService := auth.NewAuthService(auth.NewUserService(userStore), sessions, nil)
 
 	brandingService, err := branding.NewBrandingService(dataDir)
 	if err != nil {

--- a/internal/restore/manager_test.go
+++ b/internal/restore/manager_test.go
@@ -3,6 +3,8 @@ package restore
 import (
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -285,5 +287,56 @@ func TestManager_Restore_RollsBackOnBrandingReloadFailure(t *testing.T) {
 	}
 	if _, err := f.authService.Login("snapshot-admin", "snapshot-password-123"); err == nil {
 		t.Fatal("expected the snapshot's user to no longer exist after rollback")
+	}
+}
+
+// TestManager_Restore_BlocksConcurrentWritesDuringSwap runs real goroutines
+// racing WriteGate.TryEnter against a real Manager.runLocked (file swap, auth
+// reopen, branding reload) — closing the gap between the gate primitive's own
+// race coverage (writegate_test.go) and the HTTP middleware's gate coverage
+// (internal/http/middleware/maintenance/writegate_test.go), neither of which
+// exercises an actual in-flight restore.
+func TestManager_Restore_BlocksConcurrentWritesDuringSwap(t *testing.T) {
+	f := newManagerFixture(t, "v1.0.0")
+
+	var admitted, rejected int64
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if leave, ok := f.manager.cfg.WriteGate.TryEnter(); ok {
+					atomic.AddInt64(&admitted, 1)
+					time.Sleep(time.Millisecond)
+					leave()
+				} else {
+					atomic.AddInt64(&rejected, 1)
+				}
+			}
+		}()
+	}
+
+	if err := f.manager.TriggerRestore(f.snapshotID); err != nil {
+		t.Fatalf("TriggerRestore failed: %v", err)
+	}
+	status := waitForRestoreDone(t, f.manager)
+	close(stop)
+	wg.Wait()
+
+	if status.Error != "" {
+		t.Fatalf("expected successful restore, got: %s", status.Error)
+	}
+	if atomic.LoadInt64(&rejected) == 0 {
+		t.Error("expected at least some concurrent TryEnter calls to be rejected while the gate was engaged")
+	}
+	if f.manager.cfg.WriteGate.Engaged() {
+		t.Error("expected write gate to be disengaged after restore completes")
 	}
 }

--- a/internal/restore/selfrestart_unix.go
+++ b/internal/restore/selfrestart_unix.go
@@ -7,6 +7,11 @@ import (
 	"syscall"
 )
 
+// execFn is a seam over syscall.Exec: replacing the process image can't be
+// exercised directly in a test without terminating the test binary itself,
+// so tests stub this to capture the computed exe/argv/env instead.
+var execFn = syscall.Exec
+
 // SelfRestart replaces the current process image in place (same PID) via
 // exec(3), re-running main()'s cold boot against whatever is currently on
 // disk. Used as the last-resort recovery path when a restore's rollback
@@ -19,5 +24,5 @@ func SelfRestart() error {
 	if err != nil {
 		return err
 	}
-	return syscall.Exec(exe, os.Args, os.Environ())
+	return execFn(exe, os.Args, os.Environ())
 }

--- a/internal/restore/selfrestart_unix_test.go
+++ b/internal/restore/selfrestart_unix_test.go
@@ -1,0 +1,51 @@
+//go:build !windows
+
+package restore
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestSelfRestart_CallsExecWithCurrentExecutableArgsAndEnv(t *testing.T) {
+	orig := execFn
+	t.Cleanup(func() { execFn = orig })
+
+	var gotArgv0 string
+	var gotArgv, gotEnv []string
+	execFn = func(argv0 string, argv, envv []string) error {
+		gotArgv0, gotArgv, gotEnv = argv0, argv, envv
+		return nil
+	}
+
+	if err := SelfRestart(); err != nil {
+		t.Fatalf("SelfRestart() error = %v", err)
+	}
+
+	wantExe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable() error = %v", err)
+	}
+	if gotArgv0 != wantExe {
+		t.Errorf("execFn called with argv0 = %q, want %q", gotArgv0, wantExe)
+	}
+	if !reflect.DeepEqual(gotArgv, os.Args) {
+		t.Errorf("execFn called with argv = %v, want %v", gotArgv, os.Args)
+	}
+	if !reflect.DeepEqual(gotEnv, os.Environ()) {
+		t.Errorf("execFn called with envv = %v, want %v", gotEnv, os.Environ())
+	}
+}
+
+func TestSelfRestart_PropagatesExecError(t *testing.T) {
+	orig := execFn
+	t.Cleanup(func() { execFn = orig })
+
+	wantErr := os.ErrPermission
+	execFn = func(argv0 string, argv, envv []string) error { return wantErr }
+
+	if err := SelfRestart(); err != wantErr {
+		t.Errorf("SelfRestart() error = %v, want %v", err, wantErr)
+	}
+}

--- a/internal/restore/swap_test.go
+++ b/internal/restore/swap_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -112,6 +113,48 @@ func TestSwapper_SwapAll_ReplacesLiveContentAndKeepsPreRestoreCopyUntilCommit(t 
 	sw.CommitAll()
 	if hasPreRestoreEntries(t, dataDir) {
 		t.Error("expected .pre-restore-* entries to be gone after CommitAll")
+	}
+}
+
+func TestSwapper_SwapAll_PermissionDeniedMovingAside(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission-bit semantics differ on windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses permission checks")
+	}
+
+	zipPath := buildFixtureSnapshot(t, "v1.0.0")
+	dataDir := t.TempDir()
+	test_utils.WriteFile(t, dataDir, "root/live-page.md", "# Live content\n")
+
+	// Build the staging dir before dataDir is made read-only: extractAndValidate
+	// itself needs to create a directory inside dataDir, which is a separate
+	// concern from the rename-permission failure this test targets.
+	stagingDir, _, err := extractAndValidate(zipPath, dataDir)
+	if err != nil {
+		t.Fatalf("extractAndValidate failed: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingDir) })
+
+	if err := os.Chmod(dataDir, 0o555); err != nil {
+		t.Fatalf("chmod failed: %v", err)
+	}
+	// Must run before t.TempDir()'s own cleanup, which needs dataDir writable
+	// to remove it; t.Cleanup runs LIFO, so registering this after t.TempDir()
+	// (called above) puts it first.
+	t.Cleanup(func() { _ = os.Chmod(dataDir, 0o755) })
+
+	sw := newSwapper(dataDir, stagingDir)
+	if err := sw.SwapAll(); err == nil {
+		t.Fatal("expected SwapAll to fail with a permission error")
+	}
+
+	if _, statErr := os.Stat(filepath.Join(dataDir, "root", "live-page.md")); statErr != nil {
+		t.Errorf("expected live content to remain untouched, got: %v", statErr)
+	}
+	if rbErr := sw.RollbackAll(); rbErr != nil {
+		t.Errorf("expected RollbackAll to be a safe no-op after a failed move-aside, got: %v", rbErr)
 	}
 }
 

--- a/internal/wiki/auth/errors.go
+++ b/internal/wiki/auth/errors.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -95,6 +96,7 @@ func respondWithAuthError(c *gin.Context, err error) {
 	case errors.Is(err, ErrAuthDisabled):
 		respondWithAuthStatusError(c, http.StatusForbidden, ErrCodeAuthDisabled, "Authentication is disabled", "authentication is disabled")
 	default:
+		slog.Default().Error("unhandled auth error", "error", err)
 		respondWithAuthStatusError(c, http.StatusInternalServerError, ErrCodeAuthInternalError, "Authentication request failed", "authentication request failed")
 	}
 }

--- a/internal/wiki/auth/routes.go
+++ b/internal/wiki/auth/routes.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"errors"
-	"log"
 	"log/slog"
 	"net/http"
 	"time"
@@ -309,19 +308,20 @@ func (r *Routes) handleLoginTOTP(rctx httpinternal.RouterContext) gin.HandlerFun
 
 func (r *Routes) handleLogout(rctx httpinternal.RouterContext) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		refreshToken, _ := rctx.AuthCookies.ReadRefresh(c)
+		refreshToken, err := rctx.AuthCookies.ReadRefresh(c)
+		if err != nil {
+			slog.Default().Warn("could not read refresh token during logout; refresh token will not be revoked", "error", err)
+		}
 		if refreshToken != "" {
 			if err := r.logout.Execute(c.Request.Context(), LogoutInput{RefreshToken: refreshToken}); err != nil {
-				log.Printf("[INFO] Unable to revoke the refresh token: %v", err)
+				slog.Default().Warn("failed to revoke refresh token during logout", "error", err)
 			}
 		}
 		if err := rctx.AuthCookies.Clear(c); err != nil {
-			log.Printf("[INFO] Unable to clear auth cookies: %v", err)
 			respondWithAuthStatusError(c, http.StatusBadRequest, ErrCodeAuthCookieFailed, "Failed to clear authentication cookies", "failed to clear authentication cookies")
 			return
 		}
 		if err := rctx.CSRFCookie.Clear(c); err != nil {
-			log.Printf("[INFO] Unable to clear CSRF cookie: %v", err)
 			respondWithAuthStatusError(c, http.StatusBadRequest, ErrCodeAuthCsrfFailed, "Failed to clear CSRF cookie", "failed to clear csrf cookie")
 			return
 		}

--- a/internal/wiki/auth/use_cases.go
+++ b/internal/wiki/auth/use_cases.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"context"
 	"errors"
-	"log"
 	"log/slog"
 	"regexp"
 	"strings"
@@ -11,14 +10,13 @@ import (
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	sharederrors "github.com/perber/wiki/internal/core/shared/errors"
 	"github.com/perber/wiki/internal/favorites"
+	httpmetrics "github.com/perber/wiki/internal/http/metrics"
 )
 
 // ErrAuthDisabled is returned when an auth operation is called while auth is disabled.
 var ErrAuthDisabled = errors.New("authentication is disabled")
 
 var emailRegex = regexp.MustCompile(`^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+$`)
-
-const logReloadUserResolverCacheWarning = "warning: could not reload user resolver cache: %v"
 
 // ─── LoginUseCase ────────────────────────────────────────────────────────────
 
@@ -32,11 +30,12 @@ type LoginOutput struct {
 }
 
 type LoginUseCase struct {
-	auth *coreauth.AuthService
+	auth    *coreauth.AuthService
+	metrics *httpmetrics.HTTPMetrics
 }
 
-func NewLoginUseCase(a *coreauth.AuthService) *LoginUseCase {
-	return &LoginUseCase{auth: a}
+func NewLoginUseCase(a *coreauth.AuthService, metrics *httpmetrics.HTTPMetrics) *LoginUseCase {
+	return &LoginUseCase{auth: a, metrics: metrics}
 }
 
 func (uc *LoginUseCase) Execute(_ context.Context, in LoginInput) (*LoginOutput, error) {
@@ -45,7 +44,21 @@ func (uc *LoginUseCase) Execute(_ context.Context, in LoginInput) (*LoginOutput,
 	}
 	token, err := uc.auth.Login(in.Identifier, in.Password)
 	if err != nil {
+		switch {
+		case errors.Is(err, coreauth.ErrUserAccountLocked):
+			uc.metrics.IncAuthLoginAttempt("locked")
+		case errors.Is(err, coreauth.ErrUserInvalidCredentials):
+			uc.metrics.IncAuthLoginAttempt("invalid_credentials")
+		default:
+			uc.metrics.IncAuthLoginAttempt("error")
+		}
 		return nil, err
+	}
+	if token.RequiresTOTP {
+		uc.metrics.IncAuthLoginAttempt("totp_required")
+	} else {
+		uc.metrics.IncAuthLoginAttempt("success")
+		uc.metrics.IncAuthSession("issued")
 	}
 	return &LoginOutput{Token: token}, nil
 }
@@ -62,11 +75,12 @@ type CompleteTOTPLoginOutput struct {
 }
 
 type CompleteTOTPLoginUseCase struct {
-	auth *coreauth.AuthService
+	auth    *coreauth.AuthService
+	metrics *httpmetrics.HTTPMetrics
 }
 
-func NewCompleteTOTPLoginUseCase(a *coreauth.AuthService) *CompleteTOTPLoginUseCase {
-	return &CompleteTOTPLoginUseCase{auth: a}
+func NewCompleteTOTPLoginUseCase(a *coreauth.AuthService, metrics *httpmetrics.HTTPMetrics) *CompleteTOTPLoginUseCase {
+	return &CompleteTOTPLoginUseCase{auth: a, metrics: metrics}
 }
 
 func (uc *CompleteTOTPLoginUseCase) Execute(_ context.Context, in CompleteTOTPLoginInput) (*CompleteTOTPLoginOutput, error) {
@@ -75,8 +89,15 @@ func (uc *CompleteTOTPLoginUseCase) Execute(_ context.Context, in CompleteTOTPLo
 	}
 	token, err := uc.auth.CompleteTOTPLogin(in.LoginChallengeToken, in.Code)
 	if err != nil {
+		if errors.Is(err, coreauth.ErrUserAccountLocked) {
+			uc.metrics.IncAuthTOTPVerification("locked")
+		} else {
+			uc.metrics.IncAuthTOTPVerification("invalid")
+		}
 		return nil, err
 	}
+	uc.metrics.IncAuthTOTPVerification("success")
+	uc.metrics.IncAuthSession("issued")
 	return &CompleteTOTPLoginOutput{Token: token}, nil
 }
 
@@ -124,11 +145,12 @@ type ConfirmTOTPSetupOutput struct {
 }
 
 type ConfirmTOTPSetupUseCase struct {
-	auth *coreauth.AuthService
+	auth    *coreauth.AuthService
+	metrics *httpmetrics.HTTPMetrics
 }
 
-func NewConfirmTOTPSetupUseCase(a *coreauth.AuthService) *ConfirmTOTPSetupUseCase {
-	return &ConfirmTOTPSetupUseCase{auth: a}
+func NewConfirmTOTPSetupUseCase(a *coreauth.AuthService, metrics *httpmetrics.HTTPMetrics) *ConfirmTOTPSetupUseCase {
+	return &ConfirmTOTPSetupUseCase{auth: a, metrics: metrics}
 }
 
 func (uc *ConfirmTOTPSetupUseCase) Execute(_ context.Context, in ConfirmTOTPSetupInput) (*ConfirmTOTPSetupOutput, error) {
@@ -139,6 +161,7 @@ func (uc *ConfirmTOTPSetupUseCase) Execute(_ context.Context, in ConfirmTOTPSetu
 	if err != nil {
 		return nil, err
 	}
+	uc.metrics.IncAuthTOTPEnrollment("enabled")
 	return &ConfirmTOTPSetupOutput{RecoveryCodes: codes}, nil
 }
 
@@ -152,18 +175,23 @@ type DisableTOTPInput struct {
 }
 
 type DisableTOTPUseCase struct {
-	auth *coreauth.AuthService
+	auth    *coreauth.AuthService
+	metrics *httpmetrics.HTTPMetrics
 }
 
-func NewDisableTOTPUseCase(a *coreauth.AuthService) *DisableTOTPUseCase {
-	return &DisableTOTPUseCase{auth: a}
+func NewDisableTOTPUseCase(a *coreauth.AuthService, metrics *httpmetrics.HTTPMetrics) *DisableTOTPUseCase {
+	return &DisableTOTPUseCase{auth: a, metrics: metrics}
 }
 
 func (uc *DisableTOTPUseCase) Execute(_ context.Context, in DisableTOTPInput) error {
 	if uc.auth == nil {
 		return ErrAuthDisabled
 	}
-	return uc.auth.DisableTOTP(in.UserID, in.CurrentPassword, in.Code, in.CurrentRefreshToken)
+	if err := uc.auth.DisableTOTP(in.UserID, in.CurrentPassword, in.Code, in.CurrentRefreshToken); err != nil {
+		return err
+	}
+	uc.metrics.IncAuthTOTPEnrollment("disabled")
+	return nil
 }
 
 // ─── GetTOTPStatusUseCase ────────────────────────────────────────────────────
@@ -201,16 +229,23 @@ func (uc *GetTOTPStatusUseCase) Execute(_ context.Context, in GetTOTPStatusInput
 type LogoutInput struct{ RefreshToken string }
 
 type LogoutUseCase struct {
-	auth *coreauth.AuthService
+	auth    *coreauth.AuthService
+	metrics *httpmetrics.HTTPMetrics
 }
 
-func NewLogoutUseCase(a *coreauth.AuthService) *LogoutUseCase { return &LogoutUseCase{auth: a} }
+func NewLogoutUseCase(a *coreauth.AuthService, metrics *httpmetrics.HTTPMetrics) *LogoutUseCase {
+	return &LogoutUseCase{auth: a, metrics: metrics}
+}
 
 func (uc *LogoutUseCase) Execute(_ context.Context, in LogoutInput) error {
 	if uc.auth == nil {
 		return ErrAuthDisabled
 	}
-	return uc.auth.RevokeRefreshToken(in.RefreshToken)
+	if err := uc.auth.RevokeRefreshToken(in.RefreshToken); err != nil {
+		return err
+	}
+	uc.metrics.IncAuthSession("revoked")
+	return nil
 }
 
 // ─── RefreshTokenUseCase ─────────────────────────────────────────────────────
@@ -222,11 +257,12 @@ type RefreshTokenOutput struct {
 }
 
 type RefreshTokenUseCase struct {
-	auth *coreauth.AuthService
+	auth    *coreauth.AuthService
+	metrics *httpmetrics.HTTPMetrics
 }
 
-func NewRefreshTokenUseCase(a *coreauth.AuthService) *RefreshTokenUseCase {
-	return &RefreshTokenUseCase{auth: a}
+func NewRefreshTokenUseCase(a *coreauth.AuthService, metrics *httpmetrics.HTTPMetrics) *RefreshTokenUseCase {
+	return &RefreshTokenUseCase{auth: a, metrics: metrics}
 }
 
 func (uc *RefreshTokenUseCase) Execute(_ context.Context, in RefreshTokenInput) (*RefreshTokenOutput, error) {
@@ -237,6 +273,7 @@ func (uc *RefreshTokenUseCase) Execute(_ context.Context, in RefreshTokenInput) 
 	if err != nil {
 		return nil, err
 	}
+	uc.metrics.IncAuthSession("refreshed")
 	return &RefreshTokenOutput{Token: token}, nil
 }
 
@@ -290,7 +327,7 @@ func (uc *CreateUserUseCase) Execute(_ context.Context, in CreateUserInput) (*Cr
 		return nil, err
 	}
 	if err := uc.resolver.Reload(); err != nil {
-		log.Printf(logReloadUserResolverCacheWarning, err)
+		uc.log.Warn("failed to reload user resolver cache", "error", err)
 	}
 	return &CreateUserOutput{User: user.ToPublicUser()}, nil
 }
@@ -352,7 +389,7 @@ func (uc *UpdateUserUseCase) Execute(_ context.Context, in UpdateUserInput) (*Up
 		return nil, err
 	}
 	if err := uc.resolver.Reload(); err != nil {
-		log.Printf(logReloadUserResolverCacheWarning, err)
+		uc.log.Warn("failed to reload user resolver cache", "error", err)
 	}
 	return &UpdateUserOutput{User: user.ToPublicUser()}, nil
 }
@@ -409,7 +446,7 @@ func (uc *DeleteUserUseCase) Execute(_ context.Context, in DeleteUserInput) erro
 		return err
 	}
 	if err := uc.resolver.Reload(); err != nil {
-		log.Printf(logReloadUserResolverCacheWarning, err)
+		uc.log.Warn("failed to reload user resolver cache", "error", err)
 	}
 	if err := uc.favorites.DeleteAllForUser(in.ID); err != nil {
 		uc.log.Warn("failed to delete favorites for deleted user", "userID", in.ID, "error", err)

--- a/internal/wiki/auth/use_cases_test.go
+++ b/internal/wiki/auth/use_cases_test.go
@@ -2,13 +2,78 @@ package auth
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/pquerna/otp/totp"
 
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	"github.com/perber/wiki/internal/favorites"
+	httpmetrics "github.com/perber/wiki/internal/http/metrics"
 )
+
+func metricsBody(t *testing.T, metrics *httpmetrics.HTTPMetrics) string {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	metrics.HTTPHandler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected metrics endpoint to return 200, got %d", rec.Code)
+	}
+	return rec.Body.String()
+}
+
+// testTOTPEncryptionKey is a throwaway 32-byte key for TOTPService in tests —
+// it never needs to match production, only to satisfy NewTOTPService's
+// minimum-length requirement.
+const testTOTPEncryptionKey = "test-totp-encryption-key-32byte!"
+
+// setupAuthUseCases builds a real AuthService (backed by temp-dir SQLite
+// stores, matching internal/core/auth's own test fixtures) together with a
+// fresh metrics registry, for exercising the wiki-layer use cases end to end.
+func setupAuthUseCases(t *testing.T, withTOTP bool) (*coreauth.AuthService, *coreauth.UserService, *httpmetrics.HTTPMetrics) {
+	t.Helper()
+
+	userStore, err := coreauth.NewUserStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewUserStore: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := userStore.Close(); err != nil {
+			t.Errorf("Close user store: %v", err)
+		}
+	})
+	userSvc := coreauth.NewUserService(userStore)
+
+	sessionStore, err := coreauth.NewSessionStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewSessionStore: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := sessionStore.Close(); err != nil {
+			t.Errorf("Close session store: %v", err)
+		}
+	})
+	sessions := coreauth.NewSessionManager(sessionStore, "test-secret-key-for-unit-tests-1", time.Hour, 24*time.Hour*7)
+
+	var totpSvc *coreauth.TOTPService
+	if withTOTP {
+		totpSvc, err = coreauth.NewTOTPService([]byte(testTOTPEncryptionKey))
+		if err != nil {
+			t.Fatalf("NewTOTPService: %v", err)
+		}
+	}
+
+	authSvc := coreauth.NewAuthService(userSvc, sessions, totpSvc)
+	return authSvc, userSvc, httpmetrics.NewHTTPMetrics()
+}
 
 func setupUpdateUserUseCase(t *testing.T) (*UpdateUserUseCase, *coreauth.UserService) {
 	t.Helper()
@@ -210,11 +275,143 @@ func TestUpdateUser_AdminInvalidRole(t *testing.T) {
 	}
 }
 
+// TestLoginUseCase_EmitsSuccessMetric verifies that a successful password
+// login (no TOTP) records both the login-attempt outcome and the
+// session-issued event.
+func TestLoginUseCase_EmitsSuccessMetric(t *testing.T) {
+	authSvc, userSvc, metrics := setupAuthUseCases(t, false)
+	if _, err := userSvc.CreateUser("alice", "alice@example.com", "securepass", coreauth.RoleViewer); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	uc := NewLoginUseCase(authSvc, metrics)
+	if _, err := uc.Execute(context.Background(), LoginInput{Identifier: "alice", Password: "securepass"}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	body := metricsBody(t, metrics)
+	if !strings.Contains(body, `leafwiki_auth_login_attempts_total{outcome="success"} 1`) {
+		t.Fatalf("expected login success metric, got: %s", body)
+	}
+	if !strings.Contains(body, `leafwiki_auth_sessions_total{event="issued"} 1`) {
+		t.Fatalf("expected session issued metric, got: %s", body)
+	}
+}
+
+// TestLoginUseCase_EmitsLockedMetric verifies that once the per-user failure
+// threshold trips, a subsequent attempt is recorded under outcome="locked"
+// (distinct from the "invalid_credentials" outcome of the failures that
+// triggered the lock itself — see loginAttemptTracker.recordAttempt).
+func TestLoginUseCase_EmitsLockedMetric(t *testing.T) {
+	authSvc, userSvc, metrics := setupAuthUseCases(t, false)
+	if _, err := userSvc.CreateUser("alice", "alice@example.com", "securepass", coreauth.RoleViewer); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	uc := NewLoginUseCase(authSvc, metrics)
+	const maxFailures = 5
+	for i := 0; i < maxFailures; i++ {
+		if _, err := uc.Execute(context.Background(), LoginInput{Identifier: "alice", Password: "wrong"}); err == nil {
+			t.Fatalf("attempt %d: expected an error for wrong password", i)
+		}
+	}
+
+	_, err := uc.Execute(context.Background(), LoginInput{Identifier: "alice", Password: "wrong"})
+	if !errors.Is(err, coreauth.ErrUserAccountLocked) {
+		t.Fatalf("expected ErrUserAccountLocked once locked, got: %v", err)
+	}
+
+	body := metricsBody(t, metrics)
+	if !strings.Contains(body, `leafwiki_auth_login_attempts_total{outcome="locked"} 1`) {
+		t.Fatalf("expected locked outcome metric, got: %s", body)
+	}
+	if !strings.Contains(body, `leafwiki_auth_login_attempts_total{outcome="invalid_credentials"} 5`) {
+		t.Fatalf("expected 5 invalid_credentials attempts before the lock, got: %s", body)
+	}
+}
+
+// TestLogoutUseCase_EmitsSessionRevokedMetric verifies a normal logout after a
+// successful login records the session as revoked.
+func TestLogoutUseCase_EmitsSessionRevokedMetric(t *testing.T) {
+	authSvc, userSvc, metrics := setupAuthUseCases(t, false)
+	if _, err := userSvc.CreateUser("alice", "alice@example.com", "securepass", coreauth.RoleViewer); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	loginUC := NewLoginUseCase(authSvc, metrics)
+	out, err := loginUC.Execute(context.Background(), LoginInput{Identifier: "alice", Password: "securepass"})
+	if err != nil {
+		t.Fatalf("Login Execute: %v", err)
+	}
+
+	logoutUC := NewLogoutUseCase(authSvc, metrics)
+	if err := logoutUC.Execute(context.Background(), LogoutInput{RefreshToken: out.Token.RefreshToken}); err != nil {
+		t.Fatalf("Logout Execute: %v", err)
+	}
+
+	body := metricsBody(t, metrics)
+	if !strings.Contains(body, `leafwiki_auth_sessions_total{event="revoked"} 1`) {
+		t.Fatalf("expected session revoked metric, got: %s", body)
+	}
+}
+
+// TestCompleteTOTPLoginUseCase_EmitsVerificationMetric verifies a successful
+// TOTP login handshake records both the verification outcome and the
+// resulting session-issued event.
+func TestCompleteTOTPLoginUseCase_EmitsVerificationMetric(t *testing.T) {
+	authSvc, userSvc, metrics := setupAuthUseCases(t, true)
+	user, err := userSvc.CreateUser("alice", "alice@example.com", "securepass", coreauth.RoleViewer)
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	generated, err := authSvc.StartTOTPSetup(user.ID, "securepass")
+	if err != nil {
+		t.Fatalf("StartTOTPSetup: %v", err)
+	}
+	setupCode, err := totp.GenerateCode(generated.Secret, time.Now())
+	if err != nil {
+		t.Fatalf("GenerateCode: %v", err)
+	}
+	if _, err := authSvc.ConfirmTOTPSetup(user.ID, setupCode, ""); err != nil {
+		t.Fatalf("ConfirmTOTPSetup: %v", err)
+	}
+
+	loginUC := NewLoginUseCase(authSvc, metrics)
+	loginOut, err := loginUC.Execute(context.Background(), LoginInput{Identifier: "alice", Password: "securepass"})
+	if err != nil {
+		t.Fatalf("Login Execute: %v", err)
+	}
+	if !loginOut.Token.RequiresTOTP {
+		t.Fatal("expected RequiresTOTP = true once TOTP is enabled")
+	}
+
+	loginCode, err := totp.GenerateCode(generated.Secret, time.Now())
+	if err != nil {
+		t.Fatalf("GenerateCode: %v", err)
+	}
+	completeUC := NewCompleteTOTPLoginUseCase(authSvc, metrics)
+	if _, err := completeUC.Execute(context.Background(), CompleteTOTPLoginInput{
+		LoginChallengeToken: loginOut.Token.LoginChallengeToken,
+		Code:                loginCode,
+	}); err != nil {
+		t.Fatalf("CompleteTOTPLogin Execute: %v", err)
+	}
+
+	body := metricsBody(t, metrics)
+	if !strings.Contains(body, `leafwiki_auth_totp_verifications_total{result="success"} 1`) {
+		t.Fatalf("expected totp verification success metric, got: %s", body)
+	}
+	if !strings.Contains(body, `leafwiki_auth_sessions_total{event="issued"} 1`) {
+		t.Fatalf("expected session issued metric, got: %s", body)
+	}
+}
+
 // TestCompleteTOTPLoginUseCase_AuthDisabled verifies the use case refuses to
 // run (rather than nil-pointer-dereferencing into AuthService) when auth is
 // disabled, matching every other use case's ErrAuthDisabled guard.
 func TestCompleteTOTPLoginUseCase_AuthDisabled(t *testing.T) {
-	uc := NewCompleteTOTPLoginUseCase(nil)
+	uc := NewCompleteTOTPLoginUseCase(nil, nil)
 
 	_, err := uc.Execute(context.Background(), CompleteTOTPLoginInput{
 		LoginChallengeToken: "token",
@@ -232,14 +429,69 @@ func TestTOTPUseCases_AuthDisabled(t *testing.T) {
 	if _, err := NewStartTOTPSetupUseCase(nil).Execute(context.Background(), StartTOTPSetupInput{}); !errors.Is(err, ErrAuthDisabled) {
 		t.Fatalf("StartTOTPSetupUseCase: expected ErrAuthDisabled, got %v", err)
 	}
-	if _, err := NewConfirmTOTPSetupUseCase(nil).Execute(context.Background(), ConfirmTOTPSetupInput{}); !errors.Is(err, ErrAuthDisabled) {
+	if _, err := NewConfirmTOTPSetupUseCase(nil, nil).Execute(context.Background(), ConfirmTOTPSetupInput{}); !errors.Is(err, ErrAuthDisabled) {
 		t.Fatalf("ConfirmTOTPSetupUseCase: expected ErrAuthDisabled, got %v", err)
 	}
-	if err := NewDisableTOTPUseCase(nil).Execute(context.Background(), DisableTOTPInput{}); !errors.Is(err, ErrAuthDisabled) {
+	if err := NewDisableTOTPUseCase(nil, nil).Execute(context.Background(), DisableTOTPInput{}); !errors.Is(err, ErrAuthDisabled) {
 		t.Fatalf("DisableTOTPUseCase: expected ErrAuthDisabled, got %v", err)
 	}
 	if _, err := NewGetTOTPStatusUseCase(nil).Execute(context.Background(), GetTOTPStatusInput{}); !errors.Is(err, ErrAuthDisabled) {
 		t.Fatalf("GetTOTPStatusUseCase: expected ErrAuthDisabled, got %v", err)
+	}
+}
+
+// TestGetUsersUseCase_DoesNotExposeTOTPSecretOrRecoveryCodes verifies that the
+// admin user list only ever surfaces the TOTPEnabled flag: the encrypted TOTP
+// secret and recovery code hashes on the internal User must never reach the
+// PublicUser the admin API serializes to JSON.
+func TestGetUsersUseCase_DoesNotExposeTOTPSecretOrRecoveryCodes(t *testing.T) {
+	store, err := coreauth.NewUserStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewUserStore: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	})
+
+	userSvc := coreauth.NewUserService(store)
+	user, err := userSvc.CreateUser("alice", "alice@example.com", "pass", coreauth.RoleViewer)
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	const secretMarker = "super-secret-encrypted-totp-blob"
+	const hashMarker = "super-secret-recovery-code-hash"
+	if err := store.EnableTOTP(user.ID, secretMarker, []string{hashMarker}); err != nil {
+		t.Fatalf("EnableTOTP: %v", err)
+	}
+
+	uc := NewGetUsersUseCase(userSvc)
+	out, err := uc.Execute(context.Background())
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var found *coreauth.PublicUser
+	for _, u := range out.Users {
+		if u.ID == user.ID {
+			found = u
+		}
+	}
+	if found == nil {
+		t.Fatal("expected the created user to be present in GetUsers output")
+	}
+	if !found.TOTPEnabled {
+		t.Error("expected TOTPEnabled = true")
+	}
+
+	data, err := json.Marshal(found)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(data), secretMarker) || strings.Contains(string(data), hashMarker) {
+		t.Fatalf("PublicUser JSON leaked TOTP secret material: %s", data)
 	}
 }
 

--- a/internal/wiki/restore/routes_test.go
+++ b/internal/wiki/restore/routes_test.go
@@ -42,7 +42,8 @@ func newTestManager(t *testing.T) *restore.Manager {
 	if err != nil {
 		t.Fatalf("NewSessionStore failed: %v", err)
 	}
-	authService := coreauth.NewAuthService(coreauth.NewUserService(userStore), sessionStore, nil, "test-secret-key-for-unit-tests-1", time.Hour, 24*time.Hour)
+	sessions := coreauth.NewSessionManager(sessionStore, "test-secret-key-for-unit-tests-1", time.Hour, 24*time.Hour)
+	authService := coreauth.NewAuthService(coreauth.NewUserService(userStore), sessions, nil)
 	t.Cleanup(func() { _ = authService.Close() })
 
 	brandingService, err := branding.NewBrandingService(base)

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -221,7 +221,8 @@ func (w *Wiki) initAuth(options *WikiOptions) error {
 		if err != nil {
 			return err
 		}
-		w.auth = auth.NewAuthService(w.user, sessionStore, w.totp, options.JWTSecret, options.AccessTokenTimeout, options.RefreshTokenTimeout)
+		sessions := auth.NewSessionManager(sessionStore, options.JWTSecret, options.AccessTokenTimeout, options.RefreshTokenTimeout)
+		w.auth = auth.NewAuthService(w.user, sessions, w.totp)
 
 		// API keys are only meaningful when authentication is meaningful:
 		// key management is admin-only and RequireAdmin already hard-blocks

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -441,10 +441,10 @@ func (w *Wiki) buildPagesRoutes() *wikipages.Routes {
 
 func (w *Wiki) buildAuthRoutes() *wikiauth.Routes {
 	return wikiauth.NewRoutes(wikiauth.RoutesConfig{
-		Login:             wikiauth.NewLoginUseCase(w.auth),
-		CompleteTOTPLogin: wikiauth.NewCompleteTOTPLoginUseCase(w.auth),
-		Logout:            wikiauth.NewLogoutUseCase(w.auth),
-		RefreshToken:      wikiauth.NewRefreshTokenUseCase(w.auth),
+		Login:             wikiauth.NewLoginUseCase(w.auth, w.metrics),
+		CompleteTOTPLogin: wikiauth.NewCompleteTOTPLoginUseCase(w.auth, w.metrics),
+		Logout:            wikiauth.NewLogoutUseCase(w.auth, w.metrics),
+		RefreshToken:      wikiauth.NewRefreshTokenUseCase(w.auth, w.metrics),
 		CreateUser:        wikiauth.NewCreateUserUseCase(w.user, w.userResolver, w.log),
 		UpdateUser:        wikiauth.NewUpdateUserUseCase(w.user, w.userResolver, w.log),
 		ChangeOwnPassword: wikiauth.NewChangeOwnPasswordUseCase(w.user),
@@ -452,8 +452,8 @@ func (w *Wiki) buildAuthRoutes() *wikiauth.Routes {
 		GetUsers:          wikiauth.NewGetUsersUseCase(w.user),
 		GetUserByID:       wikiauth.NewGetUserByIDUseCase(w.user),
 		StartTOTPSetup:    wikiauth.NewStartTOTPSetupUseCase(w.auth),
-		ConfirmTOTPSetup:  wikiauth.NewConfirmTOTPSetupUseCase(w.auth),
-		DisableTOTP:       wikiauth.NewDisableTOTPUseCase(w.auth),
+		ConfirmTOTPSetup:  wikiauth.NewConfirmTOTPSetupUseCase(w.auth, w.metrics),
+		DisableTOTP:       wikiauth.NewDisableTOTPUseCase(w.auth, w.metrics),
 		GetTOTPStatus:     wikiauth.NewGetTOTPStatusUseCase(w.auth),
 		AuthService:       w.auth,
 	})

--- a/ui/leafwiki-ui/src/features/auth/LoginForm.test.tsx
+++ b/ui/leafwiki-ui/src/features/auth/LoginForm.test.tsx
@@ -1,0 +1,213 @@
+import '@/lib/i18n'
+import { useConfigStore } from '@/stores/config'
+import { useSessionStore } from '@/stores/session'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import LoginForm from './LoginForm'
+
+const loginMock = vi.fn()
+const completeTOTPLoginMock = vi.fn()
+
+vi.mock('@/lib/api/auth', () => ({
+  login: (...args: unknown[]) => loginMock(...args),
+  completeTOTPLogin: (...args: unknown[]) => completeTOTPLoginMock(...args),
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+import { toast } from 'sonner'
+
+const totpUser = {
+  id: 'user-1',
+  username: 'admin',
+  email: 'admin@example.com',
+  role: 'admin' as const,
+  totpEnabled: true,
+}
+
+function renderLoginForm() {
+  return render(
+    <MemoryRouter initialEntries={['/login']}>
+      <Routes>
+        <Route path="/login" element={<LoginForm />} />
+        <Route path="/" element={<div>Home page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('LoginForm TOTP flow', () => {
+  beforeEach(() => {
+    loginMock.mockReset()
+    completeTOTPLoginMock.mockReset()
+    vi.mocked(toast.error).mockReset()
+    useConfigStore.setState({
+      authDisabled: false,
+      httpRemoteUserEnabled: false,
+    })
+    useSessionStore.setState({
+      user: null,
+      isRefreshing: false,
+      accessTokenExpiresAt: null,
+    })
+  })
+
+  it('shows the TOTP code step instead of logging in when the account requires TOTP', async () => {
+    loginMock.mockResolvedValue({
+      requiresTotp: true,
+      loginChallengeToken: 'challenge-token',
+    })
+
+    const user = userEvent.setup()
+    renderLoginForm()
+
+    await user.type(screen.getByTestId('login-identifier'), 'admin')
+    await user.type(screen.getByTestId('login-password'), 'correct-password')
+    await user.click(screen.getByTestId('login-submit'))
+
+    expect(await screen.findByTestId('login-totp-code')).toBeInTheDocument()
+    expect(screen.queryByTestId('login-identifier')).not.toBeInTheDocument()
+  })
+
+  it('completes login with a valid TOTP code and redirects', async () => {
+    loginMock.mockResolvedValue({
+      requiresTotp: true,
+      loginChallengeToken: 'challenge-token',
+    })
+    completeTOTPLoginMock.mockResolvedValue({
+      accessTokenExpiresAt: 1234567890,
+      message: 'ok',
+      user: totpUser,
+    })
+
+    const user = userEvent.setup()
+    renderLoginForm()
+
+    await user.type(screen.getByTestId('login-identifier'), 'admin')
+    await user.type(screen.getByTestId('login-password'), 'correct-password')
+    await user.click(screen.getByTestId('login-submit'))
+
+    await user.type(await screen.findByTestId('login-totp-code'), '123456')
+    await user.click(screen.getByTestId('login-totp-submit'))
+
+    await screen.findByText('Home page')
+    expect(completeTOTPLoginMock).toHaveBeenCalledWith(
+      'challenge-token',
+      '123456',
+    )
+  })
+
+  it('accepts a recovery code in the same field as a TOTP code', async () => {
+    loginMock.mockResolvedValue({
+      requiresTotp: true,
+      loginChallengeToken: 'challenge-token',
+    })
+    completeTOTPLoginMock.mockResolvedValue({
+      accessTokenExpiresAt: 1234567890,
+      message: 'ok',
+      user: totpUser,
+    })
+
+    const user = userEvent.setup()
+    renderLoginForm()
+
+    await user.type(screen.getByTestId('login-identifier'), 'admin')
+    await user.type(screen.getByTestId('login-password'), 'correct-password')
+    await user.click(screen.getByTestId('login-submit'))
+
+    await user.type(await screen.findByTestId('login-totp-code'), 'AB12-CD34')
+    await user.click(screen.getByTestId('login-totp-submit'))
+
+    await screen.findByText('Home page')
+    expect(completeTOTPLoginMock).toHaveBeenCalledWith(
+      'challenge-token',
+      'AB12-CD34',
+    )
+  })
+
+  it('shows an error and clears the code field when the TOTP code is rejected', async () => {
+    loginMock.mockResolvedValue({
+      requiresTotp: true,
+      loginChallengeToken: 'challenge-token',
+    })
+    completeTOTPLoginMock.mockRejectedValue(new Error('invalid code'))
+
+    const user = userEvent.setup()
+    renderLoginForm()
+
+    await user.type(screen.getByTestId('login-identifier'), 'admin')
+    await user.type(screen.getByTestId('login-password'), 'correct-password')
+    await user.click(screen.getByTestId('login-submit'))
+
+    const codeInput = await screen.findByTestId('login-totp-code')
+    await user.type(codeInput, '000000')
+    await user.click(screen.getByTestId('login-totp-submit'))
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled())
+    expect(codeInput).toHaveValue('')
+    // Still on the TOTP step, not redirected.
+    expect(screen.queryByText('Home page')).not.toBeInTheDocument()
+  })
+
+  it('returns to the password step on "back", clearing the code but keeping the typed password', async () => {
+    loginMock.mockResolvedValue({
+      requiresTotp: true,
+      loginChallengeToken: 'challenge-token',
+    })
+
+    const user = userEvent.setup()
+    renderLoginForm()
+
+    await user.type(screen.getByTestId('login-identifier'), 'admin')
+    await user.type(screen.getByTestId('login-password'), 'correct-password')
+    await user.click(screen.getByTestId('login-submit'))
+
+    await screen.findByTestId('login-totp-code')
+    await user.click(screen.getByRole('button', { name: 'Back' }))
+
+    const passwordInput = await screen.findByTestId('login-password')
+    // The password field is not cleared on "back" — resubmitting re-uses
+    // the previously typed value without requiring it to be retyped.
+    expect(passwordInput).toHaveValue('correct-password')
+    expect(screen.queryByTestId('login-totp-code')).not.toBeInTheDocument()
+  })
+
+  it('preserves redirectTo across both login steps', async () => {
+    loginMock.mockResolvedValue({
+      requiresTotp: true,
+      loginChallengeToken: 'challenge-token',
+    })
+    completeTOTPLoginMock.mockResolvedValue({
+      accessTokenExpiresAt: 1234567890,
+      message: 'ok',
+      user: totpUser,
+    })
+
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter
+        initialEntries={[
+          { pathname: '/login', state: { redirectTo: '/some/page' } },
+        ]}
+      >
+        <Routes>
+          <Route path="/login" element={<LoginForm />} />
+          <Route path="/some/page" element={<div>Requested page</div>} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await user.type(screen.getByTestId('login-identifier'), 'admin')
+    await user.type(screen.getByTestId('login-password'), 'correct-password')
+    await user.click(screen.getByTestId('login-submit'))
+
+    await user.type(await screen.findByTestId('login-totp-code'), '123456')
+    await user.click(screen.getByTestId('login-totp-submit'))
+
+    await screen.findByText('Requested page')
+  })
+})

--- a/ui/leafwiki-ui/src/features/preview/TocSidePanel.test.tsx
+++ b/ui/leafwiki-ui/src/features/preview/TocSidePanel.test.tsx
@@ -85,6 +85,14 @@ describe('TocSidePanel — rendering', () => {
     )
   })
 
+  it('sets the full entry text as a title attribute for hover tooltips', () => {
+    render(<TocSidePanel entries={entries} />)
+    expect(screen.getByTestId('toc-entry-background')).toHaveAttribute(
+      'title',
+      'Background',
+    )
+  })
+
   it('does not register scroll listener when entries is empty', () => {
     const spy = vi.spyOn(scrollContainer, 'addEventListener')
     render(<TocSidePanel entries={[]} />)

--- a/ui/leafwiki-ui/src/features/preview/TocSidePanel.tsx
+++ b/ui/leafwiki-ui/src/features/preview/TocSidePanel.tsx
@@ -89,6 +89,7 @@ export function TocSidePanel({ entries, activeId: externalActiveId }: Props) {
                   waitForStableLayout: false,
                 })
               }
+              title={entry.text}
               data-testid={`toc-entry-${entry.id}`}
               tabIndex={collapsed ? -1 : 0}
             >

--- a/ui/leafwiki-ui/src/features/users/TOTPDisableDialog.test.tsx
+++ b/ui/leafwiki-ui/src/features/users/TOTPDisableDialog.test.tsx
@@ -1,0 +1,152 @@
+import '@/lib/i18n'
+import { DIALOG_TOTP_DISABLE } from '@/lib/registries'
+import { useDialogsStore } from '@/stores/dialogs'
+import { useSessionStore } from '@/stores/session'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TOTPDisableDialog } from './TOTPDisableDialog'
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+vi.mock('@/lib/api/totp', () => ({
+  startTOTPSetup: vi.fn(),
+  confirmTOTPSetup: vi.fn(),
+  disableTOTP: vi.fn(),
+  getTOTPStatus: vi.fn(),
+}))
+
+import { toast } from 'sonner'
+import * as totpAPI from '@/lib/api/totp'
+
+const sessionUser = {
+  id: 'user-1',
+  username: 'admin',
+  email: 'admin@example.com',
+  role: 'admin' as const,
+  totpEnabled: true,
+}
+
+describe('TOTPDisableDialog', () => {
+  beforeEach(() => {
+    useDialogsStore.setState({
+      dialogType: DIALOG_TOTP_DISABLE,
+      dialogProps: null,
+    })
+    useSessionStore.setState({
+      user: sessionUser,
+      isRefreshing: false,
+      accessTokenExpiresAt: null,
+    })
+    vi.clearAllMocks()
+  })
+
+  it('disables TOTP with a valid password and code, closing the dialog', async () => {
+    const user = userEvent.setup()
+    ;(totpAPI.disableTOTP as ReturnType<typeof vi.fn>).mockResolvedValue(
+      undefined,
+    )
+
+    render(<TOTPDisableDialog />)
+
+    await user.type(
+      screen.getByTestId('totp-disable-password'),
+      'current-password',
+    )
+    await user.type(screen.getByTestId('totp-disable-code'), '123456')
+    await user.click(screen.getByTestId('totp-disable-dialog-button-confirm'))
+
+    await waitFor(() =>
+      expect(totpAPI.disableTOTP).toHaveBeenCalledWith(
+        'current-password',
+        '123456',
+      ),
+    )
+    expect(useSessionStore.getState().user?.totpEnabled).toBe(false)
+    expect(toast.success).toHaveBeenCalled()
+  })
+
+  it('accepts a recovery code in place of a TOTP code', async () => {
+    const user = userEvent.setup()
+    ;(totpAPI.disableTOTP as ReturnType<typeof vi.fn>).mockResolvedValue(
+      undefined,
+    )
+
+    render(<TOTPDisableDialog />)
+
+    await user.type(
+      screen.getByTestId('totp-disable-password'),
+      'current-password',
+    )
+    await user.type(screen.getByTestId('totp-disable-code'), 'AB12-CD34')
+    await user.click(screen.getByTestId('totp-disable-dialog-button-confirm'))
+
+    await waitFor(() =>
+      expect(totpAPI.disableTOTP).toHaveBeenCalledWith(
+        'current-password',
+        'AB12-CD34',
+      ),
+    )
+  })
+
+  it('clears both fields and shows the same error on both when the password is wrong', async () => {
+    const user = userEvent.setup()
+    ;(totpAPI.disableTOTP as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('wrong password'),
+    )
+
+    render(<TOTPDisableDialog />)
+
+    const passwordInput = screen.getByTestId('totp-disable-password')
+    const codeInput = screen.getByTestId('totp-disable-code')
+    await user.type(passwordInput, 'wrong-password')
+    await user.type(codeInput, '123456')
+    await user.click(screen.getByTestId('totp-disable-dialog-button-confirm'))
+
+    await waitFor(() => expect(totpAPI.disableTOTP).toHaveBeenCalled())
+    expect(passwordInput).toHaveValue('')
+    expect(codeInput).toHaveValue('')
+    expect(useSessionStore.getState().user?.totpEnabled).toBe(true)
+  })
+
+  it('clears both fields when the code is wrong, keeping TOTP enabled', async () => {
+    const user = userEvent.setup()
+    ;(totpAPI.disableTOTP as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('wrong code'),
+    )
+
+    render(<TOTPDisableDialog />)
+
+    const passwordInput = screen.getByTestId('totp-disable-password')
+    const codeInput = screen.getByTestId('totp-disable-code')
+    await user.type(passwordInput, 'current-password')
+    await user.type(codeInput, '000000')
+    await user.click(screen.getByTestId('totp-disable-dialog-button-confirm'))
+
+    await waitFor(() => expect(totpAPI.disableTOTP).toHaveBeenCalled())
+    expect(passwordInput).toHaveValue('')
+    expect(codeInput).toHaveValue('')
+    expect(useSessionStore.getState().user?.totpEnabled).toBe(true)
+  })
+
+  it('disables the confirm button until both password and code are filled in', async () => {
+    const user = userEvent.setup()
+    render(<TOTPDisableDialog />)
+
+    expect(
+      screen.getByTestId('totp-disable-dialog-button-confirm'),
+    ).toBeDisabled()
+
+    await user.type(screen.getByTestId('totp-disable-password'), 'pw')
+    expect(
+      screen.getByTestId('totp-disable-dialog-button-confirm'),
+    ).toBeDisabled()
+
+    await user.type(screen.getByTestId('totp-disable-code'), '123456')
+    expect(
+      screen.getByTestId('totp-disable-dialog-button-confirm'),
+    ).not.toBeDisabled()
+  })
+})

--- a/ui/leafwiki-ui/src/features/users/TOTPSetupDialog.test.tsx
+++ b/ui/leafwiki-ui/src/features/users/TOTPSetupDialog.test.tsx
@@ -1,0 +1,172 @@
+import '@/lib/i18n'
+import { DIALOG_TOTP_SETUP } from '@/lib/registries'
+import { useDialogsStore } from '@/stores/dialogs'
+import { useSessionStore } from '@/stores/session'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TOTPSetupDialog } from './TOTPSetupDialog'
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+vi.mock('@/lib/api/totp', () => ({
+  startTOTPSetup: vi.fn(),
+  confirmTOTPSetup: vi.fn(),
+  disableTOTP: vi.fn(),
+  getTOTPStatus: vi.fn(),
+}))
+
+// qrcode.react renders an actual <canvas>/<svg> via a library that isn't
+// relevant to this component's behavior; stub it to keep the test focused.
+vi.mock('qrcode.react', () => ({
+  QRCodeSVG: () => <div data-testid="totp-setup-qr" />,
+}))
+
+import { toast } from 'sonner'
+import * as totpAPI from '@/lib/api/totp'
+
+const sessionUser = {
+  id: 'user-1',
+  username: 'admin',
+  email: 'admin@example.com',
+  role: 'admin' as const,
+  totpEnabled: false,
+}
+
+describe('TOTPSetupDialog', () => {
+  beforeEach(() => {
+    useDialogsStore.setState({
+      dialogType: DIALOG_TOTP_SETUP,
+      dialogProps: null,
+    })
+    useSessionStore.setState({
+      user: sessionUser,
+      isRefreshing: false,
+      accessTokenExpiresAt: null,
+    })
+    vi.clearAllMocks()
+  })
+
+  it('walks through password, verify and recovery steps, then enables TOTP', async () => {
+    const user = userEvent.setup()
+    ;(totpAPI.startTOTPSetup as ReturnType<typeof vi.fn>).mockResolvedValue({
+      secret: 'JBSWY3DPEHPK3PXP',
+      otpAuthUrl: 'otpauth://totp/LeafWiki:admin?secret=JBSWY3DPEHPK3PXP',
+    })
+    ;(totpAPI.confirmTOTPSetup as ReturnType<typeof vi.fn>).mockResolvedValue({
+      recoveryCodes: ['AB12-CD34', 'EF56-GH78'],
+    })
+
+    render(<TOTPSetupDialog />)
+
+    await user.type(
+      screen.getByTestId('totp-setup-password'),
+      'current-password',
+    )
+    await user.click(screen.getByTestId('totp-setup-dialog-button-confirm'))
+
+    await waitFor(() =>
+      expect(totpAPI.startTOTPSetup).toHaveBeenCalledWith('current-password'),
+    )
+    expect(
+      await screen.findByTestId('totp-setup-manual-key'),
+    ).toHaveTextContent('JBSWY3DPEHPK3PXP')
+
+    await user.type(screen.getByTestId('totp-setup-code'), '654321')
+    await user.click(screen.getByTestId('totp-setup-dialog-button-confirm'))
+
+    await waitFor(() =>
+      expect(totpAPI.confirmTOTPSetup).toHaveBeenCalledWith('654321'),
+    )
+    expect(
+      await screen.findByTestId('totp-setup-recovery-codes'),
+    ).toHaveTextContent('AB12-CD34')
+    expect(useSessionStore.getState().user?.totpEnabled).toBe(true)
+    expect(toast.success).toHaveBeenCalled()
+
+    // Dialog closes on "Done" without another API call.
+    await user.click(screen.getByTestId('totp-setup-dialog-button-confirm'))
+    expect(totpAPI.startTOTPSetup).toHaveBeenCalledTimes(1)
+    expect(totpAPI.confirmTOTPSetup).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows a field error and clears the password on a wrong password, staying on step 1', async () => {
+    const user = userEvent.setup()
+    ;(totpAPI.startTOTPSetup as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('wrong password'),
+    )
+
+    render(<TOTPSetupDialog />)
+
+    const passwordInput = screen.getByTestId('totp-setup-password')
+    await user.type(passwordInput, 'wrong-password')
+    await user.click(screen.getByTestId('totp-setup-dialog-button-confirm'))
+
+    await waitFor(() => expect(totpAPI.startTOTPSetup).toHaveBeenCalled())
+    expect(passwordInput).toHaveValue('')
+    expect(
+      screen.queryByTestId('totp-setup-manual-key'),
+    ).not.toBeInTheDocument()
+    expect(useSessionStore.getState().user?.totpEnabled).toBe(false)
+  })
+
+  it('shows a field error and clears the code on a wrong verification code, staying on step 2', async () => {
+    const user = userEvent.setup()
+    ;(totpAPI.startTOTPSetup as ReturnType<typeof vi.fn>).mockResolvedValue({
+      secret: 'JBSWY3DPEHPK3PXP',
+      otpAuthUrl: 'otpauth://totp/LeafWiki:admin?secret=JBSWY3DPEHPK3PXP',
+    })
+    ;(totpAPI.confirmTOTPSetup as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('wrong code'),
+    )
+
+    render(<TOTPSetupDialog />)
+
+    await user.type(
+      screen.getByTestId('totp-setup-password'),
+      'current-password',
+    )
+    await user.click(screen.getByTestId('totp-setup-dialog-button-confirm'))
+    await screen.findByTestId('totp-setup-manual-key')
+
+    const codeInput = screen.getByTestId('totp-setup-code')
+    await user.type(codeInput, '000000')
+    await user.click(screen.getByTestId('totp-setup-dialog-button-confirm'))
+
+    await waitFor(() => expect(totpAPI.confirmTOTPSetup).toHaveBeenCalled())
+    expect(codeInput).toHaveValue('')
+    expect(
+      screen.queryByTestId('totp-setup-recovery-codes'),
+    ).not.toBeInTheDocument()
+    expect(useSessionStore.getState().user?.totpEnabled).toBe(false)
+  })
+
+  it('disables the confirm button until the current step has the required input', async () => {
+    const user = userEvent.setup()
+    ;(totpAPI.startTOTPSetup as ReturnType<typeof vi.fn>).mockResolvedValue({
+      secret: 'JBSWY3DPEHPK3PXP',
+      otpAuthUrl: 'otpauth://totp/LeafWiki:admin?secret=JBSWY3DPEHPK3PXP',
+    })
+
+    render(<TOTPSetupDialog />)
+
+    expect(
+      screen.getByTestId('totp-setup-dialog-button-confirm'),
+    ).toBeDisabled()
+    await user.type(
+      screen.getByTestId('totp-setup-password'),
+      'current-password',
+    )
+    expect(
+      screen.getByTestId('totp-setup-dialog-button-confirm'),
+    ).not.toBeDisabled()
+
+    await user.click(screen.getByTestId('totp-setup-dialog-button-confirm'))
+    await screen.findByTestId('totp-setup-manual-key')
+    expect(
+      screen.getByTestId('totp-setup-dialog-button-confirm'),
+    ).toBeDisabled()
+  })
+})

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -1771,7 +1771,7 @@
      lines as the pane narrows during the collapse transition, which reads as
      jumbled reflow rather than a clean shrink. */
   .page-viewer__toc-panel-entry {
-    @apply text-interface-text/70 hover:text-interface-text block w-full cursor-pointer overflow-hidden py-0.5 text-left text-sm leading-snug text-ellipsis whitespace-nowrap transition-colors;
+    @apply text-interface-text/70 hover:text-interface-text block w-full cursor-pointer overflow-hidden py-0.5 pr-3 text-left text-sm leading-snug text-ellipsis whitespace-nowrap transition-colors;
     background: none;
     border: none;
   }


### PR DESCRIPTION
Splits JWT/session issuance, refresh, revocation, and validation out of AuthService into a standalone SessionManager, leaving AuthService with just local password + TOTP verification. AuthService's public API is unchanged (RefreshToken/RevokeRefreshToken/RevokeAllUserSessions/ ValidateToken now delegate to sessions), so no caller outside internal/core/auth needed to change.

