### PR TITLE
fix(toc): cap sticky side panel height so it stops overflowing the vi…

### DIFF
--- a/e2e/tests/page.spec.ts
+++ b/e2e/tests/page.spec.ts
@@ -1604,6 +1604,57 @@ Content.`;
     await expect(tocExpandButton).toBeHidden();
   });
 
+  test('toc side panel scrolls internally instead of overflowing the viewport when there are many headings', async ({
+    page,
+  }) => {
+    const timestamp = Date.now();
+    const slug = `toc-many-headings-${timestamp}`;
+    const title = `Toc Many Headings ${timestamp}`;
+    const headingCount = 40;
+    const sections = Array.from(
+      { length: headingCount },
+      (_, index) => `## Section ${index + 1}\n\nContent ${index + 1}.`,
+    ).join('\n\n');
+    const content = `# Intro\n\nIntro text.\n\n${sections}`;
+
+    await createPageWithContent(page, { title, slug, content });
+
+    const viewPage = new ViewPage(page);
+    await viewPage.goto(`/${slug}`);
+
+    const tocPane = page.locator('.app-layout__toc-pane');
+    const tocList = page.getByTestId('toc-side-panel-list');
+    await expect(tocList).toBeVisible();
+
+    // Sanity check: with this many headings, the list's natural (unclipped)
+    // height genuinely exceeds the space available to it — otherwise the
+    // assertions below wouldn't be testing anything.
+    const { scrollHeight, clientHeight } = await tocList.evaluate((el) => ({
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    }));
+    expect(scrollHeight).toBeGreaterThan(clientHeight);
+
+    // The sticky panel itself must stay within the viewport rather than
+    // growing past the bottom of the window.
+    const viewportSize = page.viewportSize();
+    const paneBox = await tocPane.boundingBox();
+    expect(paneBox).not.toBeNull();
+    expect(paneBox!.y + paneBox!.height).toBeLessThanOrEqual(viewportSize!.height + 1);
+
+    // The last entry starts out of view, but is reachable by scrolling the
+    // list itself — not stranded below the fold with no way to reach it.
+    const lastEntry = page.getByTestId(`toc-entry-section-${headingCount}`);
+    await expect(lastEntry).toBeAttached();
+    await expect(lastEntry).not.toBeInViewport();
+
+    await tocList.evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+
+    await expect(lastEntry).toBeInViewport();
+  });
+
   test('navigating away from page with footnote headline stays responsive', async ({ page }) => {
     const timestamp = Date.now();
     const slug = `footnotes-navigation-repro-${timestamp}`;

--- a/ui/leafwiki-ui/src/features/preview/TocSidePanel.tsx
+++ b/ui/leafwiki-ui/src/features/preview/TocSidePanel.tsx
@@ -71,6 +71,7 @@ export function TocSidePanel({ entries, activeId: externalActiveId }: Props) {
       <ul
         className={cn(
           'page-viewer__toc-panel-list',
+          'custom-scrollbar',
           collapsed && 'page-viewer__toc-panel-hidden',
         )}
         aria-hidden={collapsed}

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -602,6 +602,12 @@
       width: 0;
       flex-shrink: 0;
       overflow: hidden;
+      /* Caps the panel to the height of #scroll-container (its sticky
+         containing block, itself bounded by .app-layout's viewport-derived
+         height) so it can never grow past the bottom of the window with
+         many headings. .page-viewer__toc-panel-list is the part that
+         actually scrolls once capped — see index.css further down. */
+      max-height: 100%;
       transition: width 200ms ease;
     }
 
@@ -1716,7 +1722,7 @@
      border-color (not display/width), independent of the always-visible
      header/toggle button below. */
   .page-viewer__toc-panel {
-    @apply border-surface-border w-full border-l pb-4 pl-3 transition-colors duration-200;
+    @apply border-surface-border flex min-h-0 w-full flex-1 flex-col border-l pb-4 pl-3 transition-colors duration-200;
   }
 
   .page-viewer__toc-panel--collapsed {
@@ -1749,7 +1755,13 @@
     border: none;
   }
 
+  /* flex: 1 + min-height: 0 lets this take whatever space is left in the
+     panel after the fixed-height header and scroll internally once that's
+     less than the entry list's natural height — the header stays put and
+     only the entries scroll, instead of the whole sticky panel growing
+     past the bottom of the viewport (see .app-layout__toc-pane). */
   .page-viewer__toc-panel-list {
+    @apply min-h-0 flex-1 overflow-y-auto;
     visibility: visible;
     transition: visibility 0s linear 0s;
   }


### PR DESCRIPTION
…ewport

The ToC side panel was position: sticky with no max-height, so pages with many headings grew the panel past the bottom of the window with no way to scroll or reach the lower entries. It now caps to the available height and scrolls the entry list internally once it's too long, while staying sticky and visible during scroll.
