### PR TITLE
fix(auth): hide TOTP enable option when no encryption key is configured

### DIFF
--- a/cmd/leafwiki/main.go
+++ b/cmd/leafwiki/main.go
@@ -652,6 +652,7 @@ func main() {
 		Metrics:                 metrics,
 		GitBackupEnabled:        gitBackupEnabled,
 		SnapshotEnabled:         snapshotEnabled,
+		TOTPAvailable:           w.TOTPService() != nil,
 		HTTPRemoteUser: httpinternal.HTTPRemoteUserConfig{
 			Enabled:        enableHTTPRemoteUser,
 			HeaderName:     httpRemoteUserHeader,

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -101,6 +101,7 @@ type RouterOptions struct {
 	Metrics                 *httpmetrics.HTTPMetrics // Optional Prometheus HTTP metrics collector; nil disables request instrumentation
 	GitBackupEnabled        bool                     // Whether git backup is enabled (surfaced to admin UI via /api/config)
 	SnapshotEnabled         bool                     // Whether full-backup (snapshot) is enabled (surfaced to admin UI via /api/config)
+	TOTPAvailable           bool                     // Whether a TOTP encryption key is configured, i.e. TOTP self-service can be offered (surfaced to UI via /api/config)
 	HTTPRemoteUser          HTTPRemoteUserConfig     // Reverse-proxy authentication via HTTP header
 	APIKeyService           *coreauth.APIKeyService  // Bearer API-key authentication; nil disables the feature
 	DisableRequestLog       bool                     // Whether to suppress per-request access log lines

--- a/internal/http/router_test.go
+++ b/internal/http/router_test.go
@@ -1042,6 +1042,79 @@ func TestConfigEndpoint_EnableAPIKeyManagementDefaultsToFalse(t *testing.T) {
 	}
 }
 
+func TestConfigEndpoint_IncludesTOTPAvailable(t *testing.T) {
+	w := createWikiTestInstance(t)
+	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
+
+	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
+		PublicAccess:            true,
+		InjectCodeInHeader:      "",
+		AllowInsecure:           true,
+		AccessTokenTimeout:      15 * time.Minute,
+		RefreshTokenTimeout:     7 * 24 * time.Hour,
+		HideLinkMetadataSection: false,
+		MaxAssetUploadSizeBytes: assets.DefaultMaxUploadSizeBytes,
+		TOTPAvailable:           true,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected 200 OK, got %d", rec.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Invalid JSON response: %v", err)
+	}
+
+	gotAvailable, ok := resp["totpAvailable"].(bool)
+	if !ok {
+		t.Fatalf("Expected totpAvailable in config response, got %v", resp)
+	}
+
+	if !gotAvailable {
+		t.Fatalf("Expected totpAvailable=true, got %v", gotAvailable)
+	}
+}
+
+func TestConfigEndpoint_TOTPAvailableDefaultsToFalse(t *testing.T) {
+	w := createWikiTestInstance(t)
+	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
+
+	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
+		PublicAccess:            true,
+		AllowInsecure:           true,
+		AccessTokenTimeout:      15 * time.Minute,
+		RefreshTokenTimeout:     7 * 24 * time.Hour,
+		MaxAssetUploadSizeBytes: assets.DefaultMaxUploadSizeBytes,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected 200 OK, got %d", rec.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Invalid JSON response: %v", err)
+	}
+
+	gotAvailable, ok := resp["totpAvailable"].(bool)
+	if !ok {
+		t.Fatalf("Expected totpAvailable in config response, got %v", resp)
+	}
+
+	if gotAvailable {
+		t.Fatalf("Expected totpAvailable=false by default, got %v", gotAvailable)
+	}
+}
+
 func TestConfigEndpoint_IncludesUserManagementUrl(t *testing.T) {
 	w := createWikiTestInstance(t)
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)

--- a/internal/wiki/auth/routes.go
+++ b/internal/wiki/auth/routes.go
@@ -177,6 +177,7 @@ func (r *Routes) handleConfig(ctx httpinternal.RouterContext) gin.HandlerFunc {
 			"enableApiKeyManagement":  opts.EnableAPIKeyManagement,
 			"gitBackupEnabled":        opts.GitBackupEnabled,
 			"snapshotEnabled":         opts.SnapshotEnabled,
+			"totpAvailable":           opts.TOTPAvailable,
 			"httpRemoteUserEnabled":   opts.HTTPRemoteUser.Enabled,
 			"loginUrl":                opts.LoginURL,
 			"logoutUrl":               opts.LogoutURL,

--- a/ui/leafwiki-ui/src/components/UserToolbar.test.tsx
+++ b/ui/leafwiki-ui/src/components/UserToolbar.test.tsx
@@ -29,6 +29,7 @@ describe('UserToolbar', () => {
       loginUrl: '',
       logoutUrl: '',
       userManagementUrl: '',
+      totpAvailable: false,
     })
     useBackupStore.setState({ enabled: false })
     useSessionStore.setState({
@@ -253,6 +254,69 @@ describe('UserToolbar', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Login' }))
 
       expect(window.location.href).toBe('https://idp.example.com/login')
+    })
+  })
+
+  describe('totp menu item', () => {
+    it('does not show "enable two-factor authentication" when totp is not available on the server', async () => {
+      const user = userEvent.setup()
+      useConfigStore.setState({ totpAvailable: false })
+
+      render(
+        <MemoryRouter>
+          <UserToolbar />
+        </MemoryRouter>,
+      )
+
+      const avatar = screen.getByTestId('user-toolbar-avatar')
+      await user.click(avatar.closest('button') as HTMLButtonElement)
+
+      expect(
+        screen.queryByTestId('user-toolbar-totp-enable'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('shows "enable two-factor authentication" when totp is available on the server', async () => {
+      const user = userEvent.setup()
+      useConfigStore.setState({ totpAvailable: true })
+
+      render(
+        <MemoryRouter>
+          <UserToolbar />
+        </MemoryRouter>,
+      )
+
+      const avatar = screen.getByTestId('user-toolbar-avatar')
+      await user.click(avatar.closest('button') as HTMLButtonElement)
+
+      expect(screen.getByTestId('user-toolbar-totp-enable')).toBeInTheDocument()
+    })
+
+    it('still shows "disable two-factor authentication" for a user who already has it enabled, even when totpAvailable is false', async () => {
+      const user = userEvent.setup()
+      useConfigStore.setState({ totpAvailable: false })
+      useSessionStore.setState({
+        user: {
+          id: 'user-1',
+          username: 'alice',
+          email: 'alice@example.com',
+          role: 'editor',
+          totpEnabled: true,
+        },
+      })
+
+      render(
+        <MemoryRouter>
+          <UserToolbar />
+        </MemoryRouter>,
+      )
+
+      const avatar = screen.getByTestId('user-toolbar-avatar')
+      await user.click(avatar.closest('button') as HTMLButtonElement)
+
+      expect(
+        screen.getByTestId('user-toolbar-totp-disable'),
+      ).toBeInTheDocument()
     })
   })
 

--- a/ui/leafwiki-ui/src/components/UserToolbar.tsx
+++ b/ui/leafwiki-ui/src/components/UserToolbar.tsx
@@ -59,6 +59,7 @@ export default function UserToolbar() {
   const backupEnabled = useConfigStore((s) => s.gitBackupEnabled)
   const apiKeysEnabled = useConfigStore((s) => s.enableApiKeyManagement)
   const snapshotEnabled = useConfigStore((s) => s.snapshotEnabled)
+  const totpAvailable = useConfigStore((s) => s.totpAvailable)
   const httpRemoteUserEnabled = useConfigStore((s) => s.httpRemoteUserEnabled)
   const registerHotkey = useHotKeysStore((state) => state.registerHotkey)
   const unregisterHotkey = useHotKeysStore((state) => state.unregisterHotkey)
@@ -232,13 +233,15 @@ export default function UserToolbar() {
                 {t('totp.menuDisable', { ns: 'users' })}
               </DropdownMenuItem>
             ) : (
-              <DropdownMenuItem
-                className="cursor-pointer"
-                onClick={() => openDialog(DIALOG_TOTP_SETUP)}
-                data-testid="user-toolbar-totp-enable"
-              >
-                {t('totp.menuEnable', { ns: 'users' })}
-              </DropdownMenuItem>
+              totpAvailable && (
+                <DropdownMenuItem
+                  className="cursor-pointer"
+                  onClick={() => openDialog(DIALOG_TOTP_SETUP)}
+                  data-testid="user-toolbar-totp-enable"
+                >
+                  {t('totp.menuEnable', { ns: 'users' })}
+                </DropdownMenuItem>
+              )
             ))}
           {(!httpRemoteUserEnabled || logoutUrl) && (
             <DropdownMenuItem

--- a/ui/leafwiki-ui/src/lib/api/config.ts
+++ b/ui/leafwiki-ui/src/lib/api/config.ts
@@ -21,6 +21,7 @@ export type Config = {
   enableApiKeyManagement: boolean
   gitBackupEnabled: boolean
   snapshotEnabled: boolean
+  totpAvailable: boolean
   httpRemoteUserEnabled: boolean
   loginUrl: string
   logoutUrl: string

--- a/ui/leafwiki-ui/src/stores/config.ts
+++ b/ui/leafwiki-ui/src/stores/config.ts
@@ -12,6 +12,7 @@ type ConfigStore = {
   enableApiKeyManagement: boolean
   gitBackupEnabled: boolean
   snapshotEnabled: boolean
+  totpAvailable: boolean
   httpRemoteUserEnabled: boolean
   loginUrl: string
   logoutUrl: string
@@ -32,6 +33,7 @@ export const useConfigStore = create<ConfigStore>((set) => ({
   enableApiKeyManagement: false,
   gitBackupEnabled: false,
   snapshotEnabled: false,
+  totpAvailable: false,
   httpRemoteUserEnabled: false,
   loginUrl: '',
   logoutUrl: '',
@@ -60,6 +62,7 @@ export const useConfigStore = create<ConfigStore>((set) => ({
         enableApiKeyManagement: config.enableApiKeyManagement ?? false,
         gitBackupEnabled: config.gitBackupEnabled ?? false,
         snapshotEnabled: config.snapshotEnabled ?? false,
+        totpAvailable: config.totpAvailable ?? false,
         httpRemoteUserEnabled: config.httpRemoteUserEnabled ?? false,
         loginUrl: config.loginUrl ?? '',
         logoutUrl: config.logoutUrl ?? '',


### PR DESCRIPTION
Expose totpAvailable via /api/config so the frontend can gate the "Enable two-factor authentication" menu item on server-side TOTP support, instead of only failing after the user submits their password.
