### PR TITLE
fix(markdown): recover unquoted colon in leafwiki_* frontmatter fields

### DIFF
--- a/internal/core/markdown/frontmatter.go
+++ b/internal/core/markdown/frontmatter.go
@@ -28,26 +28,41 @@ type Frontmatter struct {
 	LeafWikiLastAuthorID string                 `yaml:"leafwiki_last_author_id,omitempty" json:"lastAuthorId,omitempty"`
 	LeafWikiPinned       bool                   `yaml:"leafwiki_pinned,omitempty" json:"pinned,omitempty"`
 	ExtraFields          map[string]interface{} `yaml:"-" json:"-"`
+
+	// repaired records whether parsing this frontmatter block required the
+	// sanitize-and-retry fallback (see sanitizeFrontmatterYAML): the file's
+	// raw frontmatter didn't parse as-is and had to be patched in memory.
+	repaired bool
+}
+
+// WasRepaired reports whether this frontmatter was recovered via the
+// sanitize-and-retry fallback rather than parsing cleanly on the first
+// attempt. Callers with a logger (e.g. tree reconstruction) can use this to
+// surface a warning that a file's frontmatter needed automatic repair.
+func (fm Frontmatter) WasRepaired() bool {
+	return fm.repaired
 }
 
 var unquotedTemplatePlaceholderLine = regexp.MustCompile(`^(\s*[^:\n]+:\s*)(\{\{[^}\n]+\}\})(\s*(?:#.*)?)$`)
 
 func parseFrontmatterYAML(yamlPart string) (Frontmatter, error) {
 	var raw map[string]interface{}
+	repaired := false
 	if err := yaml.Unmarshal([]byte(yamlPart), &raw); err != nil {
-		sanitized, changed := sanitizeTemplatePlaceholderFrontmatter(yamlPart)
+		sanitized, changed := sanitizeFrontmatterYAML(yamlPart)
 		if !changed {
 			return Frontmatter{}, errors.Join(ErrFrontmatterParse, err)
 		}
 		if retryErr := yaml.Unmarshal([]byte(sanitized), &raw); retryErr != nil {
 			return Frontmatter{}, errors.Join(ErrFrontmatterParse, err)
 		}
+		repaired = true
 	}
 	if raw == nil {
 		raw = map[string]interface{}{}
 	}
 
-	fm := Frontmatter{ExtraFields: map[string]interface{}{}}
+	fm := Frontmatter{ExtraFields: map[string]interface{}{}, repaired: repaired}
 
 	if value, ok := raw["leafwiki_id"]; ok {
 		fm.LeafWikiID = fm.stripSingleAndDoubleQuotes(strings.TrimSpace(valueToString(value)))
@@ -92,21 +107,137 @@ func parseFrontmatterYAML(yamlPart string) (Frontmatter, error) {
 	return fm, nil
 }
 
-func sanitizeTemplatePlaceholderFrontmatter(yamlPart string) (string, bool) {
+// sanitizeLines rewrites yamlPart one line at a time via fn, which returns
+// the replacement line and whether it changed anything. Shared scaffolding
+// for the frontmatter recovery fixups below, which otherwise differ only in
+// their per-line match/replace logic.
+func sanitizeLines(yamlPart string, fn func(line string) (string, bool)) (string, bool) {
 	lines := strings.Split(yamlPart, "\n")
 	changed := false
 
 	for i, line := range lines {
-		matches := unquotedTemplatePlaceholderLine.FindStringSubmatch(line)
-		if matches == nil {
-			continue
+		if rewritten, ok := fn(line); ok {
+			lines[i] = rewritten
+			changed = true
 		}
-
-		lines[i] = matches[1] + strconv.Quote(matches[2]) + matches[3]
-		changed = true
 	}
 
 	return strings.Join(lines, "\n"), changed
+}
+
+func sanitizeTemplatePlaceholderFrontmatter(yamlPart string) (string, bool) {
+	return sanitizeLines(yamlPart, func(line string) (string, bool) {
+		matches := unquotedTemplatePlaceholderLine.FindStringSubmatch(line)
+		if matches == nil {
+			return "", false
+		}
+		return matches[1] + strconv.Quote(matches[2]) + matches[3], true
+	})
+}
+
+// knownLeafWikiStringFrontmatterKeys are the leafwiki_* keys that are always
+// plain string scalars. leafwiki_pinned is deliberately excluded: it's a
+// bool, and quoting "true"/"false" would break its type assertion.
+var knownLeafWikiStringFrontmatterKeys = []string{
+	"leafwiki_id",
+	"leafwiki_title",
+	"leafwiki_created_at",
+	"leafwiki_updated_at",
+	"leafwiki_creator_id",
+	"leafwiki_last_author_id",
+}
+
+// unquotedLeafWikiStringFieldLine matches a leafwiki_* string key together
+// with the rest of its line as a raw value. Anchored at column 0
+// (no leading \s*) deliberately: these keys always live at the top level of
+// the frontmatter map, so requiring zero indentation means this can never
+// match an indented continuation line inside an unrelated field's block
+// scalar (e.g. "notes: |") content, which would otherwise get corrupted.
+var unquotedLeafWikiStringFieldLine = regexp.MustCompile(
+	`^((?:` + strings.Join(knownLeafWikiStringFrontmatterKeys, "|") + `)\s*:\s*)(\S.*)$`,
+)
+
+// lineIsValidYAML reports whether a single "key: value" line parses on its
+// own as valid YAML.
+func lineIsValidYAML(line string) bool {
+	var probe map[string]interface{}
+	return yaml.Unmarshal([]byte(line), &probe) == nil
+}
+
+// sanitizeUnquotedColonInLeafWikiStringFields quotes leafwiki_* string field
+// values that don't parse as valid YAML on their own -- most commonly an
+// unquoted colon (e.g. "leafwiki_title: ADR-0001: Filesystem as Source of
+// Truth", which yaml.v3 otherwise misparses as a nested mapping key), but
+// also other YAML-hostile leading characters (a stray backtick or "@").
+// Scoped to known leafwiki_* keys only, since arbitrary user-defined
+// frontmatter keys may legitimately hold nested YAML. Values that look like
+// deliberate YAML constructs (flow-collections, anchors, aliases, tags,
+// block scalars, directives) are left alone regardless of validity, so a
+// malformed one keeps failing loudly instead of being silently coerced into
+// a string.
+//
+// Beyond that exclusion, validity is checked by actually parsing the
+// candidate line with yaml.v3, rather than a hand-maintained "does it look
+// already-quoted" heuristic. That means already-valid lines (properly
+// quoted, or simply unproblematic -- including a genuine "#" comment) are
+// always left untouched, while anything that truly fails to parse on its
+// own gets the same quote-and-retry treatment, regardless of
+// which specific character caused the failure.
+func sanitizeUnquotedColonInLeafWikiStringFields(yamlPart string) (string, bool) {
+	return sanitizeLines(yamlPart, func(line string) (string, bool) {
+		matches := unquotedLeafWikiStringFieldLine.FindStringSubmatch(line)
+		if matches == nil {
+			return "", false
+		}
+
+		prefix, value := matches[1], strings.TrimRight(matches[2], " \t")
+		if value == "" {
+			return "", false
+		}
+		// Leave flow-collection/anchor/alias/tag/block-scalar/directive-style
+		// values alone (e.g. "[...", "{...", "&anchor", "*alias", "!tag",
+		// "|block", ">folded", "%directive") -- those are deliberate YAML
+		// constructs, not a plain string that merely needs quoting. A
+		// malformed one (e.g. an unclosed "[..." list) should keep failing
+		// loudly rather than being silently coerced into a string. A leading
+		// "{{" is excepted: that's the template-placeholder syntax the
+		// sibling sanitizeTemplatePlaceholderFrontmatter fixup targets, not a
+		// single-brace YAML flow mapping, so it's safe (and necessary, for
+		// composite values like "{{date}}: draft") to let it fall through to
+		// the real-parse check below.
+		if strings.IndexByte("[&*!|>%", value[0]) >= 0 {
+			return "", false
+		}
+		if value[0] == '{' && !strings.HasPrefix(value, "{{") {
+			return "", false
+		}
+		if lineIsValidYAML(prefix + value) {
+			return "", false
+		}
+
+		return prefix + strconv.Quote(value), true
+	})
+}
+
+// sanitizeFrontmatterYAML chains the frontmatter recovery fixups, feeding
+// each one's output into the next. Safe to chain rather than retry
+// independently: sanitizeUnquotedColonInLeafWikiStringFields re-validates
+// each candidate line with the real YAML parser before touching it, so a
+// line the template-placeholder fixup already rewrote (and thus already
+// parses fine on its own) is correctly recognized as done and left alone --
+// this only ever runs after the initial yaml.Unmarshal has already failed.
+func sanitizeFrontmatterYAML(yamlPart string) (string, bool) {
+	out := yamlPart
+	changedAny := false
+
+	if sanitized, changed := sanitizeTemplatePlaceholderFrontmatter(out); changed {
+		out, changedAny = sanitized, true
+	}
+	if sanitized, changed := sanitizeUnquotedColonInLeafWikiStringFields(out); changed {
+		out, changedAny = sanitized, true
+	}
+
+	return out, changedAny
 }
 
 func valueToString(value interface{}) string {

--- a/internal/core/markdown/frontmatter_test.go
+++ b/internal/core/markdown/frontmatter_test.go
@@ -3,6 +3,7 @@ package markdown
 import (
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -270,6 +271,113 @@ func TestParseFrontmatter(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name:  "leafwiki_title with unquoted colon is auto-quoted and parses successfully",
+			input: "---\nleafwiki_id: abc123\nleafwiki_title: ADR-0001: Filesystem as Source of Truth\n---\nBody",
+			wantFM: Frontmatter{
+				LeafWikiID:    "abc123",
+				LeafWikiTitle: "ADR-0001: Filesystem as Source of Truth",
+			},
+			wantBody: "Body",
+			wantHas:  true,
+			wantErr:  false,
+		},
+		{
+			name:  "leafwiki_pinned bool is unaffected when leafwiki_title in the same file needs colon-quoting",
+			input: "---\nleafwiki_title: ADR-0001: Filesystem as Source of Truth\nleafwiki_pinned: true\n---\nBody",
+			wantFM: Frontmatter{
+				LeafWikiTitle:  "ADR-0001: Filesystem as Source of Truth",
+				LeafWikiPinned: true,
+			},
+			wantBody: "Body",
+			wantHas:  true,
+			wantErr:  false,
+		},
+		{
+			name:  "unquoted colon fixup and template placeholder fixup both apply in one document",
+			input: "---\nleafwiki_title: ADR-0001: Filesystem as Source of Truth\nDatum: {{date}}\n---\nBody",
+			wantFM: Frontmatter{
+				LeafWikiTitle: "ADR-0001: Filesystem as Source of Truth",
+				ExtraFields: map[string]interface{}{
+					"Datum": "{{date}}",
+				},
+			},
+			wantBody: "Body",
+			wantHas:  true,
+			wantErr:  false,
+		},
+		{
+			name:        "unquoted colon in arbitrary ExtraFields key remains a parse error (scope guard)",
+			input:       "---\nleafwiki_id: abc123\ncustom_note: Some: Value\n---\nBody",
+			wantFM:      Frontmatter{},
+			wantBody:    "---\nleafwiki_id: abc123\ncustom_note: Some: Value\n---\nBody",
+			wantHas:     true,
+			wantErr:     true,
+			wantErrType: ErrFrontmatterParse,
+		},
+		{
+			name:  "leafwiki_title with a quoted substring followed by more unquoted colon text is fixed",
+			input: "---\nleafwiki_title: \"Start\" middle: end\"\n---\nBody",
+			wantFM: Frontmatter{
+				LeafWikiTitle: "Start\" middle: end",
+			},
+			wantBody: "Body",
+			wantHas:  true,
+			wantErr:  false,
+		},
+		{
+			name:  "leafwiki_title starting with a backtick is fixed",
+			input: "---\nleafwiki_title: `code`: an explanation\n---\nBody",
+			wantFM: Frontmatter{
+				LeafWikiTitle: "`code`: an explanation",
+			},
+			wantBody: "Body",
+			wantHas:  true,
+			wantErr:  false,
+		},
+		{
+			name:  "leafwiki_title starting with @ is fixed",
+			input: "---\nleafwiki_title: @mentions: how they work\n---\nBody",
+			wantFM: Frontmatter{
+				LeafWikiTitle: "@mentions: how they work",
+			},
+			wantBody: "Body",
+			wantHas:  true,
+			wantErr:  false,
+		},
+		{
+			name:  "an unrelated leafwiki_title YAML comment is not corrupted when another field needs colon-fixing",
+			input: "---\nleafwiki_id: something: else\nleafwiki_title: #comment: oops\n---\nBody",
+			wantFM: Frontmatter{
+				LeafWikiID: "something: else",
+			},
+			wantBody: "Body",
+			wantHas:  true,
+			wantErr:  false,
+		},
+		{
+			name:  "an indented line inside an unrelated block-scalar field is not corrupted by the colon fixup",
+			input: "---\nleafwiki_title: ADR-0001: Filesystem as Source of Truth\nnotes: |\n  Meeting notes.\n  leafwiki_title: v2: draft notes not real metadata\n---\nBody",
+			wantFM: Frontmatter{
+				LeafWikiTitle: "ADR-0001: Filesystem as Source of Truth",
+				ExtraFields: map[string]interface{}{
+					"notes": "Meeting notes.\nleafwiki_title: v2: draft notes not real metadata",
+				},
+			},
+			wantBody: "Body",
+			wantHas:  true,
+			wantErr:  false,
+		},
+		{
+			name:  "leafwiki_title with an unquoted template placeholder followed by more colon text is fixed",
+			input: "---\nleafwiki_title: {{date}}: draft\n---\nBody",
+			wantFM: Frontmatter{
+				LeafWikiTitle: "{{date}}: draft",
+			},
+			wantBody: "Body",
+			wantHas:  true,
+			wantErr:  false,
+		},
+		{
 			name:  "frontmatter with whitespace in values",
 			input: "---\nleafwiki_id: \"  abc123  \"\nleafwiki_title: \"  My Title  \"\n---\nBody",
 			wantFM: Frontmatter{
@@ -300,6 +408,10 @@ func TestParseFrontmatter(t *testing.T) {
 				t.Fatalf("has = %v, want %v", has, tt.wantHas)
 			}
 
+			// WasRepaired() is asserted separately (see
+			// TestParseFrontmatter_WasRepaired); this table only cares about
+			// the parsed field values, so ignore it for the DeepEqual here.
+			fm.repaired = false
 			if !reflect.DeepEqual(fm, tt.wantFM) {
 				t.Fatalf("frontmatter = %+v, want %+v", fm, tt.wantFM)
 			}
@@ -596,5 +708,68 @@ func TestFrontmatter_MetadataRoundtripRFC3339(t *testing.T) {
 	}
 	if !reflect.DeepEqual(fm, input) {
 		t.Fatalf("frontmatter changed: got %+v want %+v", fm, input)
+	}
+}
+
+func TestParseFrontmatter_WasRepaired(t *testing.T) {
+	t.Run("clean frontmatter is not marked as repaired", func(t *testing.T) {
+		fm, _, has, err := ParseFrontmatter("---\nleafwiki_id: abc123\nleafwiki_title: My Title\n---\nBody")
+		if err != nil || !has {
+			t.Fatalf("unexpected has=%v err=%v", has, err)
+		}
+		if fm.WasRepaired() {
+			t.Fatalf("expected WasRepaired() to be false for clean frontmatter")
+		}
+	})
+
+	t.Run("frontmatter needing the colon fixup is marked as repaired", func(t *testing.T) {
+		fm, _, has, err := ParseFrontmatter("---\nleafwiki_title: ADR-0001: Filesystem as Source of Truth\n---\nBody")
+		if err != nil || !has {
+			t.Fatalf("unexpected has=%v err=%v", has, err)
+		}
+		if !fm.WasRepaired() {
+			t.Fatalf("expected WasRepaired() to be true after the colon fixup ran")
+		}
+	})
+
+	t.Run("a genuine parse failure is not marked as repaired", func(t *testing.T) {
+		fm, _, has, err := ParseFrontmatter("---\nleafwiki_id: [invalid: yaml: structure\n---\nBody")
+		if err == nil || !has {
+			t.Fatalf("expected a parse error, got has=%v err=%v", has, err)
+		}
+		if fm.WasRepaired() {
+			t.Fatalf("expected WasRepaired() to be false on a zero-value Frontmatter from a failed parse")
+		}
+	})
+}
+
+// TestKnownLeafWikiStringFrontmatterKeys_MatchesFrontmatterStruct guards
+// against knownLeafWikiStringFrontmatterKeys silently drifting out of sync
+// with the Frontmatter struct: every string field with a "leafwiki_*" yaml
+// tag (other than the bool leafwiki_pinned) must appear in the whitelist, or
+// that field silently loses unquoted-colon recovery with no compiler error.
+func TestKnownLeafWikiStringFrontmatterKeys_MatchesFrontmatterStruct(t *testing.T) {
+	whitelisted := make(map[string]bool, len(knownLeafWikiStringFrontmatterKeys))
+	for _, key := range knownLeafWikiStringFrontmatterKeys {
+		whitelisted[key] = true
+	}
+
+	fmType := reflect.TypeOf(Frontmatter{})
+	for i := 0; i < fmType.NumField(); i++ {
+		field := fmType.Field(i)
+		if field.Type.Kind() != reflect.String {
+			continue
+		}
+		tag := field.Tag.Get("yaml")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		key := strings.Split(tag, ",")[0]
+		if !strings.HasPrefix(key, "leafwiki_") {
+			continue
+		}
+		if !whitelisted[key] {
+			t.Errorf("Frontmatter field %s (yaml key %q) is a leafwiki_* string field but missing from knownLeafWikiStringFrontmatterKeys", field.Name, key)
+		}
 	}
 }

--- a/internal/core/tree/node_store.go
+++ b/internal/core/tree/node_store.go
@@ -366,6 +366,9 @@ func (f *NodeStore) reconstructTreeRecursive(ctx context.Context, currentPath st
 					// fall back to default title and generated ID, but still add the section and recurse
 				} else {
 					fm := mdFile.GetFrontmatter()
+					if fm.WasRepaired() {
+						f.log.Warn("frontmatter did not parse as-is and was auto-repaired", "path", indexPath)
+					}
 					metadata = f.metadataFromFrontmatter(fm, reconstructNow, indexPath)
 					title, err = mdFile.GetTitle()
 					if err != nil {
@@ -442,6 +445,9 @@ func (f *NodeStore) reconstructTreeRecursive(ctx context.Context, currentPath st
 			continue
 		}
 		fm := mdFile.GetFrontmatter()
+		if fm.WasRepaired() {
+			f.log.Warn("frontmatter did not parse as-is and was auto-repaired", "path", filePath)
+		}
 		metadata = f.metadataFromFrontmatter(fm, reconstructNow, filePath)
 		title, err = mdFile.GetTitle()
 		if err != nil {

--- a/internal/core/tree/node_store_reconstruct_test.go
+++ b/internal/core/tree/node_store_reconstruct_test.go
@@ -799,3 +799,80 @@ func TestCreatePage_MultiLevelIgnore(t *testing.T) {
 		t.Fatalf("expected CreatePage to succeed for non-ignored notes: %v", err)
 	}
 }
+
+func TestNodeStore_ReconstructTreeFromFS_PageWithUnquotedColonInFrontmatterTitle_IsNotDropped(t *testing.T) {
+	tmp := t.TempDir()
+	store := NewNodeStore(tmp)
+
+	page := `---
+leafwiki_id: page-adr
+leafwiki_title: ADR-0001: Filesystem as Source of Truth
+---
+# ADR-0001`
+	mustWriteFile(t, filepath.Join(tmp, "root", "adr-0001.md"), page, 0o644)
+
+	tree, err := store.ReconstructTreeFromFS()
+	if err != nil {
+		t.Fatalf("ReconstructTreeFromFS: %v", err)
+	}
+
+	p := findChildBySlug(t, tree, "adr-0001")
+	if p.Title != "ADR-0001: Filesystem as Source of Truth" {
+		t.Fatalf("expected title %q, got %q", "ADR-0001: Filesystem as Source of Truth", p.Title)
+	}
+	if p.ID != "page-adr" {
+		t.Fatalf("expected ID page-adr, got %q", p.ID)
+	}
+}
+
+// TestNodeStore_ReconstructTreeFromFS_ColonFixupDoesNotCorruptUnrelatedBlockScalar
+// pins down a regression found in code review: the frontmatter colon-fixup
+// must not touch an unrelated block-scalar ("notes: |") field just because
+// one of its indented content lines happens to start with "leafwiki_title:"
+// after left-trim. The page is also missing leafwiki_created_at/updated_at,
+// so it goes through the writeback path (needsWriteback) on the same
+// resync -- if the fixup corrupted the in-memory ExtraFields, that
+// corruption would get permanently persisted back to the file on disk.
+func TestNodeStore_ReconstructTreeFromFS_ColonFixupDoesNotCorruptUnrelatedBlockScalar(t *testing.T) {
+	tmp := t.TempDir()
+	store := NewNodeStore(tmp)
+
+	filePath := filepath.Join(tmp, "root", "adr-0001.md")
+	page := `---
+leafwiki_id: page-adr
+leafwiki_title: ADR-0001: Filesystem as Source of Truth
+notes: |
+  Meeting notes.
+  leafwiki_title: v2: draft notes not real metadata
+---
+# ADR-0001`
+	mustWriteFile(t, filePath, page, 0o644)
+
+	tree, err := store.ReconstructTreeFromFS()
+	if err != nil {
+		t.Fatalf("ReconstructTreeFromFS: %v", err)
+	}
+
+	p := findChildBySlug(t, tree, "adr-0001")
+	if p.Title != "ADR-0001: Filesystem as Source of Truth" {
+		t.Fatalf("expected title %q, got %q", "ADR-0001: Filesystem as Source of Truth", p.Title)
+	}
+
+	mdFile, err := markdown.LoadMarkdownFile(filePath)
+	if err != nil {
+		t.Fatalf("LoadMarkdownFile after reconstruct: %v", err)
+	}
+	fm := mdFile.GetFrontmatter()
+	wantNotes := "Meeting notes.\nleafwiki_title: v2: draft notes not real metadata"
+	if got, _ := fm.ExtraFields["notes"].(string); got != wantNotes {
+		t.Fatalf("notes field was corrupted by the colon fixup and/or writeback: got %q, want %q", got, wantNotes)
+	}
+
+	raw, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("reading persisted file: %v", err)
+	}
+	if strings.Contains(string(raw), `\"`) {
+		t.Fatalf("on-disk file contains injected escape sequences from the colon fixup, notes field was corrupted on writeback:\n%s", raw)
+	}
+}


### PR DESCRIPTION
An externally-authored page whose leafwiki_title (or other leafwiki_* string field) contains an unquoted colon, e.g. "ADR-0001: Filesystem as Source of Truth", failed YAML frontmatter parsing entirely and was silently dropped from the tree during filesystem reconstruction.

parseFrontmatterYAML now falls back to a real-parse-validated sanitizer that quotes leafwiki_* values which don't parse on their own (unquoted colons, but also stray backticks/@ signs), while leaving genuine YAML constructs (flow-collections, anchors, block scalars) alone so malformed ones keep failing loudly. The sanitizer is anchored to column 0 so it can never reach into an unrelated field's indented block-scalar content.

Frontmatter now exposes WasRepaired(), and node_store logs a warning when a file's frontmatter needed this recovery, so auto-repair isn't silent.
