### PR TITLE
feat(i18n): close hardcoded-string gaps in frontend features

### DIFF
--- a/ui/leafwiki-ui/src/features/assets/AssetItem.tsx
+++ b/ui/leafwiki-ui/src/features/assets/AssetItem.tsx
@@ -11,6 +11,7 @@ import { createHotkeyDefinition } from '@/lib/shortcuts/shortcutCatalog'
 import { HotKeyDefinition, useHotKeysStore } from '@/stores/hotkeys'
 import { Check, FileText, Link2, Pencil, Play, Trash2, X } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { AssetPreviewTooltip } from './AssetPreviewTooltip'
 
@@ -39,6 +40,7 @@ export function AssetItem({
   onFilenameChange,
   onAssetVersionChange,
 }: Props) {
+  const { t } = useTranslation('assets')
   const markdownAssetUrl = filename
   const assetPath = filename.startsWith('/assets/')
     ? filename
@@ -67,12 +69,12 @@ export function AssetItem({
       }
 
       await renameAsset(pageId, baseName, newFilename)
-      toast.success('Asset renamed')
+      toast.success(t('item.renameSuccess'))
       onFilenameChange?.(baseName, newFilename)
       onAssetVersionChange?.()
       onReload()
     } catch (err: unknown) {
-      toast.error(mapApiError(err, 'Rename failed').message)
+      toast.error(mapApiError(err, t('item.renameErrorFallback')).message)
     }
   }, [
     pageId,
@@ -83,16 +85,17 @@ export function AssetItem({
     onFilenameChange,
     onAssetVersionChange,
     setEditingFilename,
+    t,
   ])
 
   const handleDelete = async () => {
     try {
       await deleteAsset(pageId, baseName)
-      toast.success('Asset deleted')
+      toast.success(t('item.deleteSuccess'))
       onReload()
       onAssetVersionChange?.()
     } catch (err) {
-      toast.error(mapApiError(err, 'Delete failed').message)
+      toast.error(mapApiError(err, t('item.deleteErrorFallback')).message)
       console.error('Delete failed', err)
     }
   }
@@ -204,7 +207,7 @@ export function AssetItem({
               size="icon"
               className="asset-item__action-button asset-item__action-button--save"
               onClick={handleRename}
-              title="Save"
+              title={t('item.save')}
             >
               <Check size={16} />
             </Button>
@@ -216,7 +219,7 @@ export function AssetItem({
                 setEditingFilename(null)
                 setNewName(baseName.replace(/\.[^/.]+$/, ''))
               }}
-              title="Cancel"
+              title={t('item.cancel')}
             >
               <X size={16} />
             </Button>
@@ -232,7 +235,7 @@ export function AssetItem({
                   e.stopPropagation()
                   handleInsertLink()
                 }}
-                title="Insert image link"
+                title={t('item.insertImageLink')}
                 data-testid="asset-insert-link-button"
               >
                 <Link2 size={16} />
@@ -247,7 +250,11 @@ export function AssetItem({
                   e.stopPropagation()
                   handleInsertPlayer()
                 }}
-                title={isAudio ? 'Insert audio player' : 'Insert video player'}
+                title={
+                  isAudio
+                    ? t('item.insertAudioPlayer')
+                    : t('item.insertVideoPlayer')
+                }
                 data-testid="asset-insert-player-button"
               >
                 <Play size={16} />
@@ -261,7 +268,7 @@ export function AssetItem({
                 e.stopPropagation()
                 handleInsertMarkdown()
               }}
-              title={isImage ? 'Insert image' : 'Insert link'}
+              title={isImage ? t('item.insertImage') : t('item.insertLink')}
               data-testid="asset-insert-default-button"
             >
               <FileText size={16} />
@@ -275,7 +282,7 @@ export function AssetItem({
                 setNewName(baseName.replace(/\.[^/.]+$/, ''))
                 setEditingFilename(filename)
               }}
-              title="Rename"
+              title={t('item.rename')}
             >
               <Pencil size={16} />
             </Button>
@@ -287,7 +294,7 @@ export function AssetItem({
                 e.stopPropagation()
                 handleDelete()
               }}
-              title="Delete"
+              title={t('item.delete')}
             >
               <Trash2 size={16} />
             </Button>

--- a/ui/leafwiki-ui/src/features/assets/AssetManager.tsx
+++ b/ui/leafwiki-ui/src/features/assets/AssetManager.tsx
@@ -4,6 +4,7 @@ import { formatBytes } from '@/lib/config'
 import { useConfigStore } from '@/stores/config'
 import { UploadCloud } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { AssetItem } from './AssetItem'
 
@@ -22,6 +23,7 @@ export function AssetManager({
   onAssetVersionChange,
   isRenamingRef,
 }: Props) {
+  const { t } = useTranslation('assets')
   const [assets, setAssets] = useState<string[]>([])
   const [loading, setLoading] = useState(true)
   const fileInput = useRef<HTMLInputElement>(null)
@@ -61,7 +63,9 @@ export function AssetManager({
   const handleUploadFile = async (file: File) => {
     if (file.size > maxAssetUploadSizeBytes) {
       toast.error(
-        `File too large. Max ${formatBytes(maxAssetUploadSizeBytes)} allowed.`,
+        t('manager.fileTooLarge', {
+          maxSize: formatBytes(maxAssetUploadSizeBytes),
+        }),
       )
       return
     }
@@ -74,7 +78,7 @@ export function AssetManager({
       onAssetVersionChange?.()
     } catch (err) {
       console.error('Upload failed', err)
-      toast.error(mapApiError(err, 'Asset upload failed').message)
+      toast.error(mapApiError(err, t('manager.uploadErrorFallback')).message)
     } finally {
       setUploadingFiles((prev) => {
         const next = new Set(prev)
@@ -111,7 +115,7 @@ export function AssetManager({
 
   return (
     <div className="asset-manager">
-      <div className="asset-manager__title">Assets</div>
+      <div className="asset-manager__title">{t('manager.title')}</div>
 
       <div
         data-testid="asset-upload-dropzone"
@@ -133,10 +137,12 @@ export function AssetManager({
       >
         <UploadCloud className="asset-manager__dropzone-icon" size={20} />
         <p className="asset-manager__dropzone-text">
-          Drop files here or click to upload
+          {t('manager.dropzoneText')}
         </p>
         <p className="asset-manager__dropzone-text">
-          Max file size: {formatBytes(maxAssetUploadSizeBytes)}
+          {t('manager.maxFileSize', {
+            maxSize: formatBytes(maxAssetUploadSizeBytes),
+          })}
         </p>
         <input
           type="file"
@@ -147,17 +153,16 @@ export function AssetManager({
         />
         {uploadingFiles.size > 0 && (
           <div className="asset-manager__dropzone-uploading">
-            Uploading {uploadingFiles.size} file
-            {uploadingFiles.size > 1 ? 's' : ''}…
+            {t('manager.uploading', { count: uploadingFiles.size })}
           </div>
         )}
       </div>
 
       <div className="asset-manager__list-container">
         {loading ? (
-          <p className="asset-manager__loading">Loading assets…</p>
+          <p className="asset-manager__loading">{t('manager.loading')}</p>
         ) : assets.length === 0 ? (
-          <p className="asset-manager__empty">No assets yet</p>
+          <p className="asset-manager__empty">{t('manager.empty')}</p>
         ) : (
           <ul className="asset-manager__list custom-scrollbar">
             {assets.map((filename) => (
@@ -177,10 +182,7 @@ export function AssetManager({
         )}
       </div>
 
-      <p className="asset-manager__tip">
-        Tip: Double-click inserts the default markup. Images can also be added
-        as links, and audio/video have a player insert button.
-      </p>
+      <p className="asset-manager__tip">{t('manager.tip')}</p>
     </div>
   )
 }

--- a/ui/leafwiki-ui/src/features/assets/AssetManagerDialog.tsx
+++ b/ui/leafwiki-ui/src/features/assets/AssetManagerDialog.tsx
@@ -10,6 +10,7 @@ import { createHotkeyDefinition } from '@/lib/shortcuts/shortcutCatalog'
 import { useDialogsStore } from '@/stores/dialogs'
 import { HotKeyDefinition, useHotKeysStore } from '@/stores/hotkeys'
 import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 import { AssetManager } from './AssetManager'
 
 export type AssetManagerDialogProps = {
@@ -23,6 +24,7 @@ export type AssetManagerDialogProps = {
 }
 
 export function AssetManagerDialog(props: AssetManagerDialogProps) {
+  const { t } = useTranslation('assets')
   const { pageId, editorRef, onAssetVersionChange, isRenamingRef } = props
   const closeDialog = useDialogsStore((s) => s.closeDialog)
   const open = useDialogsStore((s) => s.dialogType === DIALOG_ASSET_MANAGER)
@@ -65,10 +67,8 @@ export function AssetManagerDialog(props: AssetManagerDialogProps) {
         }}
       >
         <DialogHeader>
-          <DialogTitle>Asset Manager</DialogTitle>
-          <DialogDescription>
-            Upload or select an asset to insert into the page.
-          </DialogDescription>
+          <DialogTitle>{t('dialog.title')}</DialogTitle>
+          <DialogDescription>{t('dialog.description')}</DialogDescription>
         </DialogHeader>
         <AssetManager
           pageId={pageId}

--- a/ui/leafwiki-ui/src/features/designtoggle/DesignToggle.tsx
+++ b/ui/leafwiki-ui/src/features/designtoggle/DesignToggle.tsx
@@ -1,4 +1,5 @@
 import { Moon, Sun } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { Button } from '../../components/ui/button'
 import { useDesignModeStore } from './designmode'
 import { TooltipWrapper } from '@/components/TooltipWrapper'
@@ -6,9 +7,13 @@ import { useAppMode } from '@/lib/useAppMode'
 import { useIsMobile } from '@/lib/useIsMobile'
 
 export default function DesignToggle() {
+  const { t } = useTranslation('viewer')
   const mode = useDesignModeStore((s) => s.mode)
   const setMode = useDesignModeStore((s) => s.setMode)
-  const label = mode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'
+  const label =
+    mode === 'dark'
+      ? t('designToggle.switchToLight')
+      : t('designToggle.switchToDark')
   const isMobile = useIsMobile()
   const appMode = useAppMode()
 

--- a/ui/leafwiki-ui/src/features/editor/LinkInsertDialog.tsx
+++ b/ui/leafwiki-ui/src/features/editor/LinkInsertDialog.tsx
@@ -16,6 +16,7 @@ import { useDialogsStore } from '@/stores/dialogs'
 import { HotKeyDefinition, useHotKeysStore } from '@/stores/hotkeys'
 import { useTreeStore } from '@/stores/tree'
 import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import type { MarkdownEditorRef } from './MarkdownEditor'
 
 const EXTERNAL_PREFIXES = ['http', 'https', 'mailto']
@@ -37,6 +38,7 @@ export function LinkInsertDialog({
   editorRef,
   selectedText,
 }: LinkInsertDialogProps) {
+  const { t } = useTranslation('editor')
   const closeDialog = useDialogsStore((s) => s.closeDialog)
   const open = useDialogsStore((s) => s.dialogType === DIALOG_LINK_INSERT)
   const registerHotkey = useHotKeysStore((s) => s.registerHotkey)
@@ -121,7 +123,7 @@ export function LinkInsertDialog({
               ref={textInputRef}
               value={text}
               onChange={(e) => setText(e.target.value)}
-              placeholder="Link text"
+              placeholder={t('linkInsertDialog.textPlaceholder')}
               onKeyDown={(e) => {
                 if (e.key === 'Enter') handleConfirm()
               }}
@@ -135,7 +137,7 @@ export function LinkInsertDialog({
                 ref={urlInputRef}
                 value={url}
                 onChange={(e) => setUrl(e.target.value)}
-                placeholder="https:// or search pages…"
+                placeholder={t('linkInsertDialog.urlPlaceholder')}
                 onFocus={() => setUrlFocused(true)}
                 onBlur={() => setTimeout(() => setUrlFocused(false), 150)}
                 onKeyDown={(e) => {

--- a/ui/leafwiki-ui/src/features/editor/MarkdownEditor.tsx
+++ b/ui/leafwiki-ui/src/features/editor/MarkdownEditor.tsx
@@ -194,7 +194,9 @@ const MarkdownEditor = (
       for (const file of files) {
         if (file.size > maxAssetUploadSizeBytes) {
           toast.error(
-            `File too large. Max ${formatBytes(maxAssetUploadSizeBytes)} allowed.`,
+            t('markdownEditor.fileTooLarge', {
+              maxSize: formatBytes(maxAssetUploadSizeBytes),
+            }),
           )
           continue
         }
@@ -203,7 +205,9 @@ const MarkdownEditor = (
         try {
           const res: UploadAssetResponse = await uploadAsset(pageId, file)
 
-          toast.success(`Uploaded ${file.name}`)
+          toast.success(
+            t('markdownEditor.uploadedToast', { filename: file.name }),
+          )
 
           // The result of uploadAsset looks like this:
           // {"file":"/assets/0NmpvSivg/preview-scrollbar.gif"}
@@ -232,11 +236,16 @@ const MarkdownEditor = (
           editorViewRef.current?.focus()
         } catch (err) {
           console.error('Upload failed', err)
-          toast.error(mapApiError(err, `Failed to upload ${file.name}`).message)
+          toast.error(
+            mapApiError(
+              err,
+              t('markdownEditor.uploadErrorFallback', { filename: file.name }),
+            ).message,
+          )
         }
       }
     },
-    [editorViewRef, maxAssetUploadSizeBytes, onChange, pageId, setMarkdown],
+    [editorViewRef, maxAssetUploadSizeBytes, onChange, pageId, setMarkdown, t],
   )
 
   useEffect(() => {
@@ -787,7 +796,7 @@ const MarkdownEditor = (
                   onMouseDown={handleSplitResize}
                   role="separator"
                   aria-orientation={previewStacked ? 'horizontal' : 'vertical'}
-                  aria-label="Resize editor and preview panes"
+                  aria-label={t('markdownEditor.resizeAriaLabel')}
                   aria-valuemin={MIN_EDITOR_PANE_WIDTH}
                   aria-valuemax={MAX_EDITOR_PANE_WIDTH}
                   aria-valuenow={Math.round(editorPaneWidth)}

--- a/ui/leafwiki-ui/src/features/editor/PageEditor.tsx
+++ b/ui/leafwiki-ui/src/features/editor/PageEditor.tsx
@@ -7,6 +7,7 @@ import { getWikiTargetRoutePath } from '@/lib/wikiPath'
 import { useDialogsStore } from '@/stores/dialogs'
 import { useTreeStore } from '@/stores/tree'
 import { useCallback, useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate, useParams } from 'react-router'
 import { toast } from 'sonner'
 import MarkdownEditor, { MarkdownEditorRef } from './MarkdownEditor'
@@ -18,6 +19,7 @@ import useNavigationGuard from './useNavigationGuard'
 import { useToolbarActions } from './useToolbarActions'
 
 export default function PageEditor() {
+  const { t } = useTranslation('editor')
   const { '*': path } = useParams()
 
   const { pathname } = useLocation()
@@ -88,20 +90,20 @@ export default function PageEditor() {
             '',
             buildBrowserEditUrl(`/${page?.path}`),
           )
-          toast.success('Page saved successfully')
+          toast.success(t('pageEditor.savedToast'))
         }
       })
       .catch((err) => {
         const localized = asApiLocalizedError(err)
         if (localized?.code === 'page_version_conflict') {
-          const mapped = mapApiError(err, 'Error saving page')
+          const mapped = mapApiError(err, t('pageEditor.saveErrorFallback'))
           toast.error(mapped.message, {
             duration: 10000,
             testId: 'page-save-version-conflict-toast',
             action: {
               label: (
                 <span data-testid="page-save-version-conflict-action">
-                  Save anyway
+                  {t('pageEditor.saveAnyway')}
                 </span>
               ),
               onClick: () => {
@@ -113,20 +115,19 @@ export default function PageEditor() {
                         '',
                         buildBrowserEditUrl(`/${page.path}`),
                       )
-                      toast.success('Page saved successfully')
+                      toast.success(t('pageEditor.savedToast'))
                     }
                   })
                   .catch((overwriteErr) => {
                     const overwriteLocalized = asApiLocalizedError(overwriteErr)
                     if (overwriteLocalized?.code === 'page_version_conflict') {
-                      toast.error(
-                        'The page was modified again while saving. Please reload the page and re-apply your changes.',
-                        { duration: 8000 },
-                      )
+                      toast.error(t('pageEditor.conflictAgainMessage'), {
+                        duration: 8000,
+                      })
                     } else {
                       const overwriteMapped = mapApiError(
                         overwriteErr,
-                        'Error saving page',
+                        t('pageEditor.saveErrorFallback'),
                       )
                       toast.error(overwriteMapped.message)
                     }
@@ -135,11 +136,11 @@ export default function PageEditor() {
             },
           })
         } else {
-          const mapped = mapApiError(err, 'Error saving page')
+          const mapped = mapApiError(err, t('pageEditor.saveErrorFallback'))
           toast.error(mapped.message)
         }
       })
-  }, [savePage, forceOverwrite])
+  }, [savePage, forceOverwrite, t])
 
   const handleClose = useCallback(() => {
     const state = usePageEditorStore.getState()
@@ -197,7 +198,12 @@ export default function PageEditor() {
     return <Page404 targetPath={getWikiTargetRoutePath(pathname)} />
   }
 
-  if (error) return <p className="page-editor__error">Error: {error}</p>
+  if (error)
+    return (
+      <p className="page-editor__error">
+        {t('pageEditor.errorPrefix', { error })}
+      </p>
+    )
 
   return (
     <>

--- a/ui/leafwiki-ui/src/features/editor/PageFrontmatterPanel.tsx
+++ b/ui/leafwiki-ui/src/features/editor/PageFrontmatterPanel.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { ChevronDown, ChevronRight, Plus, Tag, Trash2 } from 'lucide-react'
 import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { EditorFrontmatterField } from './frontmatter'
 
 const METADATA_ALLOWED_HOTKEYS = 'Mod+KeyS Escape'
@@ -50,6 +51,7 @@ export function PageFrontmatterPanel({
   onTagsChange,
   onFieldsChange,
 }: PageFrontmatterPanelProps) {
+  const { t } = useTranslation('editor')
   const [showInternalFields, setShowInternalFields] = useState(false)
 
   const normalizedTags = useMemo(() => {
@@ -169,7 +171,7 @@ export function PageFrontmatterPanel({
                   <TagInputWithSuggestions
                     tags={normalizedTags}
                     onTagsChange={onTagsChange}
-                    placeholder="Add tag"
+                    placeholder={t('frontmatterPanel.addTagPlaceholder')}
                     variant="metadata"
                     inputTestId="page-frontmatter-tag-input"
                     inputHotkeys={METADATA_ALLOWED_HOTKEYS}
@@ -203,7 +205,9 @@ export function PageFrontmatterPanel({
                                     key: event.target.value,
                                   })
                                 }
-                                placeholder="Key"
+                                placeholder={t(
+                                  'frontmatterPanel.keyPlaceholder',
+                                )}
                                 className={`page-frontmatter-panel__field-key${errors[`properties.${index}.key`] ? 'page-frontmatter-panel__input--error' : ''}`}
                                 data-testid={`page-frontmatter-field-key-${index}`}
                                 data-allow-hotkeys={METADATA_ALLOWED_HOTKEYS}
@@ -217,7 +221,9 @@ export function PageFrontmatterPanel({
                                     value: event.target.value,
                                   })
                                 }
-                                placeholder="Value"
+                                placeholder={t(
+                                  'frontmatterPanel.valuePlaceholder',
+                                )}
                                 className={`page-frontmatter-panel__field-value${errors[`properties.${index}.value`] ? 'page-frontmatter-panel__input--error' : ''}`}
                                 data-testid={`page-frontmatter-field-value-${index}`}
                                 data-allow-hotkeys={METADATA_ALLOWED_HOTKEYS}

--- a/ui/leafwiki-ui/src/features/history/PageHistoryContent.tsx
+++ b/ui/leafwiki-ui/src/features/history/PageHistoryContent.tsx
@@ -11,6 +11,7 @@ import {
   type RevisionSnapshot,
 } from '@/lib/api/revisions'
 import { formatRelativeTime } from '@/lib/formatDate'
+import i18next from '@/lib/i18n'
 import { createNavigationVisitState } from '@/lib/navigationVisit'
 import { buildHistoryUrl, withBasePath } from '@/lib/routePath'
 import { useIsMobile } from '@/lib/useIsMobile'
@@ -45,6 +46,9 @@ import {
   usePageHistoryStore,
 } from './pageHistory'
 
+const t = (key: string, opts?: Record<string, unknown>) =>
+  i18next.t(key, { ...opts, ns: 'history' })
+
 export type PageHistoryContentProps = {
   pageId: string
   pageTitle: string
@@ -78,10 +82,10 @@ type RevisionGroup = {
 }
 
 function groupLabel(value?: string) {
-  if (!value) return 'Unknown'
+  if (!value) return t('common.unknown')
 
   const date = new Date(value)
-  if (Number.isNaN(date.getTime())) return 'Unknown'
+  if (Number.isNaN(date.getTime())) return t('common.unknown')
 
   return new Intl.DateTimeFormat(undefined, {
     dateStyle: 'medium',
@@ -107,7 +111,7 @@ function groupRevisions(revisions: Revision[]): RevisionGroup[] {
 }
 
 function revisionTitle(revision: Revision) {
-  if (!revision.createdAt) return 'Unknown time'
+  if (!revision.createdAt) return t('common.unknownTime')
 
   const date = new Date(revision.createdAt)
   if (Number.isNaN(date.getTime())) return revision.createdAt
@@ -118,7 +122,7 @@ function revisionTitle(revision: Revision) {
 }
 
 function revisionMeta(revision: Revision) {
-  return revision.author?.username || revision.authorId || 'Unknown'
+  return revision.author?.username || revision.authorId || t('common.unknown')
 }
 
 function getPathLeaf(path: string) {
@@ -143,35 +147,35 @@ type DiffSummary = {
 function revisionTriggerLabel(type: string) {
   switch (type) {
     case 'content_update':
-      return 'Saved after content update'
+      return t('trigger.contentUpdate')
     case 'asset_update':
-      return 'Saved after asset update'
+      return t('trigger.assetUpdate')
     case 'structure_update':
-      return 'Saved after structure update'
+      return t('trigger.structureUpdate')
     case 'restore':
-      return 'Saved after restore'
+      return t('trigger.restore')
     case 'delete':
-      return 'Saved before delete'
+      return t('trigger.delete')
     default:
-      return `Saved as ${type}`
+      return t('trigger.generic', { type })
   }
 }
 
 function assetChangeLabel(status: RevisionAssetChange['status']) {
   switch (status) {
     case 'added':
-      return 'Added'
+      return t('assetChange.added')
     case 'removed':
-      return 'Removed'
+      return t('assetChange.removed')
     case 'modified':
-      return 'Replaced'
+      return t('assetChange.replaced')
     default:
       return status
   }
 }
 
 function displayAuthor(revision: Revision) {
-  return revision.author?.username || revision.authorId || 'Unknown'
+  return revision.author?.username || revision.authorId || t('common.unknown')
 }
 
 function formatTimestamp(value?: string) {
@@ -381,7 +385,7 @@ function DiffView({ comparison }: { comparison: RevisionComparison }) {
   if (!comparison.contentChanged) {
     return (
       <div className="page-history__empty-message">
-        No text difference between this revision and the active version.
+        {t('diff.noTextDifference')}
       </div>
     )
   }
@@ -428,22 +432,24 @@ function ChangesPanel({ comparison }: { comparison: RevisionComparison }) {
   return (
     <div className="page-history__detail-stack">
       <section className="page-history__summary">
-        <div className="page-history__section-heading">Change Summary</div>
+        <div className="page-history__section-heading">
+          {t('changes.summaryHeading')}
+        </div>
         <div className="page-history__summary-grid">
           <SummaryStat
-            label="Lines added since"
+            label={t('changes.linesAdded')}
             value={String(diff.summary.addedLines)}
             emphasized={diff.summary.addedLines > 0}
             tone="added"
           />
           <SummaryStat
-            label="Lines removed since"
+            label={t('changes.linesRemoved')}
             value={String(diff.summary.removedLines)}
             emphasized={diff.summary.removedLines > 0}
             tone="removed"
           />
           <SummaryStat
-            label="Assets changed"
+            label={t('changes.assetsChanged')}
             value={String(comparison.assetChanges.length)}
             emphasized={comparison.assetChanges.length > 0}
           />
@@ -452,9 +458,9 @@ function ChangesPanel({ comparison }: { comparison: RevisionComparison }) {
 
       <section className="page-history__section">
         <div className="page-history__section-heading">
-          Diff{' '}
+          {t('changes.diffHeading')}{' '}
           <span className="page-history__section-heading-note">
-            compared to the active version
+            {t('changes.diffNote')}
           </span>
         </div>
         <DiffView comparison={comparison} />
@@ -463,7 +469,9 @@ function ChangesPanel({ comparison }: { comparison: RevisionComparison }) {
       {comparison.assetChanges.length > 0 ? (
         <details className="page-history__asset-details">
           <summary className="page-history__asset-summary">
-            Assets ({comparison.assetChanges.length})
+            {t('changes.assetsDetails', {
+              count: comparison.assetChanges.length,
+            })}
           </summary>
           <div className="page-history__asset-list">
             {comparison.assetChanges.map((change) => (
@@ -480,13 +488,19 @@ function ChangesPanel({ comparison }: { comparison: RevisionComparison }) {
           </div>
           <div className="page-history__asset-summary-row">
             {assetSummary.added > 0 ? (
-              <span>{assetSummary.added} added</span>
+              <span>
+                {t('changes.assetAdded', { count: assetSummary.added })}
+              </span>
             ) : null}
             {assetSummary.modified > 0 ? (
-              <span>{assetSummary.modified} replaced</span>
+              <span>
+                {t('changes.assetReplaced', { count: assetSummary.modified })}
+              </span>
             ) : null}
             {assetSummary.removed > 0 ? (
-              <span>{assetSummary.removed} removed</span>
+              <span>
+                {t('changes.assetRemoved', { count: assetSummary.removed })}
+              </span>
             ) : null}
           </div>
         </details>
@@ -535,10 +549,12 @@ function RawTextPanel({ snapshot }: { snapshot: RevisionSnapshot }) {
   return (
     <div className="page-history__detail-stack">
       <section className="page-history__section">
-        <div className="page-history__section-heading">Raw Text</div>
+        <div className="page-history__section-heading">
+          {t('rawText.heading')}
+        </div>
         <div className="custom-scrollbar markdown-code-block page-history__raw-text-block">
           <pre className="custom-scrollbar page-history__snapshot-content">
-            <code>{snapshot.content || '(empty)'}</code>
+            <code>{snapshot.content || t('rawText.empty')}</code>
           </pre>
         </div>
       </section>
@@ -580,7 +596,7 @@ function HistoryAssetItem({
         <div className="page-history__asset-copy">
           <span className="asset-item__filename">{baseName}</span>
           <span className="page-history__asset-copy-meta">
-            {asset.mimeType || 'application/octet-stream'} ·{' '}
+            {asset.mimeType || t('assetsPanel.octetStream')} ·{' '}
             {Intl.NumberFormat().format(asset.sizeBytes)} bytes
           </span>
         </div>
@@ -596,7 +612,7 @@ function HistoryAssetItem({
           href={assetUrl}
           target="_blank"
           rel="noreferrer"
-          title="Open asset"
+          title={t('assetsPanel.openAsset')}
           data-testid={`history-asset-open-${baseName}`}
         >
           <ExternalLink size={16} />
@@ -611,7 +627,7 @@ function HistoryAssetItem({
         <a
           href={assetUrl}
           download={baseName}
-          title="Download asset"
+          title={t('assetsPanel.downloadAsset')}
           data-testid={`history-asset-download-${baseName}`}
         >
           <Download size={16} />
@@ -625,10 +641,12 @@ function AssetsPanel({ snapshot }: { snapshot: RevisionSnapshot }) {
   return (
     <div className="page-history__detail-stack">
       <section className="page-history__section">
-        <div className="page-history__section-heading">Assets</div>
+        <div className="page-history__section-heading">
+          {t('assetsPanel.heading')}
+        </div>
         {snapshot.assets.length === 0 ? (
           <div className="page-history__empty-message">
-            No assets were stored with this revision.
+            {t('assetsPanel.empty')}
           </div>
         ) : (
           <ul className="page-history__asset-list">
@@ -698,19 +716,21 @@ export function PageHistoryContent({
     if (!selectedRevision) return []
 
     const result = [
-      `Revision slug: ${selectedRevision.slug || '/'}`,
+      t('chips.revisionSlug', { slug: selectedRevision.slug || '/' }),
       getPathLeaf(selectedRevision.path),
       revisionTriggerLabel(selectedRevision.type),
     ]
 
     if (pageSlug && pageSlug !== selectedRevision.slug) {
-      result.unshift(`Current slug: ${pageSlug}`)
+      result.unshift(t('chips.currentSlug', { slug: pageSlug }))
     }
 
     if (comparison) {
-      result.push(`${comparison.assetChanges.length} asset changes`)
+      result.push(
+        t('chips.assetChangesCount', { count: comparison.assetChanges.length }),
+      )
     } else if (snapshot) {
-      result.push(`${snapshot.assets.length} Assets`)
+      result.push(t('chips.assetsCount', { count: snapshot.assets.length }))
     }
 
     return result
@@ -723,17 +743,17 @@ export function PageHistoryContent({
 
     if (comparison.base.revision?.title !== comparison.target.revision?.title) {
       changes.push({
-        label: 'Title',
-        from: comparison.base.revision?.title || '(empty)',
-        to: comparison.target.revision?.title || '(empty)',
+        label: t('header.titleLabel'),
+        from: comparison.base.revision?.title || t('header.emptyValue'),
+        to: comparison.target.revision?.title || t('header.emptyValue'),
       })
     }
 
     if (comparison.base.revision?.slug !== comparison.target.revision?.slug) {
       changes.push({
-        label: 'Slug',
-        from: comparison.base.revision?.slug || '(empty)',
-        to: comparison.target.revision?.slug || '(empty)',
+        label: t('header.slugLabel'),
+        from: comparison.base.revision?.slug || t('header.emptyValue'),
+        to: comparison.target.revision?.slug || t('header.emptyValue'),
       })
     }
 
@@ -743,10 +763,10 @@ export function PageHistoryContent({
   // Preview is first and the default active tab so users immediately see the
   // rendered content of the selected revision without an extra click.
   const tabs: { id: HistoryTab; label: string }[] = [
-    { id: 'preview', label: 'Preview' },
-    { id: 'changes', label: 'Changes' },
-    { id: 'raw', label: 'Raw Text' },
-    { id: 'assets', label: 'Assets' },
+    { id: 'preview', label: t('tabs.preview') },
+    { id: 'changes', label: t('tabs.changes') },
+    { id: 'raw', label: t('tabs.raw') },
+    { id: 'assets', label: t('tabs.assets') },
   ]
 
   const detailLoading =
@@ -832,9 +852,9 @@ export function PageHistoryContent({
         replace: true,
         state: createNavigationVisitState(),
       })
-      toast.success('Revision restored')
+      toast.success(t('toasts.restoreSuccess'))
     } catch (err) {
-      const mapped = mapApiError(err, 'Failed to restore revision')
+      const mapped = mapApiError(err, t('toasts.restoreErrorFallback'))
       toast.error(mapped.message)
     } finally {
       setRestoreLoading(false)
@@ -877,7 +897,9 @@ export function PageHistoryContent({
   const renderDetailContent = () => {
     if (listLoading) {
       return (
-        <div className="page-history__loading-state">Loading history...</div>
+        <div className="page-history__loading-state">
+          {t('detail.loadingHistory')}
+        </div>
       )
     }
 
@@ -888,8 +910,8 @@ export function PageHistoryContent({
     if (!selectedRevision) {
       return (
         <EmptyState
-          title="No revision selected"
-          message="Select a revision from the list to view details."
+          title={t('detail.noRevisionSelectedTitle')}
+          message={t('detail.noRevisionSelectedMessage')}
         />
       )
     }
@@ -898,8 +920,8 @@ export function PageHistoryContent({
       return (
         <div className="page-history__loading-state">
           {activeTab === 'changes' || activeTab === 'assets'
-            ? 'Loading diff...'
-            : 'Loading preview...'}
+            ? t('detail.loadingDiff')
+            : t('detail.loadingPreview')}
         </div>
       )
     }
@@ -913,7 +935,7 @@ export function PageHistoryContent({
         <PreviewPanel snapshot={snapshot} />
       ) : (
         <div className="page-history__empty-message page-history__empty-message--padded">
-          No preview available.
+          {t('detail.noPreview')}
         </div>
       )
     }
@@ -922,7 +944,7 @@ export function PageHistoryContent({
       if (isSelectedRevisionLatest) {
         return (
           <div className="page-history__empty-message page-history__empty-message--padded">
-            No differences from the current version.
+            {t('detail.noChangesFromCurrent')}
           </div>
         )
       }
@@ -931,7 +953,7 @@ export function PageHistoryContent({
         <ChangesPanel comparison={comparison} />
       ) : (
         <div className="page-history__empty-message page-history__empty-message--padded">
-          No comparison data available.
+          {t('detail.noComparisonData')}
         </div>
       )
     }
@@ -941,7 +963,7 @@ export function PageHistoryContent({
         <RawTextPanel snapshot={snapshot} />
       ) : (
         <div className="page-history__empty-message page-history__empty-message--padded">
-          No raw text available.
+          {t('detail.noRawText')}
         </div>
       )
     }
@@ -950,7 +972,7 @@ export function PageHistoryContent({
       <AssetsPanel snapshot={snapshot} />
     ) : (
       <div className="page-history__empty-message page-history__empty-message--padded">
-        No asset data available.
+        {t('detail.noAssetData')}
       </div>
     )
   }
@@ -960,7 +982,7 @@ export function PageHistoryContent({
       return (
         <div className="page-history__list-status">
           <Loader2 className="h-4 w-4 animate-spin" />
-          Loading history...
+          {t('list.loading')}
         </div>
       )
     }
@@ -977,8 +999,8 @@ export function PageHistoryContent({
       return (
         <div className="page-history__list-status">
           {latestRevisionId
-            ? 'No previous revisions yet. Older versions will appear here after more changes.'
-            : 'No revisions yet. They will appear here after the page changes.'}
+            ? t('list.emptyWithLatest')
+            : t('list.emptyNoLatest')}
         </div>
       )
     }
@@ -1012,7 +1034,7 @@ export function PageHistoryContent({
                       <RevisionBadge
                         testId={`history-sidebar-revision-current-badge-${revision.id}`}
                       >
-                        Active version
+                        {t('list.activeVersionBadge')}
                       </RevisionBadge>
                     ) : null}
                   </div>
@@ -1033,7 +1055,7 @@ export function PageHistoryContent({
               onClick={() => void loadMorePageHistory()}
               disabled={loadingMore}
             >
-              {loadingMore ? 'Loading...' : 'Load more'}
+              {loadingMore ? t('list.loadMoreLoading') : t('list.loadMore')}
             </Button>
           </div>
         ) : null}
@@ -1047,8 +1069,16 @@ export function PageHistoryContent({
         <div className="markdown-editor__tabs" role="tablist">
           {(
             [
-              { id: 'list', label: 'Revisions', icon: <History size={16} /> },
-              { id: 'detail', label: 'Details', icon: <FileText size={16} /> },
+              {
+                id: 'list',
+                label: t('tabs.mobileRevisions'),
+                icon: <History size={16} />,
+              },
+              {
+                id: 'detail',
+                label: t('tabs.mobileDetails'),
+                icon: <FileText size={16} />,
+              },
             ] as const
           ).map((tab) => {
             const active =
@@ -1084,7 +1114,7 @@ export function PageHistoryContent({
               <div className="page-history__list-header">
                 <div className="page-history__list-title">
                   <History className="h-4 w-4" />
-                  Revision History
+                  {t('list.title')}
                 </div>
               </div>
               <div className="page-history__list-scroll custom-scrollbar">
@@ -1102,7 +1132,7 @@ export function PageHistoryContent({
                 }}
                 role="separator"
                 aria-orientation="vertical"
-                aria-label="Resize revision list"
+                aria-label={t('list.resizeAriaLabel')}
                 data-testid={`${testidPrefix}-list-resize-handle`}
               >
                 <div
@@ -1132,9 +1162,12 @@ export function PageHistoryContent({
               </div>
               {selectedRevision ? (
                 <div className="page-history__header-subtitle">
-                  Revision by {displayAuthor(selectedRevision)} ·{' '}
-                  {formatRelativeTime(selectedRevision.createdAt) ||
-                    formatTimestamp(selectedRevision.createdAt)}
+                  {t('header.revisionBy', {
+                    author: displayAuthor(selectedRevision),
+                    time:
+                      formatRelativeTime(selectedRevision.createdAt) ||
+                      formatTimestamp(selectedRevision.createdAt),
+                  })}
                 </div>
               ) : null}
               {selectedRevision ? (
@@ -1173,10 +1206,10 @@ export function PageHistoryContent({
                 data-testid={`${testidPrefix}-restore`}
               >
                 {restoreLoading
-                  ? 'Restoring...'
+                  ? t('header.restoreLoading')
                   : isSelectedRevisionLatest
-                    ? 'Current version'
-                    : 'Restore'}
+                    ? t('header.currentVersion')
+                    : t('header.restore')}
               </Button>
             </div>
           </div>

--- a/ui/leafwiki-ui/src/features/history/RestoreRevisionDialog.tsx
+++ b/ui/leafwiki-ui/src/features/history/RestoreRevisionDialog.tsx
@@ -2,6 +2,7 @@ import BaseDialog from '@/components/BaseDialog'
 import { type Revision } from '@/lib/api/revisions'
 import { DIALOG_RESTORE_REVISION_CONFIRMATION } from '@/lib/registries'
 import { useRef } from 'react'
+import { Trans, useTranslation } from 'react-i18next'
 
 export type RestoreRevisionDialogProps = {
   revision: Revision
@@ -14,6 +15,7 @@ export function RestoreRevisionDialog({
   currentSlug,
   onResolve,
 }: RestoreRevisionDialogProps) {
+  const { t } = useTranslation('history')
   const resolvedRef = useRef(false)
 
   const resolveOnce = (value: boolean | null) => {
@@ -29,8 +31,8 @@ export function RestoreRevisionDialog({
   return (
     <BaseDialog
       dialogType={DIALOG_RESTORE_REVISION_CONFIRMATION}
-      dialogTitle="Restore revision?"
-      dialogDescription="This restores the revision content, title, and assets. The current slug and location stay unchanged."
+      dialogTitle={t('restoreDialog.title')}
+      dialogDescription={t('restoreDialog.description')}
       onClose={() => {
         resolveOnce(null)
         return true
@@ -45,13 +47,13 @@ export function RestoreRevisionDialog({
       defaultAction="cancel"
       testidPrefix="restore-revision-dialog"
       cancelButton={{
-        label: 'Cancel',
+        label: t('restoreDialog.cancel'),
         variant: 'outline',
         autoFocus: true,
       }}
       buttons={[
         {
-          label: 'Restore revision',
+          label: t('restoreDialog.confirm'),
           actionType: 'confirm',
           variant: 'default',
           autoFocus: false,
@@ -60,7 +62,9 @@ export function RestoreRevisionDialog({
     >
       <div className="space-y-3 text-sm">
         <div>
-          <span className="font-medium">Restored title:</span>{' '}
+          <span className="font-medium">
+            {t('restoreDialog.restoredTitleLabel')}
+          </span>{' '}
           <span data-testid="restore-revision-dialog-title">
             {revision.title}
           </span>
@@ -70,10 +74,12 @@ export function RestoreRevisionDialog({
             className="rounded border border-amber-300 bg-amber-50 p-3 text-amber-950"
             data-testid="restore-revision-dialog-slug-note"
           >
-            This revision used slug{' '}
-            <span className="font-mono">{revision.slug}</span>. The current slug{' '}
-            <span className="font-mono">{currentSlug}</span> will stay
-            unchanged.
+            <Trans
+              i18nKey="restoreDialog.slugNote"
+              ns="history"
+              values={{ revisionSlug: revision.slug, currentSlug }}
+              components={{ mono: <span className="font-mono" /> }}
+            />
           </div>
         ) : null}
       </div>

--- a/ui/leafwiki-ui/src/features/imagepreview/ImagePreviewDialog.tsx
+++ b/ui/leafwiki-ui/src/features/imagepreview/ImagePreviewDialog.tsx
@@ -9,6 +9,7 @@ import { createHotkeyDefinition } from '@/lib/shortcuts/shortcutCatalog'
 import { useDialogsStore } from '@/stores/dialogs'
 import { HotKeyDefinition, useHotKeysStore } from '@/stores/hotkeys'
 import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 type Props = {
   src: string
@@ -16,6 +17,7 @@ type Props = {
 }
 
 export function ImagePreviewDialog({ src, alt }: Props) {
+  const { t } = useTranslation('viewer')
   const closeDialog = useDialogsStore((s) => s.closeDialog)
   const registerHotkey = useHotKeysStore((s) => s.registerHotkey)
   const unregisterHotkey = useHotKeysStore((s) => s.unregisterHotkey)
@@ -80,7 +82,7 @@ export function ImagePreviewDialog({ src, alt }: Props) {
               className="text-muted-foreground hover:text-foreground ml-auto text-sm underline"
               onClick={(e) => e.stopPropagation()}
             >
-              Open in new tab
+              {t('imagePreview.openInNewTab')}
             </a>
           </DialogTitle>
         </DialogHeader>

--- a/ui/leafwiki-ui/src/features/importer/Importer.tsx
+++ b/ui/leafwiki-ui/src/features/importer/Importer.tsx
@@ -1,21 +1,26 @@
 import { Button } from '@/components/ui/button'
+import i18next from '@/lib/i18n'
 import { useImportStore } from '@/stores/import'
 import { FileUp, Loader2, PlayIcon, UploadIcon, XIcon } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { Trans } from 'react-i18next'
 import { useNavigate } from 'react-router'
 import { useSetTitle } from '../viewer/setTitle'
 import { useToolbarActions } from './useToolbarActions'
 
 type ResultFilter = 'all' | 'created' | 'skipped' | 'failed'
 
+const t = (key: string, opts?: Record<string, unknown>) =>
+  i18next.t(key, { ...opts, ns: 'importer' })
+
 function getPlanActionLabel(action: 'create' | 'update' | 'skip'): string {
   switch (action) {
     case 'create':
-      return 'Create page'
+      return t('planActions.create')
     case 'update':
-      return 'Update page'
+      return t('planActions.update')
     case 'skip':
-      return 'Skip item'
+      return t('planActions.skip')
   }
 }
 
@@ -35,18 +40,18 @@ function getResultActionLabel(
   hasError: boolean,
 ): string {
   if (hasError) {
-    return 'Needs attention'
+    return t('resultActions.needsAttention')
   }
 
   switch (action) {
     case 'created':
-      return 'Created'
+      return t('resultActions.created')
     case 'updated':
-      return 'Updated'
+      return t('resultActions.updated')
     case 'skipped':
-      return 'Skipped'
+      return t('resultActions.skipped')
     case 'conflicted':
-      return 'Conflicted'
+      return t('resultActions.conflicted')
   }
 }
 
@@ -71,7 +76,7 @@ function getResultActionClass(
 export default function Importer() {
   // reset toolbar actions on mount
   useToolbarActions()
-  useSetTitle({ title: 'Import' })
+  useSetTitle({ title: t('title') })
   const navigate = useNavigate()
   const zipRef = useRef<HTMLInputElement>(null)
   const [zipFileName, setZipFileName] = useState('')
@@ -146,22 +151,22 @@ export default function Importer() {
           : 'settings__pill settings__pill-success'
   const statusLabel =
     importStatus === 'running'
-      ? 'Running'
+      ? t('status.running')
       : importStatus === 'completed'
-        ? 'Completed'
+        ? t('status.completed')
         : importStatus === 'canceled'
-          ? 'Canceled'
+          ? t('status.canceled')
           : importStatus === 'failed'
-            ? 'Failed'
+            ? t('status.failed')
             : importStatus === 'planned'
-              ? 'Planned'
-              : 'Idle'
+              ? t('status.planned')
+              : t('status.idle')
   const clearButtonLabel =
     importStatus === 'running'
       ? importPlan?.cancel_requested
-        ? 'Cancel Requested'
-        : 'Cancel Import'
-      : 'Clear Import Plan'
+        ? t('run.cancelRequested')
+        : t('run.cancelImport')
+      : t('run.clearImportPlan')
   const currentStep =
     importStatus === 'running'
       ? 3
@@ -176,23 +181,23 @@ export default function Importer() {
   const stepItems = [
     {
       number: 1,
-      title: 'Select Zip',
-      description: 'Choose the package you want to import.',
+      title: t('steps.selectZip.title'),
+      description: t('steps.selectZip.description'),
     },
     {
       number: 2,
-      title: 'Review Plan',
-      description: 'Check the generated pages and paths.',
+      title: t('steps.reviewPlan.title'),
+      description: t('steps.reviewPlan.description'),
     },
     {
       number: 3,
-      title: 'Run Import',
-      description: 'Watch progress while the importer works.',
+      title: t('steps.runImport.title'),
+      description: t('steps.runImport.description'),
     },
     {
       number: 4,
-      title: 'Review Result',
-      description: 'Inspect imported, skipped, or failed items.',
+      title: t('steps.reviewResult.title'),
+      description: t('steps.reviewResult.description'),
     },
   ]
   const planItems = importPlan?.items ?? []
@@ -244,37 +249,39 @@ export default function Importer() {
   const showResultStep = currentStep === 4
   const showRunSection = currentStep === 2 || currentStep === 3
   const nextActionText = !importPlan
-    ? 'Choose a zip file and create an import plan.'
+    ? t('nextAction.chooseZip')
     : importStatus === 'planned'
-      ? 'Review the generated items, then start the import.'
+      ? t('nextAction.reviewThenStart')
       : importStatus === 'running'
         ? importPlan.cancel_requested
-          ? 'Cancellation was requested. The importer will stop after the current item finishes.'
-          : 'The import is running. You can stay on this page and watch the progress update.'
+          ? t('nextAction.cancellationRequested')
+          : t('nextAction.running')
         : importStatus === 'completed'
-          ? 'The import finished successfully. Review the result below, or start a new import with another zip package.'
+          ? t('nextAction.completed')
           : importStatus === 'failed'
-            ? 'The import stopped with an error. Check the message and result items below.'
+            ? t('nextAction.failed')
             : importStatus === 'canceled'
-              ? 'The import was canceled. Completed work was kept and is shown below.'
-              : 'Select a zip file to begin.'
+              ? t('nextAction.canceled')
+              : t('nextAction.selectZipToBegin')
 
   return (
     <>
       <div className="settings importer">
-        <h1 className="settings__title">Import</h1>
+        <h1 className="settings__title">{t('title')}</h1>
         <div className="settings__section">
-          <h2 className="settings__section-title">Before You Start</h2>
+          <h2 className="settings__section-title">
+            {t('beforeYouStart.title')}
+          </h2>
           <p className="settings__section-description">
-            Import a zip archive with Markdown files. LeafWiki first creates a
-            review plan, and only imports pages after you explicitly start the
-            execution step.
+            {t('beforeYouStart.description')}
           </p>
           <div className="importer__callout">
-            <div className="importer__callout-title">What happens next?</div>
+            <div className="importer__callout-title">
+              {t('beforeYouStart.whatHappensNext')}
+            </div>
             <div className="importer__callout-body">
               <strong>
-                Step {currentStep}
+                {t('beforeYouStart.stepPrefix', { number: currentStep })}
                 {currentStepItem ? `: ${currentStepItem.title}` : ''}
               </strong>
               <span>{nextActionText}</span>
@@ -282,27 +289,33 @@ export default function Importer() {
           </div>
           <div className="importer__info-grid">
             <div className="importer__info-card">
-              <div className="importer__info-title">Safe review first</div>
+              <div className="importer__info-title">
+                {t('beforeYouStart.safeReviewTitle')}
+              </div>
               <div className="importer__info-text">
-                Creating the plan does not import pages yet.
+                {t('beforeYouStart.safeReviewText')}
               </div>
             </div>
             <div className="importer__info-card">
-              <div className="importer__info-title">Links and assets</div>
+              <div className="importer__info-title">
+                {t('beforeYouStart.linksAssetsTitle')}
+              </div>
               <div className="importer__info-text">
-                Internal links and embedded assets are rewritten during import.
+                {t('beforeYouStart.linksAssetsText')}
               </div>
             </div>
             <div className="importer__info-card">
-              <div className="importer__info-title">Still in alpha</div>
+              <div className="importer__info-title">
+                {t('beforeYouStart.alphaTitle')}
+              </div>
               <div className="importer__info-text">
-                Some Markdown variants may still need manual cleanup afterward.
+                {t('beforeYouStart.alphaText')}
               </div>
             </div>
           </div>
         </div>
         <div className="settings__section">
-          <h2 className="settings__section-title">Import Flow</h2>
+          <h2 className="settings__section-title">{t('flow.title')}</h2>
           <div className="importer__steps">
             {stepItems.map((step) => {
               const state =
@@ -331,26 +344,29 @@ export default function Importer() {
         </div>
         {showPackageStep && (
           <div className="settings__section">
-            <h2 className="settings__section-title">Choose Import Package</h2>
+            <h2 className="settings__section-title">{t('package.title')}</h2>
             <p className="settings__section-description">
-              Select a zip archive that contains Markdown files. After that, we
-              create a preview plan so you can inspect paths, actions, and notes
-              before the import runs.
+              {t('package.description')}
             </p>
             <p className="settings__section-description">
-              If you run into problems, unexpected results, or unsupported edge
-              cases, please create an issue on our{' '}
-              <a
-                href="https://github.com/perber/leafwiki/issues"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                GitHub repository
-              </a>
-              .
+              <Trans
+                i18nKey="package.issueHint"
+                ns="importer"
+                components={{
+                  link: (
+                    <a
+                      href="https://github.com/perber/leafwiki/issues"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    />
+                  ),
+                }}
+              />
             </p>
             <div className="settings__preview">
-              <span className="settings__preview-label">Current Zip:</span>
+              <span className="settings__preview-label">
+                {t('package.currentZip')}
+              </span>
               {zipFileName ? (
                 <>
                   <span className="settings__preview-filename">
@@ -359,7 +375,7 @@ export default function Importer() {
                 </>
               ) : (
                 <span className="settings__preview-placeholder">
-                  No zip file selected
+                  {t('package.noZipSelected')}
                 </span>
               )}
             </div>
@@ -381,11 +397,10 @@ export default function Importer() {
                 }}
               >
                 <FileUp className="mr-2 h-4 w-4" />
-                Select Zip File
+                {t('package.selectZipFile')}
               </Button>
               <div className="settings__hint">
-                Supported input: a single `.zip` archive containing your
-                Markdown knowledge base.
+                {t('package.supportedInputHint')}
               </div>
             </div>
             <Button
@@ -401,34 +416,36 @@ export default function Importer() {
               ) : (
                 <UploadIcon className="mr-2 h-4 w-4" />
               )}
-              Import from Zip
+              {t('package.importFromZip')}
             </Button>
-            <div className="settings__hint">
-              This only creates the review plan. No pages are imported until you
-              click `Execute Import Plan`.
-            </div>
+            <div className="settings__hint">{t('package.planOnlyHint')}</div>
           </div>
         )}
         {importPlan && showPlanStep && (
           <div className="settings__section">
-            <h2 className="settings__section-title">Import Plan</h2>
+            <h2 className="settings__section-title">{t('plan.title')}</h2>
             <p className="settings__section-description">
-              Review what LeafWiki is about to create, update, or skip before
-              you start the import.
+              {t('plan.description')}
             </p>
             <div className="importer__status-banner">
               <div className="importer__status-header">
                 <div>
-                  <div className="settings__preview-label">Current Status</div>
+                  <div className="settings__preview-label">
+                    {t('plan.currentStatus')}
+                  </div>
                   <div className="importer__status-title">{statusLabel}</div>
                 </div>
                 <span className={statusPillClass}>{statusLabel}</span>
               </div>
               <div className="importer__status-meta">
-                <span>Plan ID: {importPlan.id}</span>
-                {progressLabel ? <span>Progress: {progressLabel}</span> : null}
+                <span>{t('plan.planId', { id: importPlan.id })}</span>
+                {progressLabel ? (
+                  <span>{t('plan.progress', { progress: progressLabel })}</span>
+                ) : null}
                 {importPlan.total_items > 0 ? (
-                  <span>{progressPercent}% complete</span>
+                  <span>
+                    {t('plan.percentComplete', { percent: progressPercent })}
+                  </span>
                 ) : null}
               </div>
               {importPlan.total_items > 0 ? (
@@ -442,19 +459,25 @@ export default function Importer() {
             </div>
             <div className="importer__summary-grid importer__summary-grid--three">
               <div className="importer__summary-card">
-                <div className="importer__summary-label">Will Create</div>
+                <div className="importer__summary-label">
+                  {t('plan.willCreate')}
+                </div>
                 <div className="importer__summary-value">
                   {plannedCreateCount}
                 </div>
               </div>
               <div className="importer__summary-card">
-                <div className="importer__summary-label">Will Update</div>
+                <div className="importer__summary-label">
+                  {t('plan.willUpdate')}
+                </div>
                 <div className="importer__summary-value">
                   {plannedUpdateCount}
                 </div>
               </div>
               <div className="importer__summary-card">
-                <div className="importer__summary-label">Will Skip</div>
+                <div className="importer__summary-label">
+                  {t('plan.willSkip')}
+                </div>
                 <div className="importer__summary-value">
                   {plannedSkipCount}
                 </div>
@@ -463,17 +486,18 @@ export default function Importer() {
             {importStatus === 'running' && (
               <p className="settings__section-description importer__status-copy">
                 {importPlan.cancel_requested
-                  ? 'Cancellation has been requested. The importer will stop after the current item finishes.'
-                  : 'The import is running in the background. You can stay on this page to watch progress.'}
+                  ? t('plan.runningCancelRequested')
+                  : t('plan.runningInBackground')}
                 {importPlan.current_item_source_path
-                  ? ` Currently processing ${importPlan.current_item_source_path}.`
+                  ? t('plan.currentlyProcessing', {
+                      path: importPlan.current_item_source_path,
+                    })
                   : ''}
               </p>
             )}
             {importStatus === 'canceled' && (
               <p className="settings__section-description importer__status-copy">
-                The import was canceled. Completed items were kept, and the
-                partial result is shown below.
+                {t('plan.canceledNotice')}
               </p>
             )}
             {importStatus === 'failed' && importPlan.execution_error && (
@@ -487,23 +511,27 @@ export default function Importer() {
                 <table className="settings__table">
                   <tbody>
                     <tr>
-                      <th className="settings__table-header-cell">ID:</th>
+                      <th className="settings__table-header-cell">
+                        {t('plan.idLabel')}
+                      </th>
                       <td>{importPlan.id}</td>
                     </tr>
                     <tr>
                       <th className="settings__table-header-cell">
-                        Tree Hash:
+                        {t('plan.treeHashLabel')}
                       </th>
                       <td>{importPlan.tree_hash}</td>
                     </tr>
                     <tr>
-                      <th className="settings__table-header-cell">Progress:</th>
+                      <th className="settings__table-header-cell">
+                        {t('plan.progressLabel')}
+                      </th>
                       <td>{progressLabel ?? '0/0'}</td>
                     </tr>
                     {importPlan.started_at && (
                       <tr>
                         <th className="settings__table-header-cell">
-                          Started At:
+                          {t('plan.startedAtLabel')}
                         </th>
                         <td>
                           {new Date(importPlan.started_at).toLocaleString()}
@@ -513,7 +541,7 @@ export default function Importer() {
                     {importPlan.finished_at && (
                       <tr>
                         <th className="settings__table-header-cell">
-                          Finished At:
+                          {t('plan.finishedAtLabel')}
                         </th>
                         <td>
                           {new Date(importPlan.finished_at).toLocaleString()}
@@ -537,7 +565,7 @@ export default function Importer() {
                 ) : (
                   <UploadIcon className="mr-2 h-4 w-4" />
                 )}
-                Start New Import
+                {t('plan.startNewImport')}
               </Button>
               <Button
                 variant="destructive"
@@ -551,7 +579,7 @@ export default function Importer() {
                 ) : (
                   <XIcon className="mr-2 h-4 w-4" />
                 )}
-                Close and Clear
+                {t('plan.closeAndClear')}
               </Button>
             </div>
           </div>
@@ -560,11 +588,10 @@ export default function Importer() {
           <>
             <div className="settings__section">
               <h2 className="settings__section-title">
-                Planned Items ({importPlan.items.length})
+                {t('plannedItems.title', { count: importPlan.items.length })}
               </h2>
               <p className="settings__section-description">
-                These are the individual files LeafWiki detected in the package
-                and how they map to target pages.
+                {t('plannedItems.description')}
               </p>
               <div className="settings__field">
                 <div className="settings__table-card">
@@ -573,18 +600,22 @@ export default function Importer() {
                       <thead className="settings__table-head">
                         <tr>
                           <th className="settings__table-header-cell">
-                            Import File
+                            {t('plannedItems.importFile')}
                           </th>
                           <th className="settings__table-header-cell">
-                            Target Page
-                          </th>
-                          <th className="settings__table-header-cell">Title</th>
-                          <th className="settings__table-header-cell">Type</th>
-                          <th className="settings__table-header-cell">
-                            Planned Action
+                            {t('plannedItems.targetPage')}
                           </th>
                           <th className="settings__table-header-cell">
-                            Notes for Review
+                            {t('plannedItems.titleColumn')}
+                          </th>
+                          <th className="settings__table-header-cell">
+                            {t('plannedItems.type')}
+                          </th>
+                          <th className="settings__table-header-cell">
+                            {t('plannedItems.plannedAction')}
+                          </th>
+                          <th className="settings__table-header-cell">
+                            {t('plannedItems.notesForReview')}
                           </th>
                         </tr>
                       </thead>
@@ -615,7 +646,7 @@ export default function Importer() {
                                 item.notes.join(', ')
                               ) : (
                                 <span className="importer__muted-copy">
-                                  No special notes
+                                  {t('plannedItems.noSpecialNotes')}
                                 </span>
                               )}
                             </td>
@@ -631,11 +662,11 @@ export default function Importer() {
         )}
         {importPlan && showRunSection && (
           <div className="settings__section">
-            <h2 className="settings__section-title">Run Import</h2>
+            <h2 className="settings__section-title">{t('run.title')}</h2>
             <p className="settings__section-description">
               {showPlanStep
-                ? 'Start the import once the plan looks correct. You can also clear the current plan and begin again with a different package.'
-                : 'The importer is currently working through the generated plan. You can stay on this page to monitor progress or request cancellation.'}
+                ? t('run.descriptionPlan')
+                : t('run.descriptionRunning')}
             </p>
             {showRunStep && (
               <>
@@ -643,7 +674,7 @@ export default function Importer() {
                   <div className="importer__status-header">
                     <div>
                       <div className="settings__preview-label">
-                        Current Status
+                        {t('run.currentStatus')}
                       </div>
                       <div className="importer__status-title">
                         {statusLabel}
@@ -652,12 +683,18 @@ export default function Importer() {
                     <span className={statusPillClass}>{statusLabel}</span>
                   </div>
                   <div className="importer__status-meta">
-                    <span>Plan ID: {importPlan.id}</span>
+                    <span>{t('plan.planId', { id: importPlan.id })}</span>
                     {progressLabel ? (
-                      <span>Progress: {progressLabel}</span>
+                      <span>
+                        {t('plan.progress', { progress: progressLabel })}
+                      </span>
                     ) : null}
                     {importPlan.total_items > 0 ? (
-                      <span>{progressPercent}% complete</span>
+                      <span>
+                        {t('plan.percentComplete', {
+                          percent: progressPercent,
+                        })}
+                      </span>
                     ) : null}
                   </div>
                   {importPlan.total_items > 0 ? (
@@ -671,10 +708,12 @@ export default function Importer() {
                 </div>
                 <p className="settings__section-description importer__status-copy">
                   {importPlan.cancel_requested
-                    ? 'Cancellation has been requested. The importer will stop after the current item finishes.'
-                    : 'The import is running in the background. You can stay on this page to watch progress.'}
+                    ? t('plan.runningCancelRequested')
+                    : t('plan.runningInBackground')}
                   {importPlan.current_item_source_path
-                    ? ` Currently processing ${importPlan.current_item_source_path}.`
+                    ? t('plan.currentlyProcessing', {
+                        path: importPlan.current_item_source_path,
+                      })
                     : ''}
                 </p>
               </>
@@ -700,8 +739,8 @@ export default function Importer() {
                   <PlayIcon className="mr-2 h-4 w-4" />
                 )}
                 {importStatus === 'running'
-                  ? 'Import Running'
-                  : 'Execute Import Plan'}
+                  ? t('run.importRunning')
+                  : t('run.executeImportPlan')}
               </Button>
               <Button
                 variant="destructive"
@@ -726,42 +765,45 @@ export default function Importer() {
         )}
         {importResult && showResultStep && (
           <div className="settings__section">
-            <h2 className="settings__section-title">Import Result</h2>
+            <h2 className="settings__section-title">{t('result.title')}</h2>
             <p className="settings__section-description">
-              This is the final outcome of the import. Skipped items usually
-              need manual review, while failed items need attention before
-              retrying.
+              {t('result.description')}
             </p>
             <div className="importer__callout">
               <div className="importer__callout-title">
-                Want to import another package?
+                {t('result.wantAnotherTitle')}
               </div>
               <div className="importer__callout-body">
-                <span>
-                  Start a new import to clear this result and choose a different
-                  zip file.
-                </span>
+                <span>{t('result.wantAnotherBody')}</span>
               </div>
             </div>
             <div className="importer__summary-grid">
               <div className="importer__summary-card">
-                <div className="importer__summary-label">Created</div>
+                <div className="importer__summary-label">
+                  {t('result.created')}
+                </div>
                 <div className="importer__summary-value">{createdCount}</div>
               </div>
               <div className="importer__summary-card">
-                <div className="importer__summary-label">Skipped</div>
+                <div className="importer__summary-label">
+                  {t('result.skipped')}
+                </div>
                 <div className="importer__summary-value">{skippedCount}</div>
               </div>
               <div className="importer__summary-card">
-                <div className="importer__summary-label">Failed</div>
+                <div className="importer__summary-label">
+                  {t('result.failed')}
+                </div>
                 <div className="importer__summary-value">{failedCount}</div>
               </div>
               <div className="importer__summary-card">
-                <div className="importer__summary-label">Tree Updated</div>
+                <div className="importer__summary-label">
+                  {t('result.treeUpdated')}
+                </div>
                 <div className="importer__summary-value">
                   {importResult.tree_hash === importResult.tree_hash_before
-                    ? 'No'
-                    : 'Yes'}
+                    ? t('result.no')
+                    : t('result.yes')}
                 </div>
               </div>
             </div>
@@ -772,19 +814,19 @@ export default function Importer() {
                   <tbody>
                     <tr>
                       <th className="settings__table-header-cell">
-                        Imported Count:
+                        {t('result.importedCount')}
                       </th>
                       <td>{importResult.imported_count}</td>
                     </tr>
                     <tr>
                       <th className="settings__table-header-cell">
-                        Updated Count:
+                        {t('result.updatedCount')}
                       </th>
                       <td>{importResult.updated_count}</td>
                     </tr>
                     <tr>
                       <th className="settings__table-header-cell">
-                        Skipped Count:
+                        {t('result.skippedCount')}
                       </th>
                       <td>{importResult.skipped_count}</td>
                     </tr>
@@ -805,7 +847,7 @@ export default function Importer() {
                 ) : (
                   <UploadIcon className="mr-2 h-4 w-4" />
                 )}
-                Start New Import
+                {t('plan.startNewImport')}
               </Button>
               <Button
                 variant="destructive"
@@ -819,7 +861,7 @@ export default function Importer() {
                 ) : (
                   <XIcon className="mr-2 h-4 w-4" />
                 )}
-                Close and Clear
+                {t('plan.closeAndClear')}
               </Button>
             </div>
           </div>
@@ -827,12 +869,13 @@ export default function Importer() {
         {importResult && showResultStep && importResult.items.length > 0 && (
           <div className="settings__section">
             <h2 className="settings__section-title">
-              Result Items ({filteredResultItems.length}/
-              {importResult.items.length})
+              {t('resultItems.title', {
+                filtered: filteredResultItems.length,
+                total: importResult.items.length,
+              })}
             </h2>
             <p className="settings__section-description">
-              Use the filters to focus on successful imports, skipped items, or
-              failures.
+              {t('resultItems.description')}
             </p>
             <div className="importer__result-toolbar">
               <div className="importer__filter-group">
@@ -858,7 +901,7 @@ export default function Importer() {
               <input
                 type="search"
                 className="importer__search"
-                placeholder="Filter by path, action, or error"
+                placeholder={t('resultItems.filterPlaceholder')}
                 value={resultSearch}
                 onChange={(e) => {
                   setResultSearch(e.target.value)
@@ -871,13 +914,17 @@ export default function Importer() {
                   <thead className="settings__table-head">
                     <tr>
                       <th className="settings__table-header-cell">
-                        Imported File
+                        {t('resultItems.importedFile')}
                       </th>
                       <th className="settings__table-header-cell">
-                        Resulting Page
+                        {t('resultItems.resultingPage')}
                       </th>
-                      <th className="settings__table-header-cell">Outcome</th>
-                      <th className="settings__table-header-cell">Details</th>
+                      <th className="settings__table-header-cell">
+                        {t('resultItems.outcome')}
+                      </th>
+                      <th className="settings__table-header-cell">
+                        {t('resultItems.details')}
+                      </th>
                     </tr>
                   </thead>
                   <tbody>
@@ -906,14 +953,14 @@ export default function Importer() {
                           {item.error ? (
                             item.error
                           ) : item.action === 'created' ? (
-                            'Imported successfully'
+                            t('resultItems.detailImported')
                           ) : item.action === 'updated' ? (
-                            'Existing page was updated'
+                            t('resultItems.detailUpdated')
                           ) : item.action === 'skipped' ? (
-                            'Skipped without error'
+                            t('resultItems.detailSkipped')
                           ) : (
                             <span className="importer__muted-copy">
-                              No extra details
+                              {t('resultItems.detailNone')}
                             </span>
                           )}
                         </td>
@@ -925,7 +972,7 @@ export default function Importer() {
                           className="settings__table-body-message"
                           colSpan={4}
                         >
-                          No items match the current filter.
+                          {t('resultItems.noItemsMatch')}
                         </td>
                       </tr>
                     )}

--- a/ui/leafwiki-ui/src/features/links/LinkInfo.tsx
+++ b/ui/leafwiki-ui/src/features/links/LinkInfo.tsx
@@ -46,7 +46,9 @@ export function BacklinkInfo() {
     <div className="backlinks__pane">
       <div className="backlinks__content">
         {error && !loading ? (
-          <p className="page-viewer__error">Error: {error}</p>
+          <p className="page-viewer__error">
+            {t('backlinks.errorPrefix', { error })}
+          </p>
         ) : null}
 
         <div className="backlinks__group">

--- a/ui/leafwiki-ui/src/features/page-switcher/PageQuickSwitcherDialog.tsx
+++ b/ui/leafwiki-ui/src/features/page-switcher/PageQuickSwitcherDialog.tsx
@@ -14,10 +14,12 @@ import { useDialogsStore } from '@/stores/dialogs'
 import { useTreeStore } from '@/stores/tree'
 import { File, FolderTree } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
 import { searchQuickSwitcherItems } from './pageQuickSwitcher'
 
 export function PageQuickSwitcherDialog() {
+  const { t } = useTranslation('viewer')
   const navigate = useNavigate()
   const closeDialog = useDialogsStore((state) => state.closeDialog)
   const isOpen = useDialogsStore(
@@ -92,9 +94,9 @@ export function PageQuickSwitcherDialog() {
     >
       <DialogContent className="max-h-[85dvh] gap-0 overflow-hidden p-0 sm:max-w-2xl">
         <DialogHeader className="border-b px-4 pt-4 pb-3">
-          <DialogTitle>Go to page</DialogTitle>
+          <DialogTitle>{t('pageSwitcher.dialogTitle')}</DialogTitle>
           <DialogDescription>
-            Search existing pages by title, path, or breadcrumb.
+            {t('pageSwitcher.dialogDescription')}
           </DialogDescription>
         </DialogHeader>
 
@@ -102,8 +104,8 @@ export function PageQuickSwitcherDialog() {
           <Input
             ref={inputRef}
             defaultValue=""
-            placeholder="Type a page title…"
-            aria-label="Search pages"
+            placeholder={t('pageSwitcher.searchPlaceholder')}
+            aria-label={t('pageSwitcher.searchAriaLabel')}
             role="combobox"
             aria-haspopup="listbox"
             aria-activedescendant={
@@ -151,13 +153,13 @@ export function PageQuickSwitcherDialog() {
         <div className="custom-scrollbar max-h-[70dvh] overflow-y-auto px-2 pb-2">
           {results.length === 0 ? (
             <div className="text-muted-foreground px-2 py-6 text-sm">
-              No matching page found.
+              {t('pageSwitcher.noMatch')}
             </div>
           ) : (
             <ul
               id="page-quick-switcher-results"
               role="listbox"
-              aria-label="Matching pages"
+              aria-label={t('pageSwitcher.matchingPagesAriaLabel')}
               className="space-y-1"
             >
               {results.map((item, index) => {

--- a/ui/leafwiki-ui/src/features/page-switcher/PageQuickSwitcherTrigger.tsx
+++ b/ui/leafwiki-ui/src/features/page-switcher/PageQuickSwitcherTrigger.tsx
@@ -9,6 +9,7 @@ import { useDialogsStore } from '@/stores/dialogs'
 import { useHotKeysStore } from '@/stores/hotkeys'
 import { FileSearch } from 'lucide-react'
 import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 
 const isMacOS =
   typeof navigator !== 'undefined' &&
@@ -19,6 +20,7 @@ const quickSwitcherHotkeyLabel = getShortcutDisplayLabel(
 )
 
 export function PageQuickSwitcherTrigger() {
+  const { t } = useTranslation('viewer')
   const appMode = useAppMode()
   const openDialog = useDialogsStore((state) => state.openDialog)
   const registerHotkey = useHotKeysStore((state) => state.registerHotkey)
@@ -43,12 +45,14 @@ export function PageQuickSwitcherTrigger() {
       variant="outline"
       size="sm"
       onClick={() => openDialog(DIALOG_PAGE_QUICK_SWITCHER)}
-      aria-label="Go to page"
-      title={`Go to page (${quickSwitcherHotkeyLabel})`}
+      aria-label={t('pageSwitcher.trigger')}
+      title={t('pageSwitcher.triggerWithHotkey', {
+        hotkey: quickSwitcherHotkeyLabel,
+      })}
       className="max-md:px-2"
     >
       <FileSearch size={16} />
-      <span className="max-md:hidden">Go to page</span>
+      <span className="max-md:hidden">{t('pageSwitcher.trigger')}</span>
       <span className="text-muted-foreground ml-1 hidden text-xs md:inline">
         {quickSwitcherHotkeyLabel}
       </span>

--- a/ui/leafwiki-ui/src/features/page/AddPageDialog.tsx
+++ b/ui/leafwiki-ui/src/features/page/AddPageDialog.tsx
@@ -9,6 +9,7 @@ import { buildEditUrl } from '@/lib/routePath'
 import { useTreeStore } from '@/stores/tree'
 import { CalendarDays } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
 import { toast } from 'sonner'
 import { SlugInputWithSuggestion } from './SlugInputWithSuggestion'
@@ -24,6 +25,7 @@ export function AddPageDialog({
   parentId,
   nodeKind = NODE_KIND_PAGE,
 }: AddPageDialogProps) {
+  const { t } = useTranslation('page')
   const [title, setTitle] = useState('')
   const [slug, setSlug] = useState('')
   const [loading, setLoading] = useState(false)
@@ -34,8 +36,12 @@ export function AddPageDialog({
   const reloadTree = useTreeStore((s) => s.reloadTree)
   const parentPath = useTreeStore((s) => s.getPathById(parentId) || '')
   const navigate = useNavigate()
-  const itemLabel = nodeKind === NODE_KIND_PAGE ? 'page' : 'section'
-  const itemLabelCapitalized = nodeKind === NODE_KIND_PAGE ? 'Page' : 'Section'
+  const itemLabel =
+    nodeKind === NODE_KIND_PAGE ? t('common.page') : t('common.section')
+  const itemLabelCapitalized =
+    nodeKind === NODE_KIND_PAGE
+      ? t('common.pageCapitalized')
+      : t('common.sectionCapitalized')
 
   const isCreateButtonDisabled =
     !title ||
@@ -71,12 +77,12 @@ export function AddPageDialog({
       if (!title) return false
 
       if (!slug) {
-        toast.error('Slug could not be generated. Please enter it manually.')
+        toast.error(t('addDialog.slugNotGenerated'))
         return false
       }
 
       if (!slugTouched && (slugLoading || title !== lastSlugTitle)) {
-        toast.warning('Please wait until the slug is fully generated.')
+        toast.warning(t('addDialog.slugStillGenerating'))
         return false
       }
 
@@ -84,7 +90,9 @@ export function AddPageDialog({
       setFieldErrors({})
       try {
         await createPage({ title, slug, parentId, kind: nodeKind })
-        toast.success(`${itemLabelCapitalized} created`)
+        toast.success(
+          t('addDialog.createdToast', { item: itemLabelCapitalized }),
+        )
         await reloadTree()
         if (redirect) {
           const fullPath = parentPath !== '' ? `${parentPath}/${slug}` : slug
@@ -93,7 +101,11 @@ export function AddPageDialog({
         return true
       } catch (err: unknown) {
         console.warn(err)
-        handleFieldErrors(err, setFieldErrors, `Error creating ${itemLabel}`)
+        handleFieldErrors(
+          err,
+          setFieldErrors,
+          t('addDialog.createErrorFallback', { item: itemLabel }),
+        )
         return false
       } finally {
         setLoading(false)
@@ -111,6 +123,7 @@ export function AddPageDialog({
       navigate,
       itemLabel,
       itemLabelCapitalized,
+      t,
     ],
   )
 
@@ -122,7 +135,7 @@ export function AddPageDialog({
   const buttons = useMemo(() => {
     const b: BaseDialogConfirmButton[] = [
       {
-        label: 'Create',
+        label: t('addDialog.create'),
         actionType: 'no-redirect',
         autoFocus: true,
         loading,
@@ -132,7 +145,7 @@ export function AddPageDialog({
     ]
     if (nodeKind === NODE_KIND_PAGE) {
       b.push({
-        label: `Create & Edit ${itemLabelCapitalized}`,
+        label: t('addDialog.createAndEdit', { item: itemLabelCapitalized }),
         actionType: 'confirm',
         autoFocus: false,
         loading,
@@ -141,17 +154,19 @@ export function AddPageDialog({
       })
     }
     return b
-  }, [isCreateButtonDisabled, loading, nodeKind, itemLabelCapitalized])
+  }, [isCreateButtonDisabled, loading, nodeKind, itemLabelCapitalized, t])
 
   return (
     <BaseDialog
       dialogTitle={
-        nodeKind === 'page' ? 'Create a new page' : 'Create a new section'
+        nodeKind === 'page'
+          ? t('addDialog.titlePage')
+          : t('addDialog.titleSection')
       }
       dialogDescription={
         nodeKind === 'page'
-          ? 'Enter the title of the new page'
-          : 'Enter the title of the new section'
+          ? t('addDialog.descriptionPage')
+          : t('addDialog.descriptionSection')
       }
       dialogType={DIALOG_ADD_PAGE}
       onClose={handleCancel}
@@ -160,7 +175,7 @@ export function AddPageDialog({
       }}
       testidPrefix="add-page-dialog"
       cancelButton={{
-        label: 'Cancel',
+        label: t('common.cancel'),
         variant: 'outline',
         disabled: loading,
         autoFocus: false,
@@ -171,14 +186,16 @@ export function AddPageDialog({
         <div className="page-dialog__title-row">
           <FormInput
             autoFocus={true}
-            label="Title"
+            label={t('addDialog.titleLabel')}
             value={title}
             onChange={(val) => {
               handleTitleChange(val)
               setFieldErrors((prev) => ({ ...prev, title: '' }))
             }}
             testid="add-page-title-input"
-            placeholder={`${itemLabelCapitalized} title`}
+            placeholder={t('addDialog.titlePlaceholder', {
+              item: itemLabelCapitalized,
+            })}
             error={fieldErrors.title}
             allowedHotkeys={DIALOG_INPUT_ALLOWED_HOTKEYS}
           />
@@ -211,7 +228,7 @@ export function AddPageDialog({
         />
       </div>
       <span className="dialog__path" data-testid="add-page-path-display">
-        Path: {parentPath !== '' && `${parentPath}/`}
+        {t('addDialog.pathPrefix')} {parentPath !== '' && `${parentPath}/`}
         {slug && `${slug}`}
       </span>
     </BaseDialog>

--- a/ui/leafwiki-ui/src/features/page/CopyPageDialog.tsx
+++ b/ui/leafwiki-ui/src/features/page/CopyPageDialog.tsx
@@ -6,6 +6,7 @@ import { DIALOG_COPY_PAGE } from '@/lib/registries'
 import { buildEditUrl } from '@/lib/routePath'
 import { useTreeStore } from '@/stores/tree'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
 import { toast } from 'sonner'
 import { PageSelect } from './PageSelect'
@@ -16,6 +17,7 @@ const DIALOG_INPUT_ALLOWED_HOTKEYS = 'Enter'
 type CopyPageSource = Pick<PageNode, 'id' | 'title' | 'kind'>
 
 export function CopyPageDialog({ sourcePage }: { sourcePage: CopyPageSource }) {
+  const { t } = useTranslation('page')
   const [targetParentID, setTargetParentID] = useState<string>('root')
   const [title, setTitle] = useState<string>('')
   const [loading, setLoading] = useState<boolean>(false)
@@ -26,9 +28,12 @@ export function CopyPageDialog({ sourcePage }: { sourcePage: CopyPageSource }) {
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
   const parentPath = useTreeStore((s) => s.getPathById(targetParentID) || '')
   const navigate = useNavigate()
-  const itemLabel = sourcePage.kind === NODE_KIND_PAGE ? 'page' : 'section'
+  const itemLabel =
+    sourcePage.kind === NODE_KIND_PAGE ? t('common.page') : t('common.section')
   const itemLabelCapitalized =
-    sourcePage.kind === NODE_KIND_PAGE ? 'Page' : 'Section'
+    sourcePage.kind === NODE_KIND_PAGE
+      ? t('common.pageCapitalized')
+      : t('common.sectionCapitalized')
 
   const { tree, reloadTree } = useTreeStore()
 
@@ -88,12 +93,12 @@ export function CopyPageDialog({ sourcePage }: { sourcePage: CopyPageSource }) {
     if (!title) return false
 
     if (!slug) {
-      toast.error('Slug could not be generated. Please enter it manually.')
+      toast.error(t('copyDialog.slugNotGenerated'))
       return false
     }
 
     if (!slugTouched && (slugLoading || title !== lastSlugTitle)) {
-      toast.warning('Please wait until the slug is fully generated.')
+      toast.warning(t('copyDialog.slugStillGenerating'))
       return false
     }
 
@@ -101,7 +106,7 @@ export function CopyPageDialog({ sourcePage }: { sourcePage: CopyPageSource }) {
     setFieldErrors({})
     try {
       await copyPage(sourcePage.id, targetParentID, title, slug)
-      toast.success(`${itemLabelCapitalized} copied`)
+      toast.success(t('copyDialog.copiedToast', { item: itemLabelCapitalized }))
       await reloadTree()
       if (redirect) {
         const fullPath = parentPath !== '' ? `${parentPath}/${slug}` : slug
@@ -111,7 +116,11 @@ export function CopyPageDialog({ sourcePage }: { sourcePage: CopyPageSource }) {
       return true
     } catch (err: unknown) {
       console.warn(err)
-      handleFieldErrors(err, setFieldErrors, `Error copying ${itemLabel}`)
+      handleFieldErrors(
+        err,
+        setFieldErrors,
+        t('copyDialog.copyErrorFallback', { item: itemLabel }),
+      )
       return false
     } finally {
       setLoading(false)
@@ -120,9 +129,9 @@ export function CopyPageDialog({ sourcePage }: { sourcePage: CopyPageSource }) {
 
   useEffect(() => {
     if (sourcePage && sourcePage.title) {
-      setTitle(`Copy of ${sourcePage.title}`)
+      setTitle(t('copyDialog.copyOfTitle', { title: sourcePage.title }))
     }
-  }, [sourcePage])
+  }, [sourcePage, t])
 
   if (!sourcePage) return null
 
@@ -130,8 +139,8 @@ export function CopyPageDialog({ sourcePage }: { sourcePage: CopyPageSource }) {
 
   return (
     <BaseDialog
-      dialogTitle={`Copy ${itemLabelCapitalized}`}
-      dialogDescription={`Create a copy of this ${itemLabel}`}
+      dialogTitle={t('copyDialog.title', { item: itemLabelCapitalized })}
+      dialogDescription={t('copyDialog.description', { item: itemLabel })}
       dialogType={DIALOG_COPY_PAGE}
       onClose={handleCancel}
       onConfirm={async (): Promise<boolean> => {
@@ -139,14 +148,16 @@ export function CopyPageDialog({ sourcePage }: { sourcePage: CopyPageSource }) {
       }}
       testidPrefix="copy-page-dialog"
       cancelButton={{
-        label: 'Cancel',
+        label: t('common.cancel'),
         variant: 'outline',
         disabled: loading,
         autoFocus: false,
       }}
       buttons={[
         {
-          label: loading ? 'Copying...' : `Copy & Edit ${itemLabelCapitalized}`,
+          label: loading
+            ? t('copyDialog.copying')
+            : t('copyDialog.copyAndEdit', { item: itemLabelCapitalized }),
           actionType: 'confirm',
           autoFocus: true,
           loading,
@@ -158,12 +169,14 @@ export function CopyPageDialog({ sourcePage }: { sourcePage: CopyPageSource }) {
       <FormInput
         testid="copy-page-dialog-title-input"
         autoFocus={true}
-        label="Title"
+        label={t('copyDialog.titleLabel')}
         value={title}
         onChange={(val) => {
           handleTitleChange(val)
         }}
-        placeholder={`${itemLabelCapitalized} title`}
+        placeholder={t('copyDialog.titlePlaceholder', {
+          item: itemLabelCapitalized,
+        })}
         error={fieldErrors.title}
         allowedHotkeys={DIALOG_INPUT_ALLOWED_HOTKEYS}
       />
@@ -181,7 +194,7 @@ export function CopyPageDialog({ sourcePage }: { sourcePage: CopyPageSource }) {
       />
       <PageSelect pageID={targetParentID} onChange={setTargetParentID} />
       <span className="dialog__path">
-        Path: {parentPath !== '' && `${parentPath}/`}
+        {t('copyDialog.pathPrefix')} {parentPath !== '' && `${parentPath}/`}
         {slug && `${slug}`}
       </span>
     </BaseDialog>

--- a/ui/leafwiki-ui/src/features/page/CreatePageByPathDialog.tsx
+++ b/ui/leafwiki-ui/src/features/page/CreatePageByPathDialog.tsx
@@ -8,6 +8,7 @@ import { useDebounce } from '@/lib/useDebounce'
 import { useTreeStore } from '@/stores/tree'
 import { Check, X } from 'lucide-react'
 import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
 import { toast } from 'sonner'
 
@@ -26,6 +27,7 @@ export function CreatePageByPathDialog({
   readOnlyPath,
   forwardToEditMode,
 }: CreatePageByPathDialogProps) {
+  const { t } = useTranslation('page')
   // Dialog state from zustand store
   const navigate = useNavigate()
 
@@ -68,11 +70,15 @@ export function CreatePageByPathDialog({
         navigate(buildEditUrl(path))
       }
 
-      toast.success('Page created successfully')
+      toast.success(t('createByPathDialog.createdToast'))
       return true // Close the dialog
     } catch (err: unknown) {
       console.warn(err)
-      handleFieldErrors(err, setFieldErrors, 'Error creating page')
+      handleFieldErrors(
+        err,
+        setFieldErrors,
+        t('createByPathDialog.createErrorFallback'),
+      )
       return false // Keep the dialog open
     } finally {
       setLoading(false)
@@ -100,8 +106,8 @@ export function CreatePageByPathDialog({
 
   return (
     <BaseDialog
-      dialogTitle="Create a new page"
-      dialogDescription="Please enter the title"
+      dialogTitle={t('createByPathDialog.title')}
+      dialogDescription={t('createByPathDialog.description')}
       dialogType={DIALOG_CREATE_PAGE_BY_PATH}
       testidPrefix="create-page-by-path-dialog"
       onClose={() => true}
@@ -109,7 +115,7 @@ export function CreatePageByPathDialog({
         return await handleCreate()
       }}
       cancelButton={{
-        label: 'Cancel',
+        label: t('common.cancel'),
         variant: 'outline',
         disabled: loading,
         autoFocus: false,
@@ -117,10 +123,10 @@ export function CreatePageByPathDialog({
       buttons={[
         {
           label: loading
-            ? 'Creating...'
+            ? t('createByPathDialog.creating')
             : !forwardToEditMode
-              ? 'Create'
-              : 'Create & Edit',
+              ? t('createByPathDialog.create')
+              : t('createByPathDialog.createAndEdit'),
           actionType: 'confirm',
           autoFocus: true,
           loading,
@@ -132,13 +138,13 @@ export function CreatePageByPathDialog({
       <div>
         {lookup?.exists && (
           <div className="create-page-by-path-dialog__alert">
-            A page already exists at this path.
+            {t('createByPathDialog.existsAlert')}
           </div>
         )}
         {lookup && !lookup.exists && lookup.segments.length > 0 && (
           <>
             <strong className="create-page-by-path-dialog__lookup-title">
-              Result of path lookup:
+              {t('createByPathDialog.lookupResultTitle')}
             </strong>
             <ul className="custom-scrollbar create-page-by-path-dialog__lookup-list">
               {lookup.segments.map((segment, index) => (
@@ -160,7 +166,9 @@ export function CreatePageByPathDialog({
                   <span className="create-page-by-path-dialog__lookup-item-slug">
                     {segment.slug}
                   </span>{' '}
-                  {segment.exists ? 'exists' : 'will be created'}
+                  {segment.exists
+                    ? t('createByPathDialog.segmentExists')
+                    : t('createByPathDialog.segmentWillBeCreated')}
                 </li>
               ))}
             </ul>
@@ -171,26 +179,26 @@ export function CreatePageByPathDialog({
         <FormInput
           autoFocus={true}
           testid="create-page-by-path-title-input"
-          label="Title"
+          label={t('createByPathDialog.titleLabel')}
           value={title}
           onChange={(val) => {
             handleTitleChange(val)
             setFieldErrors((prev) => ({ ...prev, title: '' }))
           }}
-          placeholder="Page title"
+          placeholder={t('createByPathDialog.titlePlaceholder')}
           error={fieldErrors.title}
           allowedHotkeys={DIALOG_INPUT_ALLOWED_HOTKEYS}
         />
         <FormInput
           testid="create-page-by-path-path-input"
-          label="Path"
+          label={t('createByPathDialog.pathLabel')}
           value={path}
           readOnly={readOnlyPath}
           onChange={(val) => {
             setPath(val)
             setFieldErrors((prev) => ({ ...prev, path: '' }))
           }}
-          placeholder="Page path"
+          placeholder={t('createByPathDialog.pathPlaceholder')}
           error={fieldErrors.path}
           allowedHotkeys={DIALOG_INPUT_ALLOWED_HOTKEYS}
         />

--- a/ui/leafwiki-ui/src/features/page/DeletePageDialog.tsx
+++ b/ui/leafwiki-ui/src/features/page/DeletePageDialog.tsx
@@ -11,6 +11,7 @@ import { useConfigStore } from '@/stores/config'
 import { useTreeStore } from '@/stores/tree'
 import { AlertTriangle } from 'lucide-react'
 import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router'
 import { toast } from 'sonner'
 
@@ -23,6 +24,7 @@ export function DeletePageDialog({
   pageId,
   redirectTo,
 }: DeletePageDialogProps) {
+  const { t } = useTranslation('page')
   const enableLinkRefactor = useConfigStore((s) => s.enableLinkRefactor)
   const navigate = useNavigate()
   const reloadTree = useTreeStore((s) => s.reloadTree)
@@ -57,7 +59,9 @@ export function DeletePageDialog({
       } catch (err) {
         if (cancelled) return
         const message =
-          err instanceof Error ? err.message : 'Failed to load page references'
+          err instanceof Error
+            ? err.message
+            : t('deleteDialog.loadReferencesErrorFallback')
         setBacklinksError(message)
         setBacklinks([])
       } finally {
@@ -72,18 +76,24 @@ export function DeletePageDialog({
     return () => {
       cancelled = true
     }
-  }, [enableLinkRefactor, pageId])
+  }, [enableLinkRefactor, pageId, t])
 
   if (!page) return null
   const hasChildren = (page.children?.length ?? 0) > 0
-  const itemLabel = page.kind === NODE_KIND_PAGE ? 'page' : 'section'
-  const itemLabelCapitalized = page.kind === NODE_KIND_PAGE ? 'Page' : 'Section'
+  const itemLabel =
+    page.kind === NODE_KIND_PAGE ? t('common.page') : t('common.section')
+  const itemLabelCapitalized =
+    page.kind === NODE_KIND_PAGE
+      ? t('common.pageCapitalized')
+      : t('common.sectionCapitalized')
 
   const handleDelete = async (): Promise<boolean> => {
     setLoading(true)
     try {
       await deletePage(pageId, deleteRecursive, page?.version ?? '')
-      toast.success(`${itemLabelCapitalized} deleted successfully`)
+      toast.success(
+        t('deleteDialog.deletedToast', { item: itemLabelCapitalized }),
+      )
       navigate(redirectTo, { state: createNavigationVisitState() })
       reloadTree().catch(console.error)
       return true
@@ -101,7 +111,11 @@ export function DeletePageDialog({
         }
         setPageModifiedWarning(true)
       } else {
-        handleFieldErrors(err, setFieldErrors, `Error deleting ${itemLabel}`)
+        handleFieldErrors(
+          err,
+          setFieldErrors,
+          t('deleteDialog.deleteErrorFallback', { item: itemLabel }),
+        )
       }
       return false
     } finally {
@@ -112,8 +126,8 @@ export function DeletePageDialog({
   return (
     <BaseDialog
       dialogType={DIALOG_DELETE_PAGE_CONFIRMATION}
-      dialogTitle={`Delete ${itemLabelCapitalized}?`}
-      dialogDescription={`Are you sure you want to delete this ${itemLabel}? This action cannot be undone.`}
+      dialogTitle={t('deleteDialog.title', { item: itemLabelCapitalized })}
+      dialogDescription={t('deleteDialog.description', { item: itemLabel })}
       onClose={() => true}
       onConfirm={async (): Promise<boolean> => {
         return await handleDelete()
@@ -121,14 +135,16 @@ export function DeletePageDialog({
       defaultAction="cancel"
       testidPrefix="delete-page-dialog"
       cancelButton={{
-        label: 'Cancel',
+        label: t('common.cancel'),
         variant: 'outline',
         disabled: loading,
         autoFocus: true,
       }}
       buttons={[
         {
-          label: loading ? 'Deleting...' : 'Delete',
+          label: loading
+            ? t('deleteDialog.deleting')
+            : t('deleteDialog.delete'),
           actionType: 'confirm',
           autoFocus: false,
           loading,
@@ -145,11 +161,9 @@ export function DeletePageDialog({
           >
             <div className="flex items-start gap-2 font-medium">
               <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-              <span>This page was modified by another user.</span>
+              <span>{t('deleteDialog.modifiedWarningTitle')}</span>
             </div>
-            <p className="mt-1">
-              The page has been refreshed. Do you still want to delete it?
-            </p>
+            <p className="mt-1">{t('deleteDialog.modifiedWarningBody')}</p>
           </div>
         )}
         {enableLinkRefactor &&
@@ -158,15 +172,14 @@ export function DeletePageDialog({
               className="text-muted-foreground text-sm"
               data-testid="delete-page-dialog-backlinks-loading"
             >
-              Checking which pages reference this page...
+              {t('deleteDialog.backlinksLoading')}
             </p>
           ) : backlinksError ? (
             <div
               className="rounded border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900"
               data-testid="delete-page-dialog-backlinks-error"
             >
-              Could not load page references. Deleting will still work, but link
-              impact could not be shown.
+              {t('deleteDialog.backlinksError')}
             </div>
           ) : backlinks.length > 0 ? (
             <div
@@ -176,12 +189,13 @@ export function DeletePageDialog({
               <div className="flex items-start gap-2 font-medium">
                 <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
                 <span>
-                  This page is referenced by {backlinks.length} page
-                  {backlinks.length === 1 ? '' : 's'}.
+                  {t('deleteDialog.backlinksWarning', {
+                    count: backlinks.length,
+                  })}
                 </span>
               </div>
               <p className="mt-2 text-sm">
-                Deleting this page will leave those links broken.
+                {t('deleteDialog.backlinksWarningBody')}
               </p>
               <ul
                 className="mt-3 max-h-40 space-y-1 overflow-auto pr-1 text-sm"
@@ -205,7 +219,7 @@ export function DeletePageDialog({
               className="text-muted-foreground text-sm"
               data-testid="delete-page-dialog-no-backlinks"
             >
-              No pages currently reference this page.
+              {t('deleteDialog.noBacklinks')}
             </p>
           ))}
 
@@ -217,7 +231,7 @@ export function DeletePageDialog({
                 checked={deleteRecursive}
                 onCheckedChange={(val) => setDeleteRecursive(!!val)}
               />
-              Also delete all subpages
+              {t('deleteDialog.deleteSubpages')}
             </label>
           </div>
         )}

--- a/ui/leafwiki-ui/src/features/page/EditPageMetadataDialog.tsx
+++ b/ui/leafwiki-ui/src/features/page/EditPageMetadataDialog.tsx
@@ -29,8 +29,14 @@ export function EditPageMetadataDialog({
   onChange,
 }: EditPageMetadataDialogProps) {
   const parentPath = useTreeStore((s) => s.getPathById(parentId) || '')
-  const itemLabel = itemKind === NODE_KIND_PAGE ? 'page' : 'section'
-  const itemLabelCapitalized = itemKind === NODE_KIND_PAGE ? 'Page' : 'Section'
+  const itemLabel =
+    itemKind === NODE_KIND_PAGE
+      ? i18next.t('common.page', { ns: 'page' })
+      : i18next.t('common.section', { ns: 'page' })
+  const itemLabelCapitalized =
+    itemKind === NODE_KIND_PAGE
+      ? i18next.t('common.pageCapitalized', { ns: 'page' })
+      : i18next.t('common.sectionCapitalized', { ns: 'page' })
 
   const [title, setTitle] = useState(propTitle)
   const [slug, setSlug] = useState(propSlug)
@@ -68,8 +74,14 @@ export function EditPageMetadataDialog({
   return (
     <BaseDialog
       dialogType={DIALOG_EDIT_PAGE_METADATA}
-      dialogTitle={`Edit ${itemLabel} metadata`}
-      dialogDescription={`Change metadata of the ${itemLabel}`}
+      dialogTitle={i18next.t('editPageMetadataDialog.dialogTitle', {
+        ns: 'editor',
+        item: itemLabel,
+      })}
+      dialogDescription={i18next.t('editPageMetadataDialog.dialogDescription', {
+        ns: 'editor',
+        item: itemLabel,
+      })}
       onClose={() => {
         resetForm()
         return true
@@ -110,7 +122,10 @@ export function EditPageMetadataDialog({
             })}
             value={title}
             onChange={handleTitleChange}
-            placeholder={`${itemLabelCapitalized} title`}
+            placeholder={i18next.t('editPageMetadataDialog.titlePlaceholder', {
+              ns: 'editor',
+              item: itemLabelCapitalized,
+            })}
             error={fieldErrors.title}
             testid="edit-page-metadata-dialog-title-input"
             allowedHotkeys={DIALOG_INPUT_ALLOWED_HOTKEYS}

--- a/ui/leafwiki-ui/src/features/page/MovePageDialog.tsx
+++ b/ui/leafwiki-ui/src/features/page/MovePageDialog.tsx
@@ -12,6 +12,7 @@ import { DIALOG_MOVE_PAGE } from '@/lib/registries'
 import { useConfigStore } from '@/stores/config'
 import { useTreeStore } from '@/stores/tree'
 import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router'
 import { toast } from 'sonner'
 import { PageSelect } from './PageSelect'
@@ -19,6 +20,7 @@ import { refreshAfterPageRefactor } from './pageMutationRefresh'
 import { confirmPageRefactor } from './pageRefactorDialogState'
 
 export function MovePageDialog({ pageId }: { pageId: string }) {
+  const { t } = useTranslation('page')
   const { tree } = useTreeStore()
   const [loading, setLoading] = useState(false)
   const [, setFieldErrors] = useState<Record<string, string>>({})
@@ -48,8 +50,12 @@ export function MovePageDialog({ pageId }: { pageId: string }) {
   if (!parentId) return null
   if (!page) return null
 
-  const itemLabel = page.kind === NODE_KIND_PAGE ? 'page' : 'section'
-  const itemLabelCapitalized = page.kind === NODE_KIND_PAGE ? 'Page' : 'Section'
+  const itemLabel =
+    page.kind === NODE_KIND_PAGE ? t('common.page') : t('common.section')
+  const itemLabelCapitalized =
+    page.kind === NODE_KIND_PAGE
+      ? t('common.pageCapitalized')
+      : t('common.sectionCapitalized')
 
   const getSyntheticMovePreview = (): PageRefactorPreview => {
     const nextParent = newParentId
@@ -109,11 +115,15 @@ export function MovePageDialog({ pageId }: { pageId: string }) {
         navigate,
       })
 
-      toast.success('Page moved successfully')
+      toast.success(t('moveDialog.movedToast'))
       return true // Close the dialog
     } catch (err: unknown) {
       console.warn(err)
-      handleFieldErrors(err, setFieldErrors, `Error moving ${itemLabel}`)
+      handleFieldErrors(
+        err,
+        setFieldErrors,
+        t('moveDialog.moveErrorFallback', { item: itemLabel }),
+      )
       return false
     } finally {
       setLoading(false)
@@ -124,8 +134,8 @@ export function MovePageDialog({ pageId }: { pageId: string }) {
     <BaseDialog
       dialogType={DIALOG_MOVE_PAGE}
       testidPrefix="move-page-dialog"
-      dialogTitle={`Move ${itemLabelCapitalized}`}
-      dialogDescription={`Select a new parent for this ${itemLabel}`}
+      dialogTitle={t('moveDialog.title', { item: itemLabelCapitalized })}
+      dialogDescription={t('moveDialog.description', { item: itemLabel })}
       onClose={() => true}
       onConfirm={async (type) => {
         if (type === 'confirm') {
@@ -134,14 +144,14 @@ export function MovePageDialog({ pageId }: { pageId: string }) {
         return false
       }}
       cancelButton={{
-        label: 'Cancel',
+        label: t('common.cancel'),
         variant: 'outline',
         autoFocus: false,
         disabled: loading,
       }}
       buttons={[
         {
-          label: 'Move',
+          label: t('moveDialog.move'),
           actionType: 'confirm',
           disabled: newParentId === parentId || loading,
           variant: 'default',

--- a/ui/leafwiki-ui/src/features/page/PageHistoryPage.tsx
+++ b/ui/leafwiki-ui/src/features/page/PageHistoryPage.tsx
@@ -13,6 +13,7 @@ import { type HotKeyDefinition, useHotKeysStore } from '@/stores/hotkeys'
 import { useTreeStore } from '@/stores/tree'
 import { useCallback, useEffect } from 'react'
 import { ArrowLeft } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { useToolbarStore } from '../toolbar/toolbarStore'
 import { getWikiTargetRoutePath, toWikiLookupPath } from '@/lib/wikiPath'
 import { useLocation, useNavigate } from 'react-router'
@@ -23,6 +24,7 @@ import { PageHistoryContent } from '@/features/history/PageHistoryContent'
 import { usePageHistory } from '@/features/history/pageHistory'
 
 export default function PageHistoryPage() {
+  const { t } = useTranslation('page')
   const location = useLocation()
   const { pathname } = location
   const navigate = useNavigate()
@@ -64,7 +66,7 @@ export default function PageHistoryPage() {
     setToolbarButtons([
       {
         id: 'close-history',
-        label: 'Back to Page',
+        label: t('historyPage.backToPage'),
         hotkey: getShortcutDisplayLabel('history.page.close', isMacOS),
         icon: <ArrowLeft size={18} />,
         action: closeHistory,
@@ -89,6 +91,7 @@ export default function PageHistoryPage() {
     registerHotkey,
     setToolbarButtons,
     unregisterHotkey,
+    t,
   ])
 
   const renderError = () => {
@@ -96,7 +99,11 @@ export default function PageHistoryPage() {
       return <Page404 targetPath={getWikiTargetRoutePath(pathname)} />
     }
     if (!loading && error) {
-      return <p className="page-viewer__error">Error: {error}</p>
+      return (
+        <p className="page-viewer__error">
+          {t('common.errorPrefix', { error })}
+        </p>
+      )
     }
     return null
   }

--- a/ui/leafwiki-ui/src/features/page/PageRefactorDialog.tsx
+++ b/ui/leafwiki-ui/src/features/page/PageRefactorDialog.tsx
@@ -4,6 +4,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { PageRefactorPreview } from '@/lib/api/pages'
 import { DIALOG_PAGE_REFACTOR_CONFIRMATION } from '@/lib/registries'
 import { useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 export type PageRefactorDialogProps = {
   preview: PageRefactorPreview
@@ -16,6 +17,7 @@ export function PageRefactorDialog({
   allowSkipRewrite = false,
   onResolve,
 }: PageRefactorDialogProps) {
+  const { t } = useTranslation('page')
   const previewWarnings = preview.warnings ?? []
   const defaultRewriteLinks = preview.counts.matchedLinks > 0
   const [rewriteLinks, setRewriteLinks] = useState(defaultRewriteLinks)
@@ -32,8 +34,8 @@ export function PageRefactorDialog({
   return (
     <BaseDialog
       dialogType={DIALOG_PAGE_REFACTOR_CONFIRMATION}
-      dialogTitle="Update references?"
-      dialogDescription="This change affects the page path. Review the impacted pages before continuing."
+      dialogTitle={t('refactorDialog.title')}
+      dialogDescription={t('refactorDialog.description')}
       onClose={() => {
         resolveOnce(null)
         return true
@@ -52,7 +54,7 @@ export function PageRefactorDialog({
       defaultAction="cancel"
       testidPrefix="page-refactor-dialog"
       cancelButton={{
-        label: 'Cancel',
+        label: t('common.cancel'),
         variant: 'outline',
         autoFocus: false,
       }}
@@ -60,14 +62,14 @@ export function PageRefactorDialog({
         ...(allowSkipRewrite
           ? [
               {
-                label: 'Save without updating links',
+                label: t('refactorDialog.saveWithoutRewrite'),
                 actionType: 'save-without-rewrite',
                 variant: 'secondary' as const,
               },
             ]
           : []),
         {
-          label: 'Continue',
+          label: t('refactorDialog.continue'),
           actionType: 'confirm',
           variant: 'default',
           autoFocus: true,
@@ -77,11 +79,11 @@ export function PageRefactorDialog({
       <div className="space-y-4">
         <div className="space-y-1 text-sm">
           <div>
-            <span className="font-medium">Old path:</span>{' '}
+            <span className="font-medium">{t('refactorDialog.oldPath')}</span>{' '}
             <span className="font-mono">{preview.oldPath}</span>
           </div>
           <div>
-            <span className="font-medium">New path:</span>{' '}
+            <span className="font-medium">{t('refactorDialog.newPath')}</span>{' '}
             <span className="font-mono">{preview.newPath}</span>
           </div>
         </div>
@@ -93,7 +95,7 @@ export function PageRefactorDialog({
             onCheckedChange={(value) => setRewriteLinks(!!value)}
             disabled={!defaultRewriteLinks}
           />
-          Update links on referencing pages automatically
+          {t('refactorDialog.updateLinksLabel')}
         </label>
 
         <div className="space-y-2">
@@ -101,7 +103,9 @@ export function PageRefactorDialog({
             className="text-sm font-medium"
             data-testid="page-refactor-dialog-referencing-pages-heading"
           >
-            Referencing pages ({preview.counts.affectedPages})
+            {t('refactorDialog.referencingPages', {
+              count: preview.counts.affectedPages,
+            })}
           </div>
 
           {previewWarnings.length > 0 && (
@@ -124,7 +128,7 @@ export function PageRefactorDialog({
             {preview.affectedPages.length === 0 ? (
               <div data-testid="page-refactor-dialog-no-references">
                 <ListViewStatus className="page-refactor-dialog__result-summary">
-                  No pages reference this path.
+                  {t('refactorDialog.noReferences')}
                 </ListViewStatus>
               </div>
             ) : (

--- a/ui/leafwiki-ui/src/features/page/PageSelect.tsx
+++ b/ui/leafwiki-ui/src/features/page/PageSelect.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils'
 import { useTreeStore } from '@/stores/tree'
 import { File, FolderTree } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 const LISTBOX_ID = 'page-select-results'
 
@@ -34,6 +35,7 @@ export function PageSelect({
   onChange: (id: string) => void
   autoFocus?: boolean
 }) {
+  const { t } = useTranslation('page')
   const { tree } = useTreeStore()
   const [search, setSearch] = useState('')
   const [activeIndex, setActiveIndex] = useState(0)
@@ -42,13 +44,18 @@ export function PageSelect({
   const flatPages = useMemo<FlatPage[]>(() => {
     if (!tree) return []
     const pages: FlatPage[] = [
-      { id: 'root', title: 'Top Level', depth: 0, kind: NODE_KIND_SECTION },
+      {
+        id: 'root',
+        title: t('select.topLevel'),
+        depth: 0,
+        kind: NODE_KIND_SECTION,
+      },
     ]
     for (const child of tree.children || []) {
       pages.push(...flattenTree(child))
     }
     return pages
-  }, [tree])
+  }, [tree, t])
 
   const filtered = useMemo(() => {
     const trimmedSearch = search.trim().toLowerCase()
@@ -75,7 +82,7 @@ export function PageSelect({
   return (
     <div className="flex flex-col gap-2">
       <Input
-        placeholder="Search pages..."
+        placeholder={t('select.searchPlaceholder')}
         value={search}
         autoFocus={autoFocus}
         role="combobox"
@@ -86,7 +93,7 @@ export function PageSelect({
           filtered.length > 0 ? filtered[clampedActiveIndex]?.id : undefined
         }
         aria-autocomplete="list"
-        aria-label="Search pages"
+        aria-label={t('select.searchAriaLabel')}
         onChange={(e) => setSearch(e.target.value)}
         onKeyDown={(e) => {
           if (e.key === 'ArrowDown') {
@@ -113,10 +120,14 @@ export function PageSelect({
       <div className="custom-scrollbar max-h-56 overflow-y-auto rounded-md border">
         {filtered.length === 0 && (
           <p className="text-muted-foreground px-3 py-2 text-sm">
-            No pages found.
+            {t('select.noPagesFound')}
           </p>
         )}
-        <ul id={LISTBOX_ID} role="listbox" aria-label="Pages">
+        <ul
+          id={LISTBOX_ID}
+          role="listbox"
+          aria-label={t('select.pagesAriaLabel')}
+        >
           {filtered.map((page, index) => {
             const active = index === clampedActiveIndex
             const Icon = page.kind === NODE_KIND_SECTION ? FolderTree : File

--- a/ui/leafwiki-ui/src/features/page/PermalinkDialog.tsx
+++ b/ui/leafwiki-ui/src/features/page/PermalinkDialog.tsx
@@ -7,6 +7,7 @@ import { buildPermalinkPath, withBasePath } from '@/lib/routePath'
 import copy from 'copy-to-clipboard'
 import { Copy, ExternalLink } from 'lucide-react'
 import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
 type PermalinkDialogProps = {
@@ -14,6 +15,7 @@ type PermalinkDialogProps = {
 }
 
 export function PermalinkDialog({ page }: PermalinkDialogProps) {
+  const { t } = useTranslation('page')
   const permalink = useMemo(() => {
     const path = withBasePath(buildPermalinkPath(page.id, page.slug))
     if (typeof window === 'undefined') {
@@ -24,31 +26,33 @@ export function PermalinkDialog({ page }: PermalinkDialogProps) {
 
   const handleCopy = () => {
     if (!copy(permalink)) {
-      toast.error('Could not copy permalink')
+      toast.error(t('permalinkDialog.copyErrorToast'))
       return
     }
 
-    toast.success('Permalink copied')
+    toast.success(t('permalinkDialog.copiedToast'))
   }
 
   const handleClose = () => true
 
   return (
     <BaseDialog
-      dialogTitle="Share page"
-      dialogDescription={`Shareable URL for ${page.title}`}
+      dialogTitle={t('permalinkDialog.title')}
+      dialogDescription={t('permalinkDialog.description', {
+        title: page.title,
+      })}
       dialogType={DIALOG_PAGE_PERMALINK}
       onClose={handleClose}
       onConfirm={async () => false}
       testidPrefix="permalink-dialog"
       cancelButton={{
-        label: 'Close',
+        label: t('permalinkDialog.close'),
         variant: 'outline',
       }}
     >
       <div className="space-y-3">
         <FormInput
-          label="Shareable URL"
+          label={t('permalinkDialog.urlLabel')}
           value={permalink}
           onChange={() => {}}
           readOnly={true}
@@ -63,7 +67,7 @@ export function PermalinkDialog({ page }: PermalinkDialogProps) {
             data-testid="permalink-dialog-copy-button"
           >
             <Copy />
-            Copy link
+            {t('permalinkDialog.copyLink')}
           </Button>
           <Button
             type="button"
@@ -73,7 +77,7 @@ export function PermalinkDialog({ page }: PermalinkDialogProps) {
           >
             <a href={permalink} target="_blank" rel="noreferrer">
               <ExternalLink />
-              Open link
+              {t('permalinkDialog.openLink')}
             </a>
           </Button>
         </div>

--- a/ui/leafwiki-ui/src/features/page/PermalinkRedirect.tsx
+++ b/ui/leafwiki-ui/src/features/page/PermalinkRedirect.tsx
@@ -3,9 +3,11 @@ import { getPermalinkTarget } from '@/lib/api/pages'
 import { isPageNotFoundError } from '@/lib/api/errors'
 import { useProgressbarStore } from '@/features/progressbar/progressbarStore'
 import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate, useParams } from 'react-router'
 
 export default function PermalinkRedirect() {
+  const { t } = useTranslation('page')
   const location = useLocation()
   const navigate = useNavigate()
   const { id } = useParams<{ id: string }>()
@@ -47,7 +49,7 @@ export default function PermalinkRedirect() {
           return
         }
 
-        setError('An unknown error occurred')
+        setError(t('common.unknownError'))
       } finally {
         if (active) {
           setLoading(false)
@@ -61,14 +63,16 @@ export default function PermalinkRedirect() {
       active = false
       setLoading(false)
     }
-  }, [id, location.state, navigate, setLoading])
+  }, [id, location.state, navigate, setLoading, t])
 
   if (notFound) {
     return <Page404 />
   }
 
   if (error) {
-    return <p className="page-viewer__error">Error: {error}</p>
+    return (
+      <p className="page-viewer__error">{t('common.errorPrefix', { error })}</p>
+    )
   }
 
   return null

--- a/ui/leafwiki-ui/src/features/page/SlugInputWithSuggestion.tsx
+++ b/ui/leafwiki-ui/src/features/page/SlugInputWithSuggestion.tsx
@@ -79,7 +79,10 @@ export function SlugInputWithSuggestion({
         onSlugChange(suggestion)
         onLastSlugTitleChange?.(debouncedTitle)
       } catch (err) {
-        const mapped = mapApiError(err, 'Error generating slug')
+        const mapped = mapApiError(
+          err,
+          i18next.t('slugInput.generateErrorFallback', { ns: 'editor' }),
+        )
         toast.error(mapped.message)
       } finally {
         onSlugLoadingChange?.(false)

--- a/ui/leafwiki-ui/src/features/page/SortPagesDialog.tsx
+++ b/ui/leafwiki-ui/src/features/page/SortPagesDialog.tsx
@@ -24,6 +24,7 @@ import {
 import { CSS } from '@dnd-kit/utilities'
 import { ArrowDown, ArrowUp, GripVertical } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
 function SortableItem({
@@ -32,12 +33,14 @@ function SortableItem({
   index,
   total,
   onMove,
+  dragHandleLabel,
 }: {
   id: string
   title: string
   index: number
   total: number
   onMove: (index: number, direction: -1 | 1) => void
+  dragHandleLabel: string
 }) {
   const {
     attributes,
@@ -63,7 +66,7 @@ function SortableItem({
     >
       <button
         className="sort-pages-dialog__drag-handle"
-        aria-label="Drag to reorder"
+        aria-label={dragHandleLabel}
         {...attributes}
         {...listeners}
       >
@@ -100,9 +103,13 @@ function SortableItem({
 }
 
 export function SortPagesDialog({ parent }: { parent: PageNode }) {
-  const itemLabel = parent.kind === NODE_KIND_PAGE ? 'page' : 'section'
+  const { t } = useTranslation('page')
+  const itemLabel =
+    parent.kind === NODE_KIND_PAGE ? t('common.page') : t('common.section')
   const itemLabelCapitalized =
-    parent.kind === NODE_KIND_PAGE ? 'Page' : 'Section'
+    parent.kind === NODE_KIND_PAGE
+      ? t('common.pageCapitalized')
+      : t('common.sectionCapitalized')
   const [order, setOrder] = useState(parent.children?.map((c) => c.id) || [])
   const [loading, setLoading] = useState(false)
   const [, setFieldErrors] = useState<Record<string, string>>({})
@@ -166,14 +173,14 @@ export function SortPagesDialog({ parent }: { parent: PageNode }) {
     try {
       await sortPages(parent.id, order)
       await reloadTree()
-      toast.success(`${itemLabelCapitalized} children sorted successfully`)
+      toast.success(t('sortDialog.sortedToast', { item: itemLabelCapitalized }))
       return true
     } catch (err) {
       console.warn(err)
       handleFieldErrors(
         err,
         setFieldErrors,
-        `Error sorting ${itemLabel} children`,
+        t('sortDialog.sortErrorFallback', { item: itemLabel }),
       )
       return false
     } finally {
@@ -185,8 +192,8 @@ export function SortPagesDialog({ parent }: { parent: PageNode }) {
     <BaseDialog
       dialogType={DIALOG_SORT_PAGES}
       testidPrefix="sort-pages-dialog"
-      dialogTitle={`Sort ${itemLabelCapitalized} Children`}
-      dialogDescription={`Drag items to reorder, use the arrows, or sort alphabetically. Changes are saved after clicking 'Save'.`}
+      dialogTitle={t('sortDialog.title', { item: itemLabelCapitalized })}
+      dialogDescription={t('sortDialog.description')}
       onClose={() => true}
       onConfirm={async (type) => {
         if (type === 'confirm') {
@@ -195,14 +202,14 @@ export function SortPagesDialog({ parent }: { parent: PageNode }) {
         return false
       }}
       cancelButton={{
-        label: 'Cancel',
+        label: t('common.cancel'),
         variant: 'outline',
         autoFocus: false,
         disabled: loading,
       }}
       buttons={[
         {
-          label: 'Save',
+          label: t('sortDialog.save'),
           actionType: 'confirm',
           disabled: loading,
           variant: 'default',
@@ -212,7 +219,7 @@ export function SortPagesDialog({ parent }: { parent: PageNode }) {
     >
       <div className="sort-pages-dialog__toolbar">
         <span className="sort-pages-dialog__toolbar-label">
-          Sort alphabetically:
+          {t('sortDialog.sortAlphabetically')}
         </span>
         <Button
           variant="outline"
@@ -220,7 +227,7 @@ export function SortPagesDialog({ parent }: { parent: PageNode }) {
           data-testid="sort-az-button"
           onClick={() => sortAlphabetically('asc')}
         >
-          A → Z
+          {t('sortDialog.ascending')}
         </Button>
         <Button
           variant="outline"
@@ -228,7 +235,7 @@ export function SortPagesDialog({ parent }: { parent: PageNode }) {
           data-testid="sort-za-button"
           onClick={() => sortAlphabetically('desc')}
         >
-          Z → A
+          {t('sortDialog.descending')}
         </Button>
       </div>
       <DndContext
@@ -256,6 +263,7 @@ export function SortPagesDialog({ parent }: { parent: PageNode }) {
                   index={i}
                   total={order.length}
                   onMove={move}
+                  dragHandleLabel={t('sortDialog.dragToReorder')}
                 />
               )
             })}

--- a/ui/leafwiki-ui/src/features/preview/MarkdownCodeBlock.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownCodeBlock.tsx
@@ -10,6 +10,7 @@ import {
   useEffect,
   useState,
 } from 'react'
+import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
 type CodeElementProps = {
@@ -37,6 +38,7 @@ export default function MarkdownCodeBlock(
   props: ClassAttributes<HTMLPreElement> &
     HTMLAttributes<HTMLPreElement> & { children?: ReactNode; node?: unknown },
 ) {
+  const { t } = useTranslation('viewer')
   const { children, node, ...preProps } = props
   void node
   const [copied, setCopied] = useState(false)
@@ -69,25 +71,33 @@ export default function MarkdownCodeBlock(
   const handleCopy = () => {
     const copiedSuccessfully = copy(code)
     if (!copiedSuccessfully) {
-      toast.error('Could not copy code')
+      toast.error(t('codeBlock.copyErrorToast'))
       return
     }
 
     setCopied(true)
-    toast.success('Code copied')
+    toast.success(t('codeBlock.copiedToast'))
   }
 
   return (
     <div className="markdown-code-block">
       <div className="markdown-code-block__actions">
-        <TooltipWrapper label={copied ? 'Copied' : 'Copy code'}>
+        <TooltipWrapper
+          label={
+            copied ? t('codeBlock.copiedTooltip') : t('codeBlock.copyTooltip')
+          }
+        >
           <Button
             type="button"
             variant="outline"
             size="icon"
             className="markdown-code-block__copy-button"
             onClick={handleCopy}
-            aria-label={copied ? 'Code copied' : 'Copy code'}
+            aria-label={
+              copied
+                ? t('codeBlock.copiedAriaLabel')
+                : t('codeBlock.copyAriaLabel')
+            }
             data-testid="markdown-code-copy-button"
           >
             {copied ? <Check /> : <Copy />}

--- a/ui/leafwiki-ui/src/features/tags/TagsResultCard.tsx
+++ b/ui/leafwiki-ui/src/features/tags/TagsResultCard.tsx
@@ -1,3 +1,4 @@
+import i18next from '@/lib/i18n'
 import { TaggedPage } from '@/lib/api/tags'
 import { createNavigationVisitState } from '@/lib/navigationVisit'
 import { buildViewUrl } from '@/lib/routePath'
@@ -6,6 +7,9 @@ import { MouseEvent, forwardRef } from 'react'
 import { Link, useLocation } from 'react-router'
 import type { PageEditorState } from '../editor/pageEditorStore'
 import { usePageEditorStore } from '../editor/pageEditorStore'
+
+const t = (key: string, opts?: Record<string, unknown>) =>
+  i18next.t(key, { ...opts, ns: 'search' })
 
 type TagsResultCardProps = {
   item: TaggedPage
@@ -70,7 +74,9 @@ const TagsResultCard = forwardRef<HTMLDivElement, TagsResultCardProps>(
             {item.title}
           </div>
           <div className="search-result-card__meta">
-            <span className="search-result-card__badge">Page</span>
+            <span className="search-result-card__badge">
+              {t('resultCard.kindPage')}
+            </span>
           </div>
           {item.excerpt && (
             <div className="search-result-card__excerpt">{item.excerpt}</div>

--- a/ui/leafwiki-ui/src/features/toolbar/Toolbar.tsx
+++ b/ui/leafwiki-ui/src/features/toolbar/Toolbar.tsx
@@ -9,11 +9,13 @@ import {
 import { ToolbarButton } from '@/features/toolbar/ToolbarButton'
 import { cn } from '@/lib/utils'
 import { Check, MoreHorizontal } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { useToolbarStore } from './toolbarStore'
 
 const VISIBLE_BUTTONS = 2
 
 export function Toolbar() {
+  const { t } = useTranslation('viewer')
   const buttons = useToolbarStore((state) => state.buttons)
   const visibleButtons = buttons.slice(0, VISIBLE_BUTTONS)
   const overflowButtons = buttons.slice(VISIBLE_BUTTONS)
@@ -43,7 +45,7 @@ export function Toolbar() {
               variant="outline"
               size="icon"
               className="h-8 w-8 shadow-xs"
-              aria-label="More actions"
+              aria-label={t('toolbar.moreActions')}
               data-testid="toolbar-overflow-button"
             >
               <MoreHorizontal size={18} />

--- a/ui/leafwiki-ui/src/features/tree/PinnedPageItem.tsx
+++ b/ui/leafwiki-ui/src/features/tree/PinnedPageItem.tsx
@@ -4,6 +4,7 @@ import { useTreeStore } from '@/stores/tree'
 import clsx from 'clsx'
 import { File, Folder, PinOff } from 'lucide-react'
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router'
 
 type Props = {
@@ -12,6 +13,7 @@ type Props = {
 }
 
 export function PinnedPageItem({ node, onUnpin }: Props) {
+  const { t } = useTranslation('viewer')
   const activeNodeId = useTreeStore((s) => s.activeNodeId)
   const isActive = activeNodeId === node.id
   const [hovered, setHovered] = useState(false)
@@ -40,8 +42,8 @@ export function PinnedPageItem({ node, onUnpin }: Props) {
             e.preventDefault()
             onUnpin()
           }}
-          title="Unpin"
-          aria-label="Unpin page"
+          title={t('pinned.unpinPage')}
+          aria-label={t('pinned.unpinPageAriaLabel')}
         >
           <PinOff size={13} />
         </button>

--- a/ui/leafwiki-ui/src/features/tree/TreeDnd.tsx
+++ b/ui/leafwiki-ui/src/features/tree/TreeDnd.tsx
@@ -23,7 +23,9 @@ import {
 import { getEventCoordinates } from '@dnd-kit/utilities'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
+import i18next from '@/lib/i18n'
 import { useTreeDndStore } from './treeDndStore'
 import {
   buildOrderedIds,
@@ -47,22 +49,39 @@ function offerConvertBackToPage(parentId: string) {
   if (!parent || parent.kind !== NODE_KIND_SECTION) return
   if ((parent.children?.length ?? 0) > 0) return
 
-  toast(`"${parent.title}" is now an empty section`, {
-    action: {
-      label: 'Convert back to page',
-      onClick: () => {
-        const node = useTreeStore.getState().byId[parentId]
-        if (!node) return
-        convertPage(parentId, NODE_KIND_PAGE, node.version)
-          .then(() => useTreeStore.getState().reloadTree({ silent: true }))
-          .then(() => toast.success(`"${node.title}" is a page again`))
-          .catch((err) => {
-            console.warn(err)
-            toast.error('Failed to convert section back to page')
-          })
+  toast(
+    i18next.t('treeActions.emptySectionToast', {
+      ns: 'viewer',
+      title: parent.title,
+    }),
+    {
+      action: {
+        label: i18next.t('treeActions.convertBackAction', { ns: 'viewer' }),
+        onClick: () => {
+          const node = useTreeStore.getState().byId[parentId]
+          if (!node) return
+          convertPage(parentId, NODE_KIND_PAGE, node.version)
+            .then(() => useTreeStore.getState().reloadTree({ silent: true }))
+            .then(() =>
+              toast.success(
+                i18next.t('treeActions.convertedBackToast', {
+                  ns: 'viewer',
+                  title: node.title,
+                }),
+              ),
+            )
+            .catch((err) => {
+              console.warn(err)
+              toast.error(
+                i18next.t('treeActions.convertBackErrorFallback', {
+                  ns: 'viewer',
+                }),
+              )
+            })
+        },
       },
     },
-  })
+  )
 }
 
 // Keeps the overlay chip attached to the cursor (12px right of it,
@@ -131,6 +150,7 @@ export function TreeDndProvider({
   enabled: boolean
   children: React.ReactNode
 }) {
+  const { t } = useTranslation('viewer')
   const [activeNode, setActiveNode] = useState<PageNode | null>(null)
   const [saving, setSaving] = useState(false)
   const subtreeIdsRef = useRef<Set<string>>(new Set())
@@ -259,7 +279,7 @@ export function TreeDndProvider({
         await reloadTree({ silent: true })
       } catch (err) {
         console.warn(err)
-        toast.error('Failed to reorder pages')
+        toast.error(t('treeActions.reorderErrorFallback'))
         await reloadTree({ silent: true })
       } finally {
         setSaving(false)
@@ -285,7 +305,7 @@ export function TreeDndProvider({
       }
     } catch (err) {
       console.warn(err)
-      toast.error('Failed to move page')
+      toast.error(t('treeActions.moveErrorFallback'))
       await reloadTree({ silent: true })
     } finally {
       setSaving(false)

--- a/ui/leafwiki-ui/src/features/tree/TreeNodeActionsMenu.tsx
+++ b/ui/leafwiki-ui/src/features/tree/TreeNodeActionsMenu.tsx
@@ -25,6 +25,7 @@ import {
   DIALOG_MOVE_PAGE,
   DIALOG_SORT_PAGES,
 } from '@/lib/registries'
+import i18next from '@/lib/i18n'
 import { stripBasePath } from '@/lib/routePath'
 import { useIsReadOnly } from '@/lib/useIsReadOnly'
 import { getDeleteRedirectRoutePath } from '@/lib/wikiPath'
@@ -81,6 +82,14 @@ export default function TreeNodeActionsMenu({
     (s) => s.setOpenMenuNodeId,
   )
   const open = useTreeNodeActionsMenusStore((s) => s.openMenuNodeId === node.id)
+  const itemLabel =
+    nodeKind === NODE_KIND_PAGE
+      ? i18next.t('common.page', { ns: 'page' })
+      : i18next.t('common.section', { ns: 'page' })
+  const itemLabelCapitalized =
+    nodeKind === NODE_KIND_PAGE
+      ? i18next.t('common.pageCapitalized', { ns: 'page' })
+      : i18next.t('common.sectionCapitalized', { ns: 'page' })
 
   const handleConvertPage = useCallback(() => {
     convertPage(
@@ -89,7 +98,7 @@ export default function TreeNodeActionsMenu({
       nodeVersion,
     )
       .then(() => {
-        toast.success('Page converted successfully')
+        toast.success(t('treeActions.convertedToast'))
         reloadTree()
       })
       .catch((err) => {
@@ -103,15 +112,13 @@ export default function TreeNodeActionsMenu({
               .loadPageData(viewerPage.path)
               .catch(console.error)
           }
-          toast.error(
-            'This page was modified by another user. Please try again.',
-          )
+          toast.error(t('treeActions.conflictRetryMessage'))
         } else {
-          const mapped = mapApiError(err, 'Failed to convert page')
+          const mapped = mapApiError(err, t('treeActions.convertErrorFallback'))
           toast.error(mapped.message)
         }
       })
-  }, [nodeId, nodeKind, nodeVersion, reloadTree])
+  }, [nodeId, nodeKind, nodeVersion, reloadTree, t])
 
   const setPinnedLocally = useTreeStore((s) => s.setPinnedLocally)
 
@@ -152,7 +159,7 @@ export default function TreeNodeActionsMenu({
     async (title: string, slug: string) => {
       if (currentEditorPageId === nodeId) {
         toast.warning(
-          `This ${nodeKind === NODE_KIND_PAGE ? 'page' : 'section'} is currently being edited. Please use the editor title bar to rename it.`,
+          t('treeActions.renameEditingWarning', { item: itemLabel }),
         )
         return
       }
@@ -226,19 +233,17 @@ export default function TreeNodeActionsMenu({
         }
 
         toast.success(
-          `${nodeKind === NODE_KIND_PAGE ? 'Page' : 'Section'} renamed successfully`,
+          t('treeActions.renamedToast', { item: itemLabelCapitalized }),
         )
       } catch (err) {
         const localized = asApiLocalizedError(err)
         if (localized?.code === 'page_version_conflict') {
           await reloadTree()
-          toast.error(
-            'This page was modified by another user. Please try again.',
-          )
+          toast.error(t('treeActions.conflictRetryMessage'))
           return
         }
 
-        const mapped = mapApiError(err, 'Failed to rename page')
+        const mapped = mapApiError(err, t('treeActions.renameErrorFallback'))
         toast.error(mapped.message)
       }
     },
@@ -249,8 +254,10 @@ export default function TreeNodeActionsMenu({
       navigate,
       node.path,
       nodeId,
-      nodeKind,
       reloadTree,
+      t,
+      itemLabel,
+      itemLabelCapitalized,
     ],
   )
 
@@ -259,7 +266,7 @@ export default function TreeNodeActionsMenu({
       open={open}
       onOpenChange={(nextOpen) => setOpenMenuNodeId(nextOpen ? node.id : null)}
     >
-      <DropdownMenuTrigger asChild aria-label="More actions">
+      <DropdownMenuTrigger asChild aria-label={t('toolbar.moreActions')}>
         <TreeViewActionButton
           actionName="open-more-actions"
           icon={<MoreVertical size={18} className="tree-node__action-icon" />}
@@ -278,7 +285,8 @@ export default function TreeNodeActionsMenu({
                 })
               }}
             >
-              <FilePlus size={18} className="tree-node__action-icon" /> Add Page
+              <FilePlus size={18} className="tree-node__action-icon" />{' '}
+              {t('treeActions.menuAddPage')}
             </DropdownMenuItem>
             <DropdownMenuItem
               className="cursor-pointer"
@@ -289,8 +297,8 @@ export default function TreeNodeActionsMenu({
                 })
               }}
             >
-              <FolderPlus size={18} className="tree-node__action-icon" /> Add
-              Section
+              <FolderPlus size={18} className="tree-node__action-icon" />{' '}
+              {t('treeActions.menuAddSection')}
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem
@@ -299,8 +307,8 @@ export default function TreeNodeActionsMenu({
                 navigate(`/e/${node.path}`)
               }}
             >
-              <Pencil size={18} className="tree-node__action-icon" /> Edit{' '}
-              {nodeKind === NODE_KIND_PAGE ? 'Page' : 'Section'}
+              <Pencil size={18} className="tree-node__action-icon" />{' '}
+              {t('treeActions.menuEdit', { item: itemLabelCapitalized })}
             </DropdownMenuItem>
             <DropdownMenuItem
               className="cursor-pointer"
@@ -316,8 +324,8 @@ export default function TreeNodeActionsMenu({
                 })
               }}
             >
-              <Pencil size={18} className="tree-node__action-icon" /> Rename{' '}
-              {nodeKind === NODE_KIND_PAGE ? 'Page' : 'Section'}
+              <Pencil size={18} className="tree-node__action-icon" />{' '}
+              {t('treeActions.menuRename', { item: itemLabelCapitalized })}
             </DropdownMenuItem>
             {nodeKind === NODE_KIND_PAGE && (
               <DropdownMenuItem
@@ -326,7 +334,8 @@ export default function TreeNodeActionsMenu({
                   openDialog(DIALOG_COPY_PAGE, { sourcePage: node })
                 }}
               >
-                <Copy size={18} className="tree-node__action-icon" /> Copy Page
+                <Copy size={18} className="tree-node__action-icon" />{' '}
+                {t('treeActions.menuCopyPage')}
               </DropdownMenuItem>
             )}
             {hasChildren && (
@@ -335,8 +344,10 @@ export default function TreeNodeActionsMenu({
                 data-testid="tree-view-action-button-sort"
                 onClick={() => openDialog(DIALOG_SORT_PAGES, { parent: node })}
               >
-                <List size={18} className="tree-node__action-icon" /> Sort{' '}
-                {nodeKind === NODE_KIND_SECTION ? 'Section' : 'Page'} Children
+                <List size={18} className="tree-node__action-icon" />{' '}
+                {t('treeActions.menuSortChildren', {
+                  item: itemLabelCapitalized,
+                })}
               </DropdownMenuItem>
             )}
             <DropdownMenuItem
@@ -344,16 +355,16 @@ export default function TreeNodeActionsMenu({
               data-testid="tree-view-action-button-move"
               onClick={() => openDialog(DIALOG_MOVE_PAGE, { pageId: node.id })}
             >
-              <Move size={18} className="tree-node__action-icon" /> Move{' '}
-              {nodeKind === NODE_KIND_PAGE ? 'Page' : 'Section'}
+              <Move size={18} className="tree-node__action-icon" />{' '}
+              {t('treeActions.menuMove', { item: itemLabelCapitalized })}
             </DropdownMenuItem>
             {nodeKind === NODE_KIND_SECTION && !hasChildren && (
               <DropdownMenuItem
                 className="cursor-pointer"
                 onClick={handleConvertPage}
               >
-                <Repeat2 size={18} className="tree-node__action-icon" /> Convert
-                to Page
+                <Repeat2 size={18} className="tree-node__action-icon" />{' '}
+                {t('treeActions.menuConvertToPage')}
               </DropdownMenuItem>
             )}
             <DropdownMenuSeparator />
@@ -410,7 +421,7 @@ export default function TreeNodeActionsMenu({
 
                 if (isCurrentlyEditedNode) {
                   toast.warning(
-                    `This ${nodeKind === NODE_KIND_PAGE ? 'page' : 'section'} is currently being edited. Please close the editor before deleting it.`,
+                    t('treeActions.deleteEditingWarning', { item: itemLabel }),
                   )
                   return
                 }
@@ -425,7 +436,7 @@ export default function TreeNodeActionsMenu({
               }}
             >
               <Trash size={18} className="tree-node__action-icon text-error" />{' '}
-              Delete {nodeKind === NODE_KIND_PAGE ? 'Page' : 'Section'}
+              {t('treeActions.menuDelete', { item: itemLabelCapitalized })}
             </DropdownMenuItem>
           </>
         )}

--- a/ui/leafwiki-ui/src/features/users/ChangeOwnPasswordDialog.tsx
+++ b/ui/leafwiki-ui/src/features/users/ChangeOwnPasswordDialog.tsx
@@ -5,11 +5,13 @@ import { DIALOG_CHANGE_OWN_PASSWORD } from '@/lib/registries'
 import { useSessionStore } from '@/stores/session'
 import { useUserStore } from '@/stores/users'
 import { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
 const DIALOG_INPUT_ALLOWED_HOTKEYS = 'Enter'
 
 export function ChangeOwnPasswordDialog() {
+  const { t } = useTranslation('users')
   const [oldPassword, setOldPassword] = useState('')
   const [newPassword, setNewPassword] = useState('')
   const [confirm, setConfirm] = useState('')
@@ -39,7 +41,7 @@ export function ChangeOwnPasswordDialog() {
     if (val.length < 8) {
       setFieldErrors((prev) => ({
         ...prev,
-        newPassword: 'Password must be at least 8 characters long',
+        newPassword: t('validation.passwordTooShort'),
       }))
     } else {
       setFieldErrors((prev) => ({ ...prev, newPassword: '' }))
@@ -49,7 +51,10 @@ export function ChangeOwnPasswordDialog() {
   const handleConfirmChange = (val: string) => {
     setConfirm(val)
     if (val !== newPassword) {
-      setFieldErrors((prev) => ({ ...prev, confirm: 'Passwords do not match' }))
+      setFieldErrors((prev) => ({
+        ...prev,
+        confirm: t('validation.passwordsDoNotMatch'),
+      }))
     } else {
       setFieldErrors((prev) => ({ ...prev, confirm: '' }))
     }
@@ -59,14 +64,18 @@ export function ChangeOwnPasswordDialog() {
     setLoading(true)
     try {
       await changeOwnPassword(oldPassword, newPassword)
-      toast.success('Password changed successfully')
+      toast.success(t('changeOwnPassword.successToast'))
       return true
     } catch (err) {
       console.warn(err)
       setOldPassword('')
       setNewPassword('')
       setConfirm('')
-      handleFieldErrors(err, setFieldErrors, 'Error updating password')
+      handleFieldErrors(
+        err,
+        setFieldErrors,
+        t('changeOwnPassword.errorFallback'),
+      )
       return false
     } finally {
       setLoading(false)
@@ -76,18 +85,20 @@ export function ChangeOwnPasswordDialog() {
   return (
     <BaseDialog
       dialogType={DIALOG_CHANGE_OWN_PASSWORD}
-      dialogTitle="Change Own Password"
-      dialogDescription="Change your password. Make sure to remember it!"
+      dialogTitle={t('changeOwnPassword.title')}
+      dialogDescription={t('changeOwnPassword.description')}
       testidPrefix="change-own-password-dialog"
       cancelButton={{
-        label: 'Cancel',
+        label: t('changeOwnPassword.cancel'),
         variant: 'outline',
         disabled: loading,
         autoFocus: false,
       }}
       buttons={[
         {
-          label: loading ? 'Saving...' : 'Save',
+          label: loading
+            ? t('changeOwnPassword.saving')
+            : t('changeOwnPassword.save'),
           actionType: 'confirm',
           autoFocus: true,
           loading,
@@ -118,34 +129,34 @@ export function ChangeOwnPasswordDialog() {
         />
         <FormInput
           autoFocus={true}
-          label="Old Password"
+          label={t('changeOwnPassword.oldPasswordLabel')}
           name="current-password"
           type="password"
           value={oldPassword}
           onChange={handleOldPasswordChange}
-          placeholder="Old Password"
+          placeholder={t('changeOwnPassword.oldPasswordLabel')}
           autoComplete="current-password"
           error={fieldErrors.oldPassword}
           allowedHotkeys={DIALOG_INPUT_ALLOWED_HOTKEYS}
         />
         <FormInput
-          label="New Password"
+          label={t('changeOwnPassword.newPasswordLabel')}
           name="new-password"
           type="password"
           value={newPassword}
           onChange={handleNewPasswordChange}
-          placeholder="New Password"
+          placeholder={t('changeOwnPassword.newPasswordLabel')}
           autoComplete="new-password"
           error={fieldErrors.newPassword}
           allowedHotkeys={DIALOG_INPUT_ALLOWED_HOTKEYS}
         />
         <FormInput
-          label="Confirm Password"
+          label={t('changeOwnPassword.confirmPasswordLabel')}
           name="confirm-new-password"
           type="password"
           value={confirm}
           onChange={handleConfirmChange}
-          placeholder="Confirm Password"
+          placeholder={t('changeOwnPassword.confirmPasswordLabel')}
           autoComplete="new-password"
           error={fieldErrors.confirm}
           allowedHotkeys={DIALOG_INPUT_ALLOWED_HOTKEYS}

--- a/ui/leafwiki-ui/src/features/users/ChangePasswordDialog.tsx
+++ b/ui/leafwiki-ui/src/features/users/ChangePasswordDialog.tsx
@@ -4,6 +4,7 @@ import { handleFieldErrors } from '@/lib/handleFieldErrors'
 import { DIALOG_CHANGE_USER_PASSWORD } from '@/lib/registries'
 import { useUserStore } from '@/stores/users'
 import { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
 const DIALOG_INPUT_ALLOWED_HOTKEYS = 'Enter'
@@ -17,6 +18,7 @@ export function ChangePasswordDialog({
   userId,
   username,
 }: ChangePasswordDialogProps) {
+  const { t } = useTranslation('users')
   const [password, setPassword] = useState('')
   const [confirm, setConfirm] = useState('')
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
@@ -47,7 +49,7 @@ export function ChangePasswordDialog({
     if (val.length < 8) {
       setFieldErrors((prev) => ({
         ...prev,
-        password: 'Password must be at least 8 characters long',
+        password: t('validation.passwordTooShort'),
       }))
     } else {
       setFieldErrors((prev) => ({ ...prev, password: '' }))
@@ -57,7 +59,10 @@ export function ChangePasswordDialog({
   const handleConfirmChange = (val: string) => {
     setConfirm(val)
     if (val !== password) {
-      setFieldErrors((prev) => ({ ...prev, confirm: 'Passwords do not match' }))
+      setFieldErrors((prev) => ({
+        ...prev,
+        confirm: t('validation.passwordsDoNotMatch'),
+      }))
     } else {
       setFieldErrors((prev) => ({ ...prev, confirm: '' }))
     }
@@ -70,11 +75,15 @@ export function ChangePasswordDialog({
         ...user,
         password,
       })
-      toast.success('Password changed successfully')
+      toast.success(t('changePasswordDialog.successToast'))
       return true // Close the dialog
     } catch (err) {
       console.warn(err)
-      handleFieldErrors(err, setFieldErrors, 'Error updating password')
+      handleFieldErrors(
+        err,
+        setFieldErrors,
+        t('changePasswordDialog.errorFallback'),
+      )
       return false // Keep the dialog open
     } finally {
       setLoading(false)
@@ -84,22 +93,24 @@ export function ChangePasswordDialog({
   return (
     <BaseDialog
       dialogType={DIALOG_CHANGE_USER_PASSWORD}
-      dialogTitle={`Change Password for ${username}`}
-      dialogDescription="Set a new password for the user."
+      dialogTitle={t('changePasswordDialog.title', { username })}
+      dialogDescription={t('changePasswordDialog.description')}
       onClose={resetForm}
       onConfirm={async () => {
         return await handleChange()
       }}
       testidPrefix="change-user-password-dialog"
       cancelButton={{
-        label: 'Cancel',
+        label: t('changePasswordDialog.cancel'),
         variant: 'outline',
         disabled: loading,
         autoFocus: true,
       }}
       buttons={[
         {
-          label: loading ? 'Updating...' : 'Update Password',
+          label: loading
+            ? t('changePasswordDialog.updating')
+            : t('changePasswordDialog.update'),
           actionType: 'confirm',
           autoFocus: false,
           loading,
@@ -120,23 +131,23 @@ export function ChangePasswordDialog({
         />
         <FormInput
           autoFocus={true}
-          label="New Password"
+          label={t('changePasswordDialog.newPasswordLabel')}
           name="new-password"
           type="password"
           value={password}
           onChange={handlePasswordChange}
-          placeholder="New Password"
+          placeholder={t('changePasswordDialog.newPasswordLabel')}
           autoComplete="new-password"
           error={fieldErrors.password}
           allowedHotkeys={DIALOG_INPUT_ALLOWED_HOTKEYS}
         />
         <FormInput
-          label="Confirm Password"
+          label={t('changePasswordDialog.confirmPasswordLabel')}
           name="confirm-new-password"
           type="password"
           value={confirm}
           onChange={handleConfirmChange}
-          placeholder="Confirm Password"
+          placeholder={t('changePasswordDialog.confirmPasswordLabel')}
           autoComplete="new-password"
           error={fieldErrors.confirm}
           allowedHotkeys={DIALOG_INPUT_ALLOWED_HOTKEYS}

--- a/ui/leafwiki-ui/src/features/users/DeleteUserDialog.tsx
+++ b/ui/leafwiki-ui/src/features/users/DeleteUserDialog.tsx
@@ -3,6 +3,7 @@ import { mapApiError } from '@/lib/api/errors'
 import { DIALOG_DELETE_USER_CONFIRMATION } from '@/lib/registries'
 import { useUserStore } from '@/stores/users'
 import { useState } from 'react'
+import { Trans, useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
 type DeleteUserDialogProps = {
@@ -11,6 +12,7 @@ type DeleteUserDialogProps = {
 }
 
 export function DeleteUserDialog({ userId, username }: DeleteUserDialogProps) {
+  const { t } = useTranslation('users')
   const { deleteUser } = useUserStore()
 
   const [loading, setLoading] = useState(false)
@@ -19,14 +21,11 @@ export function DeleteUserDialog({ userId, username }: DeleteUserDialogProps) {
     setLoading(true)
     try {
       await deleteUser(userId)
-      toast.success('User deleted successfully')
+      toast.success(t('deleteUser.successToast'))
       return true // Close the dialog
     } catch (err) {
       console.error('Error deleting user:', err)
-      const mapped = mapApiError(
-        err,
-        'Failed to delete user. Please try again.',
-      )
+      const mapped = mapApiError(err, t('deleteUser.errorFallback'))
       toast.error(mapped.message)
       return false // Keep the dialog open
     } finally {
@@ -37,8 +36,8 @@ export function DeleteUserDialog({ userId, username }: DeleteUserDialogProps) {
   return (
     <BaseDialog
       dialogType={DIALOG_DELETE_USER_CONFIRMATION}
-      dialogTitle="Delete User?"
-      dialogDescription="Are you sure you want to delete this user? This action cannot be undone."
+      dialogTitle={t('deleteUser.title')}
+      dialogDescription={t('deleteUser.description')}
       onClose={() => true}
       onConfirm={async (): Promise<boolean> => {
         return await handleDelete()
@@ -46,14 +45,14 @@ export function DeleteUserDialog({ userId, username }: DeleteUserDialogProps) {
       defaultAction="cancel"
       testidPrefix="delete-user-dialog"
       cancelButton={{
-        label: 'Cancel',
+        label: t('deleteUser.cancel'),
         variant: 'outline',
         disabled: loading,
         autoFocus: true,
       }}
       buttons={[
         {
-          label: loading ? 'Deleting...' : 'Delete',
+          label: loading ? t('deleteUser.deleting') : t('deleteUser.delete'),
           actionType: 'confirm',
           autoFocus: false,
           loading,
@@ -62,8 +61,12 @@ export function DeleteUserDialog({ userId, username }: DeleteUserDialogProps) {
       ]}
     >
       <p className="text-muted text-sm">
-        The user <strong>{username}</strong> will be permanently removed from
-        the system.
+        <Trans
+          i18nKey="deleteUser.body"
+          ns="users"
+          values={{ username }}
+          components={{ strong: <strong /> }}
+        />
       </p>
     </BaseDialog>
   )

--- a/ui/leafwiki-ui/src/features/users/UserFormDialog.tsx
+++ b/ui/leafwiki-ui/src/features/users/UserFormDialog.tsx
@@ -13,6 +13,7 @@ import { DIALOG_USER_FORM } from '@/lib/registries'
 import { useSessionStore } from '@/stores/session'
 import { useUserStore } from '@/stores/users'
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
 const DIALOG_INPUT_ALLOWED_HOTKEYS = 'Enter'
@@ -22,6 +23,7 @@ type UserFormDialogProps = {
 }
 
 export function UserFormDialog({ user }: UserFormDialogProps) {
+  const { t } = useTranslation('users')
   const isEdit = !!user
   const [username, setUsername] = useState(user?.username || '')
   const [email, setEmail] = useState(user?.email || '')
@@ -54,11 +56,11 @@ export function UserFormDialog({ user }: UserFormDialogProps) {
       } else {
         await createUser(userData)
       }
-      toast.success('User saved successfully')
+      toast.success(t('userForm.successToast'))
       return true // Close the dialog
     } catch (err) {
       console.warn(err)
-      handleFieldErrors(err, setFieldErrors, 'Error saving user')
+      handleFieldErrors(err, setFieldErrors, t('userForm.errorFallback'))
       return false // Keep the dialog open
     } finally {
       setLoading(false)
@@ -68,17 +70,23 @@ export function UserFormDialog({ user }: UserFormDialogProps) {
   return (
     <BaseDialog
       dialogType={DIALOG_USER_FORM}
-      dialogTitle={isEdit ? 'Edit User' : 'New User'}
-      dialogDescription={isEdit ? 'Edit user details' : 'Create a new user'}
+      dialogTitle={isEdit ? t('userForm.editTitle') : t('userForm.newTitle')}
+      dialogDescription={
+        isEdit ? t('userForm.editDescription') : t('userForm.newDescription')
+      }
       onClose={() => true}
       onConfirm={async (): Promise<boolean> => {
         return await handleSubmit()
       }}
       testidPrefix="user-form-dialog"
-      cancelButton={{ label: 'Cancel', variant: 'outline', disabled: loading }}
+      cancelButton={{
+        label: t('userForm.cancel'),
+        variant: 'outline',
+        disabled: loading,
+      }}
       buttons={[
         {
-          label: 'Save',
+          label: t('userForm.save'),
           actionType: 'confirm',
           loading,
           disabled: loading || !username || !email || (!isEdit && !password),
@@ -88,41 +96,41 @@ export function UserFormDialog({ user }: UserFormDialogProps) {
       <div className="space-y-4 pt-2">
         <FormInput
           autoFocus={true}
-          label="username"
+          label={t('userForm.usernameLabel')}
           name="username"
           value={username}
           onChange={(val) => {
             setUsername(val)
             setFieldErrors((prev) => ({ ...prev, username: '' }))
           }}
-          placeholder="username"
+          placeholder={t('userForm.usernamePlaceholder')}
           autoComplete="username"
           error={fieldErrors.username}
           allowedHotkeys={DIALOG_INPUT_ALLOWED_HOTKEYS}
         />
         <FormInput
-          label="email"
+          label={t('userForm.emailLabel')}
           name="email"
           value={email}
           onChange={(val) => {
             setEmail(val)
             setFieldErrors((prev) => ({ ...prev, email: '' }))
           }}
-          placeholder="email"
+          placeholder={t('userForm.emailPlaceholder')}
           autoComplete="email"
           error={fieldErrors.email}
           allowedHotkeys={DIALOG_INPUT_ALLOWED_HOTKEYS}
         />
         {!isEdit && (
           <FormInput
-            label="password"
+            label={t('userForm.passwordLabel')}
             name="new-password"
             value={password}
             onChange={(val) => {
               setPassword(val)
               setFieldErrors((prev) => ({ ...prev, password: '' }))
             }}
-            placeholder="password"
+            placeholder={t('userForm.passwordPlaceholder')}
             autoComplete="new-password"
             error={fieldErrors.password}
             type="password"
@@ -138,17 +146,17 @@ export function UserFormDialog({ user }: UserFormDialogProps) {
           }}
         >
           <SelectTrigger>
-            <SelectValue placeholder="Select a role" />
+            <SelectValue placeholder={t('userForm.rolePlaceholder')} />
           </SelectTrigger>
           <SelectContent>
             <SelectItem key="viewer" value="viewer">
-              Viewer
+              {t('userForm.roleViewer')}
             </SelectItem>
             <SelectItem key="editor" value="editor">
-              Editor
+              {t('userForm.roleEditor')}
             </SelectItem>
             <SelectItem key="admin" value="admin">
-              Admin
+              {t('userForm.roleAdmin')}
             </SelectItem>
           </SelectContent>
         </Select>

--- a/ui/leafwiki-ui/src/features/viewer/Breadcrumbs.tsx
+++ b/ui/leafwiki-ui/src/features/viewer/Breadcrumbs.tsx
@@ -2,10 +2,12 @@ import { useAppMode } from '@/lib/useAppMode'
 import { createNavigationVisitState } from '@/lib/navigationVisit'
 import { useTreeStore } from '@/stores/tree'
 import { FolderTree } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router'
 import { useViewerStore } from './viewer'
 
 export default function Breadcrumbs() {
+  const { t } = useTranslation('viewer')
   const tree = useTreeStore((s) => s.tree)
   const page = useViewerStore((s) => s.page)
 
@@ -38,7 +40,7 @@ export default function Breadcrumbs() {
   const breadcrumbs = buildBreadcrumbs()
 
   return (
-    <nav className="breadcrumbs-nav" aria-label="Breadcrumb">
+    <nav className="breadcrumbs-nav" aria-label={t('breadcrumbs.navAriaLabel')}>
       <span className="breadcrumbs-nav__icon" aria-hidden="true">
         <FolderTree size={14} strokeWidth={1.8} />
       </span>

--- a/ui/leafwiki-ui/src/lib/i18n.ts
+++ b/ui/leafwiki-ui/src/lib/i18n.ts
@@ -1,12 +1,16 @@
 import i18next from 'i18next'
 import { initReactI18next } from 'react-i18next'
 import enApiKeys from '../locales/en/apikeys.json'
+import enAssets from '../locales/en/assets.json'
 import enAuth from '../locales/en/auth.json'
 import enBackup from '../locales/en/backup.json'
 import enBranding from '../locales/en/branding.json'
 import enEditor from '../locales/en/editor.json'
 import enErrors from '../locales/en/errors.json'
+import enHistory from '../locales/en/history.json'
+import enImporter from '../locales/en/importer.json'
 import enMaintenance from '../locales/en/maintenance.json'
+import enPage from '../locales/en/page.json'
 import enRestore from '../locales/en/restore.json'
 import enSearch from '../locales/en/search.json'
 import enSnapshot from '../locales/en/snapshot.json'
@@ -19,12 +23,16 @@ i18next.use(initReactI18next).init({
   resources: {
     en: {
       apikeys: enApiKeys,
+      assets: enAssets,
       auth: enAuth,
       backup: enBackup,
       branding: enBranding,
       errors: enErrors,
       editor: enEditor,
+      history: enHistory,
+      importer: enImporter,
       maintenance: enMaintenance,
+      page: enPage,
       restore: enRestore,
       search: enSearch,
       snapshot: enSnapshot,

--- a/ui/leafwiki-ui/src/locales/en/assets.json
+++ b/ui/leafwiki-ui/src/locales/en/assets.json
@@ -1,0 +1,33 @@
+{
+  "manager": {
+    "title": "Assets",
+    "fileTooLarge": "File too large. Max {{maxSize}} allowed.",
+    "uploadErrorFallback": "Asset upload failed",
+    "dropzoneText": "Drop files here or click to upload",
+    "maxFileSize": "Max file size: {{maxSize}}",
+    "uploading_one": "Uploading {{count}} file…",
+    "uploading_other": "Uploading {{count}} files…",
+    "loading": "Loading assets…",
+    "empty": "No assets yet",
+    "tip": "Tip: Double-click inserts the default markup. Images can also be added as links, and audio/video have a player insert button."
+  },
+  "item": {
+    "renameSuccess": "Asset renamed",
+    "renameErrorFallback": "Rename failed",
+    "deleteSuccess": "Asset deleted",
+    "deleteErrorFallback": "Delete failed",
+    "save": "Save",
+    "cancel": "Cancel",
+    "insertImageLink": "Insert image link",
+    "insertAudioPlayer": "Insert audio player",
+    "insertVideoPlayer": "Insert video player",
+    "insertImage": "Insert image",
+    "insertLink": "Insert link",
+    "rename": "Rename",
+    "delete": "Delete"
+  },
+  "dialog": {
+    "title": "Asset Manager",
+    "description": "Upload or select an asset to insert into the page."
+  }
+}

--- a/ui/leafwiki-ui/src/locales/en/editor.json
+++ b/ui/leafwiki-ui/src/locales/en/editor.json
@@ -6,13 +6,17 @@
   },
   "slugInput": {
     "label": "Slug",
-    "placeholder": "Page slug"
+    "placeholder": "Page slug",
+    "generateErrorFallback": "Error generating slug"
   },
   "addPageDialog": {
     "dateTitleTooltip": "Set title to today's date"
   },
   "editPageMetadataDialog": {
+    "dialogTitle": "Edit {{item}} metadata",
+    "dialogDescription": "Change metadata of the {{item}}",
     "titleLabel": "Title",
+    "titlePlaceholder": "{{item}} title",
     "pathPrefix": "Path:",
     "cancelButton": "Cancel",
     "saveButton": "Change",
@@ -55,6 +59,28 @@
     "lineWrap": "Line wrap",
     "autoSave": "Auto-save",
     "autoSavePaused": "paused"
+  },
+  "pageEditor": {
+    "savedToast": "Page saved successfully",
+    "saveErrorFallback": "Error saving page",
+    "saveAnyway": "Save anyway",
+    "conflictAgainMessage": "The page was modified again while saving. Please reload the page and re-apply your changes.",
+    "errorPrefix": "Error: {{error}}"
+  },
+  "linkInsertDialog": {
+    "textPlaceholder": "Link text",
+    "urlPlaceholder": "https:// or search pages…"
+  },
+  "frontmatterPanel": {
+    "addTagPlaceholder": "Add tag",
+    "keyPlaceholder": "Key",
+    "valuePlaceholder": "Value"
+  },
+  "markdownEditor": {
+    "resizeAriaLabel": "Resize editor and preview panes",
+    "fileTooLarge": "File too large. Max {{maxSize}} allowed.",
+    "uploadedToast": "Uploaded {{filename}}",
+    "uploadErrorFallback": "Failed to upload {{filename}}"
   },
   "autoSave": {
     "savedToast": "Saved",

--- a/ui/leafwiki-ui/src/locales/en/history.json
+++ b/ui/leafwiki-ui/src/locales/en/history.json
@@ -1,0 +1,102 @@
+{
+  "common": {
+    "unknown": "Unknown",
+    "unknownTime": "Unknown time"
+  },
+  "trigger": {
+    "contentUpdate": "Saved after content update",
+    "assetUpdate": "Saved after asset update",
+    "structureUpdate": "Saved after structure update",
+    "restore": "Saved after restore",
+    "delete": "Saved before delete",
+    "generic": "Saved as {{type}}"
+  },
+  "assetChange": {
+    "added": "Added",
+    "removed": "Removed",
+    "replaced": "Replaced"
+  },
+  "restoreDialog": {
+    "title": "Restore revision?",
+    "description": "This restores the revision content, title, and assets. The current slug and location stay unchanged.",
+    "cancel": "Cancel",
+    "confirm": "Restore revision",
+    "restoredTitleLabel": "Restored title:",
+    "slugNote": "This revision used slug <mono>{{revisionSlug}}</mono>. The current slug <mono>{{currentSlug}}</mono> will stay unchanged."
+  },
+  "diff": {
+    "noTextDifference": "No text difference between this revision and the active version."
+  },
+  "changes": {
+    "summaryHeading": "Change Summary",
+    "linesAdded": "Lines added since",
+    "linesRemoved": "Lines removed since",
+    "assetsChanged": "Assets changed",
+    "diffHeading": "Diff",
+    "diffNote": "compared to the active version",
+    "assetsDetails": "Assets ({{count}})",
+    "assetAdded": "{{count}} added",
+    "assetReplaced": "{{count}} replaced",
+    "assetRemoved": "{{count}} removed"
+  },
+  "rawText": {
+    "heading": "Raw Text",
+    "empty": "(empty)"
+  },
+  "assetsPanel": {
+    "heading": "Assets",
+    "empty": "No assets were stored with this revision.",
+    "octetStream": "application/octet-stream",
+    "openAsset": "Open asset",
+    "downloadAsset": "Download asset"
+  },
+  "tabs": {
+    "preview": "Preview",
+    "changes": "Changes",
+    "raw": "Raw Text",
+    "assets": "Assets",
+    "mobileRevisions": "Revisions",
+    "mobileDetails": "Details"
+  },
+  "detail": {
+    "loadingHistory": "Loading history...",
+    "noRevisionSelectedTitle": "No revision selected",
+    "noRevisionSelectedMessage": "Select a revision from the list to view details.",
+    "loadingDiff": "Loading diff...",
+    "loadingPreview": "Loading preview...",
+    "noPreview": "No preview available.",
+    "noChangesFromCurrent": "No differences from the current version.",
+    "noComparisonData": "No comparison data available.",
+    "noRawText": "No raw text available.",
+    "noAssetData": "No asset data available."
+  },
+  "list": {
+    "loading": "Loading history...",
+    "emptyWithLatest": "No previous revisions yet. Older versions will appear here after more changes.",
+    "emptyNoLatest": "No revisions yet. They will appear here after the page changes.",
+    "activeVersionBadge": "Active version",
+    "loadMoreLoading": "Loading...",
+    "loadMore": "Load more",
+    "resizeAriaLabel": "Resize revision list",
+    "title": "Revision History"
+  },
+  "header": {
+    "revisionBy": "Revision by {{author}} · {{time}}",
+    "restoreLoading": "Restoring...",
+    "currentVersion": "Current version",
+    "restore": "Restore",
+    "titleLabel": "Title",
+    "slugLabel": "Slug",
+    "emptyValue": "(empty)"
+  },
+  "chips": {
+    "revisionSlug": "Revision slug: {{slug}}",
+    "currentSlug": "Current slug: {{slug}}",
+    "assetChangesCount": "{{count}} asset changes",
+    "assetsCount": "{{count}} Assets"
+  },
+  "toasts": {
+    "restoreSuccess": "Revision restored",
+    "restoreErrorFallback": "Failed to restore revision"
+  }
+}

--- a/ui/leafwiki-ui/src/locales/en/importer.json
+++ b/ui/leafwiki-ui/src/locales/en/importer.json
@@ -1,0 +1,150 @@
+{
+  "title": "Import",
+  "planActions": {
+    "create": "Create page",
+    "update": "Update page",
+    "skip": "Skip item"
+  },
+  "resultActions": {
+    "needsAttention": "Needs attention",
+    "created": "Created",
+    "updated": "Updated",
+    "skipped": "Skipped",
+    "conflicted": "Conflicted"
+  },
+  "steps": {
+    "selectZip": {
+      "title": "Select Zip",
+      "description": "Choose the package you want to import."
+    },
+    "reviewPlan": {
+      "title": "Review Plan",
+      "description": "Check the generated pages and paths."
+    },
+    "runImport": {
+      "title": "Run Import",
+      "description": "Watch progress while the importer works."
+    },
+    "reviewResult": {
+      "title": "Review Result",
+      "description": "Inspect imported, skipped, or failed items."
+    }
+  },
+  "nextAction": {
+    "chooseZip": "Choose a zip file and create an import plan.",
+    "reviewThenStart": "Review the generated items, then start the import.",
+    "cancellationRequested": "Cancellation was requested. The importer will stop after the current item finishes.",
+    "running": "The import is running. You can stay on this page and watch the progress update.",
+    "completed": "The import finished successfully. Review the result below, or start a new import with another zip package.",
+    "failed": "The import stopped with an error. Check the message and result items below.",
+    "canceled": "The import was canceled. Completed work was kept and is shown below.",
+    "selectZipToBegin": "Select a zip file to begin."
+  },
+  "beforeYouStart": {
+    "title": "Before You Start",
+    "description": "Import a zip archive with Markdown files. LeafWiki first creates a review plan, and only imports pages after you explicitly start the execution step.",
+    "whatHappensNext": "What happens next?",
+    "stepPrefix": "Step {{number}}",
+    "safeReviewTitle": "Safe review first",
+    "safeReviewText": "Creating the plan does not import pages yet.",
+    "linksAssetsTitle": "Links and assets",
+    "linksAssetsText": "Internal links and embedded assets are rewritten during import.",
+    "alphaTitle": "Still in alpha",
+    "alphaText": "Some Markdown variants may still need manual cleanup afterward."
+  },
+  "flow": {
+    "title": "Import Flow"
+  },
+  "package": {
+    "title": "Choose Import Package",
+    "description": "Select a zip archive that contains Markdown files. After that, we create a preview plan so you can inspect paths, actions, and notes before the import runs.",
+    "issueHint": "If you run into problems, unexpected results, or unsupported edge cases, please create an issue on our <link>GitHub repository</link>.",
+    "currentZip": "Current Zip:",
+    "noZipSelected": "No zip file selected",
+    "selectZipFile": "Select Zip File",
+    "supportedInputHint": "Supported input: a single `.zip` archive containing your Markdown knowledge base.",
+    "importFromZip": "Import from Zip",
+    "planOnlyHint": "This only creates the review plan. No pages are imported until you click `Execute Import Plan`."
+  },
+  "plan": {
+    "title": "Import Plan",
+    "description": "Review what LeafWiki is about to create, update, or skip before you start the import.",
+    "currentStatus": "Current Status",
+    "planId": "Plan ID: {{id}}",
+    "progress": "Progress: {{progress}}",
+    "percentComplete": "{{percent}}% complete",
+    "willCreate": "Will Create",
+    "willUpdate": "Will Update",
+    "willSkip": "Will Skip",
+    "runningCancelRequested": "Cancellation has been requested. The importer will stop after the current item finishes.",
+    "runningInBackground": "The import is running in the background. You can stay on this page to watch progress.",
+    "currentlyProcessing": " Currently processing {{path}}.",
+    "canceledNotice": "The import was canceled. Completed items were kept, and the partial result is shown below.",
+    "idLabel": "ID:",
+    "treeHashLabel": "Tree Hash:",
+    "progressLabel": "Progress:",
+    "startedAtLabel": "Started At:",
+    "finishedAtLabel": "Finished At:",
+    "startNewImport": "Start New Import",
+    "closeAndClear": "Close and Clear"
+  },
+  "plannedItems": {
+    "title": "Planned Items ({{count}})",
+    "description": "These are the individual files LeafWiki detected in the package and how they map to target pages.",
+    "importFile": "Import File",
+    "targetPage": "Target Page",
+    "titleColumn": "Title",
+    "type": "Type",
+    "plannedAction": "Planned Action",
+    "notesForReview": "Notes for Review",
+    "noSpecialNotes": "No special notes"
+  },
+  "run": {
+    "title": "Run Import",
+    "descriptionPlan": "Start the import once the plan looks correct. You can also clear the current plan and begin again with a different package.",
+    "descriptionRunning": "The importer is currently working through the generated plan. You can stay on this page to monitor progress or request cancellation.",
+    "currentStatus": "Current Status",
+    "importRunning": "Import Running",
+    "executeImportPlan": "Execute Import Plan",
+    "cancelRequested": "Cancel Requested",
+    "cancelImport": "Cancel Import",
+    "clearImportPlan": "Clear Import Plan"
+  },
+  "result": {
+    "title": "Import Result",
+    "description": "This is the final outcome of the import. Skipped items usually need manual review, while failed items need attention before retrying.",
+    "wantAnotherTitle": "Want to import another package?",
+    "wantAnotherBody": "Start a new import to clear this result and choose a different zip file.",
+    "created": "Created",
+    "skipped": "Skipped",
+    "failed": "Failed",
+    "treeUpdated": "Tree Updated",
+    "yes": "Yes",
+    "no": "No",
+    "importedCount": "Imported Count:",
+    "updatedCount": "Updated Count:",
+    "skippedCount": "Skipped Count:"
+  },
+  "resultItems": {
+    "title": "Result Items ({{filtered}}/{{total}})",
+    "description": "Use the filters to focus on successful imports, skipped items, or failures.",
+    "filterPlaceholder": "Filter by path, action, or error",
+    "importedFile": "Imported File",
+    "resultingPage": "Resulting Page",
+    "outcome": "Outcome",
+    "details": "Details",
+    "detailImported": "Imported successfully",
+    "detailUpdated": "Existing page was updated",
+    "detailSkipped": "Skipped without error",
+    "detailNone": "No extra details",
+    "noItemsMatch": "No items match the current filter."
+  },
+  "status": {
+    "running": "Running",
+    "completed": "Completed",
+    "canceled": "Canceled",
+    "failed": "Failed",
+    "planned": "Planned",
+    "idle": "Idle"
+  }
+}

--- a/ui/leafwiki-ui/src/locales/en/page.json
+++ b/ui/leafwiki-ui/src/locales/en/page.json
@@ -1,0 +1,124 @@
+{
+  "common": {
+    "page": "page",
+    "section": "section",
+    "pageCapitalized": "Page",
+    "sectionCapitalized": "Section",
+    "cancel": "Cancel",
+    "errorPrefix": "Error: {{error}}",
+    "unknownError": "An unknown error occurred"
+  },
+  "addDialog": {
+    "slugNotGenerated": "Slug could not be generated. Please enter it manually.",
+    "slugStillGenerating": "Please wait until the slug is fully generated.",
+    "createdToast": "{{item}} created",
+    "createErrorFallback": "Error creating {{item}}",
+    "create": "Create",
+    "createAndEdit": "Create & Edit {{item}}",
+    "titlePage": "Create a new page",
+    "titleSection": "Create a new section",
+    "descriptionPage": "Enter the title of the new page",
+    "descriptionSection": "Enter the title of the new section",
+    "titleLabel": "Title",
+    "titlePlaceholder": "{{item}} title",
+    "pathPrefix": "Path:"
+  },
+  "moveDialog": {
+    "movedToast": "Page moved successfully",
+    "moveErrorFallback": "Error moving {{item}}",
+    "title": "Move {{item}}",
+    "description": "Select a new parent for this {{item}}",
+    "move": "Move"
+  },
+  "deleteDialog": {
+    "loadReferencesErrorFallback": "Failed to load page references",
+    "deletedToast": "{{item}} deleted successfully",
+    "deleteErrorFallback": "Error deleting {{item}}",
+    "title": "Delete {{item}}?",
+    "description": "Are you sure you want to delete this {{item}}? This action cannot be undone.",
+    "deleting": "Deleting...",
+    "delete": "Delete",
+    "modifiedWarningTitle": "This page was modified by another user.",
+    "modifiedWarningBody": "The page has been refreshed. Do you still want to delete it?",
+    "backlinksLoading": "Checking which pages reference this page...",
+    "backlinksError": "Could not load page references. Deleting will still work, but link impact could not be shown.",
+    "backlinksWarning_one": "This page is referenced by {{count}} page.",
+    "backlinksWarning_other": "This page is referenced by {{count}} pages.",
+    "backlinksWarningBody": "Deleting this page will leave those links broken.",
+    "noBacklinks": "No pages currently reference this page.",
+    "deleteSubpages": "Also delete all subpages"
+  },
+  "sortDialog": {
+    "dragToReorder": "Drag to reorder",
+    "sortedToast": "{{item}} children sorted successfully",
+    "sortErrorFallback": "Error sorting {{item}} children",
+    "title": "Sort {{item}} Children",
+    "description": "Drag items to reorder, use the arrows, or sort alphabetically. Changes are saved after clicking 'Save'.",
+    "save": "Save",
+    "sortAlphabetically": "Sort alphabetically:",
+    "ascending": "A → Z",
+    "descending": "Z → A"
+  },
+  "copyDialog": {
+    "slugNotGenerated": "Slug could not be generated. Please enter it manually.",
+    "slugStillGenerating": "Please wait until the slug is fully generated.",
+    "copiedToast": "{{item}} copied",
+    "copyErrorFallback": "Error copying {{item}}",
+    "copyOfTitle": "Copy of {{title}}",
+    "title": "Copy {{item}}",
+    "description": "Create a copy of this {{item}}",
+    "copying": "Copying...",
+    "copyAndEdit": "Copy & Edit {{item}}",
+    "titleLabel": "Title",
+    "titlePlaceholder": "{{item}} title",
+    "pathPrefix": "Path:"
+  },
+  "permalinkDialog": {
+    "copyErrorToast": "Could not copy permalink",
+    "copiedToast": "Permalink copied",
+    "title": "Share page",
+    "description": "Shareable URL for {{title}}",
+    "close": "Close",
+    "urlLabel": "Shareable URL",
+    "copyLink": "Copy link",
+    "openLink": "Open link"
+  },
+  "createByPathDialog": {
+    "createdToast": "Page created successfully",
+    "createErrorFallback": "Error creating page",
+    "title": "Create a new page",
+    "description": "Please enter the title",
+    "creating": "Creating...",
+    "create": "Create",
+    "createAndEdit": "Create & Edit",
+    "existsAlert": "A page already exists at this path.",
+    "lookupResultTitle": "Result of path lookup:",
+    "segmentExists": "exists",
+    "segmentWillBeCreated": "will be created",
+    "titleLabel": "Title",
+    "titlePlaceholder": "Page title",
+    "pathLabel": "Path",
+    "pathPlaceholder": "Page path"
+  },
+  "select": {
+    "topLevel": "Top Level",
+    "searchPlaceholder": "Search pages...",
+    "searchAriaLabel": "Search pages",
+    "noPagesFound": "No pages found.",
+    "pagesAriaLabel": "Pages"
+  },
+  "refactorDialog": {
+    "title": "Update references?",
+    "description": "This change affects the page path. Review the impacted pages before continuing.",
+    "saveWithoutRewrite": "Save without updating links",
+    "continue": "Continue",
+    "oldPath": "Old path:",
+    "newPath": "New path:",
+    "updateLinksLabel": "Update links on referencing pages automatically",
+    "referencingPages": "Referencing pages ({{count}})",
+    "noReferences": "No pages reference this path."
+  },
+  "historyPage": {
+    "backToPage": "Back to Page"
+  }
+}

--- a/ui/leafwiki-ui/src/locales/en/users.json
+++ b/ui/leafwiki-ui/src/locales/en/users.json
@@ -1,6 +1,63 @@
 {
   "loading": "Loading users...",
   "noUsersFound": "No users found.",
+  "validation": {
+    "passwordTooShort": "Password must be at least 8 characters long",
+    "passwordsDoNotMatch": "Passwords do not match"
+  },
+  "changePasswordDialog": {
+    "title": "Change Password for {{username}}",
+    "description": "Set a new password for the user.",
+    "cancel": "Cancel",
+    "update": "Update Password",
+    "updating": "Updating...",
+    "newPasswordLabel": "New Password",
+    "confirmPasswordLabel": "Confirm Password",
+    "successToast": "Password changed successfully",
+    "errorFallback": "Error updating password"
+  },
+  "userForm": {
+    "editTitle": "Edit User",
+    "newTitle": "New User",
+    "editDescription": "Edit user details",
+    "newDescription": "Create a new user",
+    "cancel": "Cancel",
+    "save": "Save",
+    "successToast": "User saved successfully",
+    "errorFallback": "Error saving user",
+    "usernameLabel": "username",
+    "usernamePlaceholder": "username",
+    "emailLabel": "email",
+    "emailPlaceholder": "email",
+    "passwordLabel": "password",
+    "passwordPlaceholder": "password",
+    "rolePlaceholder": "Select a role",
+    "roleViewer": "Viewer",
+    "roleEditor": "Editor",
+    "roleAdmin": "Admin"
+  },
+  "deleteUser": {
+    "title": "Delete User?",
+    "description": "Are you sure you want to delete this user? This action cannot be undone.",
+    "cancel": "Cancel",
+    "deleting": "Deleting...",
+    "delete": "Delete",
+    "successToast": "User deleted successfully",
+    "errorFallback": "Failed to delete user. Please try again.",
+    "body": "The user <strong>{{username}}</strong> will be permanently removed from the system."
+  },
+  "changeOwnPassword": {
+    "title": "Change Own Password",
+    "description": "Change your password. Make sure to remember it!",
+    "cancel": "Cancel",
+    "saving": "Saving...",
+    "save": "Save",
+    "successToast": "Password changed successfully",
+    "errorFallback": "Error updating password",
+    "oldPasswordLabel": "Old Password",
+    "newPasswordLabel": "New Password",
+    "confirmPasswordLabel": "Confirm Password"
+  },
   "totp": {
     "column": "2FA",
     "enabled": "Enabled",

--- a/ui/leafwiki-ui/src/locales/en/viewer.json
+++ b/ui/leafwiki-ui/src/locales/en/viewer.json
@@ -4,6 +4,9 @@
     "resizeSidebar": "Resize sidebar",
     "closeSidebar": "Close sidebar"
   },
+  "breadcrumbs": {
+    "navAriaLabel": "Breadcrumb"
+  },
   "section": {
     "overviewTitle": "Overview of '{{title}}'",
     "overviewDescriptionBase": "This page is the default overview of the section and lists its pages and sections.",
@@ -20,6 +23,7 @@
     "brokenLinkTooltip": "This page doesn't exist yet."
   },
   "backlinks": {
+    "errorPrefix": "Error: {{error}}",
     "referencedBy": "Referenced by",
     "loading": "Loading…",
     "noReferences": "No pages reference this page.",
@@ -37,7 +41,8 @@
     "unpinSuccess": "Page unpinned",
     "pinError": "Failed to update pin status",
     "togglePinnedSection": "Toggle pinned pages section",
-    "togglePagesSection": "Toggle pages section"
+    "togglePagesSection": "Toggle pages section",
+    "unpinPageAriaLabel": "Unpin page"
   },
   "favorites": {
     "sectionTitle": "Favorites",
@@ -53,6 +58,58 @@
     "onThisPage": "On this page",
     "collapse": "Collapse table of contents",
     "expand": "Expand table of contents"
+  },
+  "toolbar": {
+    "moreActions": "More actions"
+  },
+  "treeActions": {
+    "convertedToast": "Page converted successfully",
+    "conflictRetryMessage": "This page was modified by another user. Please try again.",
+    "convertErrorFallback": "Failed to convert page",
+    "renameEditingWarning": "This {{item}} is currently being edited. Please use the editor title bar to rename it.",
+    "renamedToast": "{{item}} renamed successfully",
+    "renameErrorFallback": "Failed to rename page",
+    "deleteEditingWarning": "This {{item}} is currently being edited. Please close the editor before deleting it.",
+    "menuAddPage": "Add Page",
+    "menuAddSection": "Add Section",
+    "menuEdit": "Edit {{item}}",
+    "menuRename": "Rename {{item}}",
+    "menuCopyPage": "Copy Page",
+    "menuSortChildren": "Sort {{item}} Children",
+    "menuMove": "Move {{item}}",
+    "menuConvertToPage": "Convert to Page",
+    "menuDelete": "Delete {{item}}",
+    "emptySectionToast": "\"{{title}}\" is now an empty section",
+    "convertBackAction": "Convert back to page",
+    "convertedBackToast": "\"{{title}}\" is a page again",
+    "convertBackErrorFallback": "Failed to convert section back to page",
+    "reorderErrorFallback": "Failed to reorder pages",
+    "moveErrorFallback": "Failed to move page"
+  },
+  "codeBlock": {
+    "copyErrorToast": "Could not copy code",
+    "copiedToast": "Code copied",
+    "copyTooltip": "Copy code",
+    "copiedTooltip": "Copied",
+    "copyAriaLabel": "Copy code",
+    "copiedAriaLabel": "Code copied"
+  },
+  "designToggle": {
+    "switchToLight": "Switch to light mode",
+    "switchToDark": "Switch to dark mode"
+  },
+  "imagePreview": {
+    "openInNewTab": "Open in new tab"
+  },
+  "pageSwitcher": {
+    "trigger": "Go to page",
+    "triggerWithHotkey": "Go to page ({{hotkey}})",
+    "dialogTitle": "Go to page",
+    "dialogDescription": "Search existing pages by title, path, or breadcrumb.",
+    "searchPlaceholder": "Type a page title…",
+    "searchAriaLabel": "Search pages",
+    "noMatch": "No matching page found.",
+    "matchingPagesAriaLabel": "Matching pages"
   },
   "shortcutsHelp": {
     "menuItem": "Keyboard Shortcuts",


### PR DESCRIPTION
Migrates page, importer, assets, history, page-switcher, toolbar, tags, designtoggle, imagepreview, and links features to react-i18next (new page/importer/assets/history locale namespaces), and closes follow-up gaps discovered in editor, preview, tree, users, and viewer features that had picked up hardcoded strings since their migration.
