### PR TITLE
feat(i18n): close remaining hardcoded-string gaps

### DIFF
--- a/ui/leafwiki-ui/src/components/ErrorBoundary.tsx
+++ b/ui/leafwiki-ui/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button'
+import i18next from '@/lib/i18n'
 import { AlertTriangle, RefreshCw } from 'lucide-react'
 import { Component, ErrorInfo } from 'react'
 import type { ReactNode } from 'react'
@@ -50,11 +51,10 @@ export class ErrorBoundary extends Component<Props, State> {
           </div>
           <div className="flex flex-col gap-1">
             <h1 className="text-foreground text-xl font-semibold">
-              Something went wrong
+              {i18next.t('errorBoundary.heading', { ns: 'common' })}
             </h1>
             <p className="text-muted-foreground max-w-md text-sm">
-              An unexpected error occurred. Reloading the page usually fixes
-              this.
+              {i18next.t('errorBoundary.body', { ns: 'common' })}
             </p>
           </div>
         </div>
@@ -62,16 +62,16 @@ export class ErrorBoundary extends Component<Props, State> {
         <div className="flex gap-3">
           <Button onClick={this.handleReload} className="gap-2">
             <RefreshCw className="h-4 w-4" />
-            Reload page
+            {i18next.t('errorBoundary.reloadButton', { ns: 'common' })}
           </Button>
           <Button variant="outline" onClick={this.handleReset}>
-            Try to recover
+            {i18next.t('errorBoundary.tryRecoverButton', { ns: 'common' })}
           </Button>
         </div>
 
         <details className="border-border bg-muted/40 w-full max-w-xl rounded-md border">
           <summary className="text-muted-foreground cursor-pointer p-3 text-xs font-medium select-none">
-            Error details
+            {i18next.t('errorBoundary.detailsSummary', { ns: 'common' })}
           </summary>
           <pre className="text-destructive overflow-auto p-3 pt-0 text-xs break-all whitespace-pre-wrap">
             {error.stack ?? error.message}

--- a/ui/leafwiki-ui/src/components/Page404.tsx
+++ b/ui/leafwiki-ui/src/components/Page404.tsx
@@ -4,6 +4,7 @@ import { DIALOG_CREATE_PAGE_BY_PATH } from '@/lib/registries'
 import { useIsReadOnly } from '@/lib/useIsReadOnly'
 import { useDialogsStore } from '@/stores/dialogs'
 import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 type Page404Props = {
   targetPath?: string
@@ -14,6 +15,7 @@ export default function Page404({
   targetPath,
   allowCreate = false,
 }: Page404Props) {
+  const { t } = useTranslation('common')
   const readOnlyMode = useIsReadOnly()
   const openDialog = useDialogsStore((s) => s.openDialog)
   const [lookupState, setLookupState] = useState<{
@@ -65,15 +67,11 @@ export default function Page404({
   return (
     <div className="page404-shell">
       <div className="page404" data-testid="page404">
-        <h1 className="page404__title">Page Not Found</h1>
-        <p className="page404__text">
-          The page you are looking for does not exist.
-        </p>
+        <h1 className="page404__title">{t('page404.heading')}</h1>
+        <p className="page404__text">{t('page404.body')}</p>
         {showCreate && (
           <>
-            <p className="page404__text">
-              Create the page by clicking the button below.
-            </p>
+            <p className="page404__text">{t('page404.createPrompt')}</p>
             <Button
               className="mt-4"
               data-testid="page404-create-page-button"
@@ -86,7 +84,7 @@ export default function Page404({
               }
               variant={'outline'}
             >
-              Create Page
+              {t('page404.createButton')}
             </Button>
           </>
         )}

--- a/ui/leafwiki-ui/src/components/TagInputWithSuggestions.tsx
+++ b/ui/leafwiki-ui/src/components/TagInputWithSuggestions.tsx
@@ -11,6 +11,7 @@ import {
   useState,
 } from 'react'
 import { createPortal } from 'react-dom'
+import { useTranslation } from 'react-i18next'
 
 type TagInputVariant = 'browse' | 'metadata'
 
@@ -91,6 +92,7 @@ function TagInputWithSuggestions({
   onArrowUp,
   onSubmitWithoutSuggestion,
 }: TagInputWithSuggestionsProps) {
+  const { t } = useTranslation('editor')
   const classes = variantClasses(variant)
   const allowCustomTags = allowsCustomTagCreation(variant)
   const useSelectedTagSuggestions = usesSelectedTagSuggestions(variant)
@@ -333,10 +335,12 @@ function TagInputWithSuggestions({
             }}
           >
             {loading ? (
-              <p className={classes.suggestionsEmpty}>Loading…</p>
+              <p className={classes.suggestionsEmpty}>
+                {t('tagInput.loading')}
+              </p>
             ) : showNoSuggestions ? (
               <p className={classes.suggestionsEmpty}>
-                No matching tags found.
+                {t('tagInput.noMatchingTags')}
               </p>
             ) : (
               suggestedTags.map(({ tag }, index) => (
@@ -382,7 +386,7 @@ function TagInputWithSuggestions({
               type="button"
               className={classes.chipRemove}
               onClick={() => removeTag(tag)}
-              aria-label={`Remove tag ${tag}`}
+              aria-label={t('tagInput.removeTagAriaLabel', { tag })}
             >
               <X size={12} />
             </button>

--- a/ui/leafwiki-ui/src/components/UnsavedChangesDialog.tsx
+++ b/ui/leafwiki-ui/src/components/UnsavedChangesDialog.tsx
@@ -1,4 +1,5 @@
 import { DIALOG_UNSAVED_CHANGES } from '@/lib/registries'
+import { useTranslation } from 'react-i18next'
 import BaseDialog from './BaseDialog'
 
 type UnsavedChangesDialogProps = {
@@ -10,10 +11,11 @@ export function UnsavedChangesDialog({
   onConfirm,
   onCancel,
 }: UnsavedChangesDialogProps) {
+  const { t } = useTranslation('common')
   return (
     <BaseDialog
-      dialogTitle="Unsaved Changes"
-      dialogDescription="You have unsaved changes. Are you sure you want to leave this page? Unsaved data will be lost."
+      dialogTitle={t('unsavedChangesDialog.title')}
+      dialogDescription={t('unsavedChangesDialog.description')}
       dialogType={DIALOG_UNSAVED_CHANGES}
       testidPrefix="unsaved-changes-dialog"
       onClose={() => {
@@ -25,13 +27,13 @@ export function UnsavedChangesDialog({
         return true
       }}
       cancelButton={{
-        label: 'Cancel',
+        label: t('unsavedChangesDialog.cancelButton'),
         variant: 'secondary',
         autoFocus: true,
       }}
       buttons={[
         {
-          label: 'Leave anyway',
+          label: t('unsavedChangesDialog.leaveAnywayButton'),
           variant: 'destructive',
           actionType: 'confirm',
           disabled: false,

--- a/ui/leafwiki-ui/src/components/UserToolbar.tsx
+++ b/ui/leafwiki-ui/src/components/UserToolbar.tsx
@@ -162,13 +162,13 @@ export default function UserToolbar() {
               className="cursor-pointer"
               onClick={() => navigate('/settings/branding')}
             >
-              Branding Settings
+              {t('userMenu.brandingSettings')}
             </DropdownMenuItem>
             <DropdownMenuItem
               className="cursor-pointer"
               onClick={() => navigate('/settings/importer')}
             >
-              Import
+              {t('userMenu.import')}
             </DropdownMenuItem>
             {apiKeysEnabled && (
               <DropdownMenuItem
@@ -198,12 +198,12 @@ export default function UserToolbar() {
               className="cursor-pointer"
               onClick={() => navigate('/settings/maintenance')}
             >
-              Maintenance
+              {t('userMenu.maintenance')}
             </DropdownMenuItem>
             <DropdownMenuSeparator />
           </RoleGuard>
           <DropdownMenuLabel className="text-muted-foreground text-xs font-normal">
-            Version {__APP_VERSION__}
+            {t('userMenu.version', { version: __APP_VERSION__ })}
           </DropdownMenuLabel>
           <RoleGuard roles={['admin', 'editor']}>
             <DropdownMenuSeparator />
@@ -249,7 +249,7 @@ export default function UserToolbar() {
               onClick={handleLogout}
               data-testid="user-toolbar-logout"
             >
-              Logout
+              {t('userMenu.logout')}
             </DropdownMenuItem>
           )}
           <RoleGuard roles={['admin']}>
@@ -264,7 +264,7 @@ export default function UserToolbar() {
                 rel="noopener noreferrer"
               >
                 <Heart className="size-3.5 shrink-0" />
-                <span>Support LeafWiki</span>
+                <span>{t('userMenu.supportLeafWiki')}</span>
               </a>
             </DropdownMenuItem>
           </RoleGuard>

--- a/ui/leafwiki-ui/src/components/ui/dialog.tsx
+++ b/ui/leafwiki-ui/src/components/ui/dialog.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { X } from 'lucide-react'
+import i18next from '@/lib/i18n'
 
 import { cn } from '@/lib/utils'
 
@@ -44,7 +45,9 @@ const DialogContent = React.forwardRef<
       {children}
       <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
         <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+        <span className="sr-only">
+          {i18next.t('dialog.closeSrOnly', { ns: 'common' })}
+        </span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>

--- a/ui/leafwiki-ui/src/features/editor/LinkInsertDialog.tsx
+++ b/ui/leafwiki-ui/src/features/editor/LinkInsertDialog.tsx
@@ -113,11 +113,13 @@ export function LinkInsertDialog({
     >
       <DialogContent className="max-w-sm">
         <DialogHeader>
-          <DialogTitle>Insert Link</DialogTitle>
+          <DialogTitle>{t('linkInsertDialog.dialogTitle')}</DialogTitle>
         </DialogHeader>
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-1.5">
-            <Label htmlFor="link-text">Display Text</Label>
+            <Label htmlFor="link-text">
+              {t('linkInsertDialog.displayTextLabel')}
+            </Label>
             <Input
               id="link-text"
               ref={textInputRef}
@@ -130,7 +132,7 @@ export function LinkInsertDialog({
             />
           </div>
           <div className="flex flex-col gap-1.5">
-            <Label htmlFor="link-url">URL</Label>
+            <Label htmlFor="link-url">{t('linkInsertDialog.urlLabel')}</Label>
             <div className="relative">
               <Input
                 id="link-url"
@@ -192,9 +194,11 @@ export function LinkInsertDialog({
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={closeDialog}>
-            Cancel
+            {t('linkInsertDialog.cancelButton')}
           </Button>
-          <Button onClick={handleConfirm}>Insert</Button>
+          <Button onClick={handleConfirm}>
+            {t('linkInsertDialog.insertButton')}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/ui/leafwiki-ui/src/features/editor/MarkdownEditor.tsx
+++ b/ui/leafwiki-ui/src/features/editor/MarkdownEditor.tsx
@@ -705,8 +705,16 @@ const MarkdownEditor = (
           {/* Mobile Tabs */}
           <div className="markdown-editor__tabs" role="tablist">
             {[
-              { id: 'editor', label: 'Editor', icon: <Code2 size={16} /> },
-              { id: 'preview', label: 'Preview', icon: <Eye size={16} /> },
+              {
+                id: 'editor',
+                label: t('markdownEditor.editorTab'),
+                icon: <Code2 size={16} />,
+              },
+              {
+                id: 'preview',
+                label: t('markdownEditor.previewTab'),
+                icon: <Eye size={16} />,
+              },
             ].map((tab) => (
               <button
                 key={tab.id}

--- a/ui/leafwiki-ui/src/features/editor/PageFrontmatterPanel.tsx
+++ b/ui/leafwiki-ui/src/features/editor/PageFrontmatterPanel.tsx
@@ -152,7 +152,9 @@ export function PageFrontmatterPanel({
                 className={`page-frontmatter-panel__title-row${hasErrors ? 'page-frontmatter-panel__title-row--has-errors' : ''}`}
               >
                 <Tag className="page-frontmatter-panel__title-icon" size={14} />
-                <span className="page-frontmatter-panel__title">Metadata</span>
+                <span className="page-frontmatter-panel__title">
+                  {t('frontmatterPanel.metadataTitle')}
+                </span>
               </div>
               <span
                 className={`page-frontmatter-panel__summary${hasErrors ? 'page-frontmatter-panel__summary--has-errors' : ''}`}
@@ -165,7 +167,7 @@ export function PageFrontmatterPanel({
             <div className="page-frontmatter-panel__stack">
               <div className="page-frontmatter-panel__row page-frontmatter-panel__row--tags">
                 <div className="page-frontmatter-panel__section-heading page-frontmatter-panel__section-heading--inline">
-                  Tags
+                  {t('frontmatterPanel.tagsHeading')}
                 </div>
                 <div className="page-frontmatter-panel__tags-field">
                   <TagInputWithSuggestions
@@ -189,7 +191,7 @@ export function PageFrontmatterPanel({
 
               <div className="page-frontmatter-panel__row page-frontmatter-panel__row--properties">
                 <div className="page-frontmatter-panel__section-heading page-frontmatter-panel__section-heading--inline">
-                  Properties
+                  {t('frontmatterPanel.propertiesHeading')}
                 </div>
                 <div className="page-frontmatter-panel__properties">
                   <div className="page-frontmatter-panel__properties-scroll custom-scrollbar">
@@ -232,7 +234,10 @@ export function PageFrontmatterPanel({
                                 type="button"
                                 className="page-frontmatter-panel__field-remove"
                                 onClick={() => removeField(index)}
-                                aria-label={`Remove frontmatter field ${field.key || index + 1}`}
+                                aria-label={t(
+                                  'frontmatterPanel.removeFieldAriaLabel',
+                                  { field: field.key || index + 1 },
+                                )}
                               >
                                 <Trash2 size={14} />
                               </button>

--- a/ui/leafwiki-ui/src/features/editor/pageEditorStore.ts
+++ b/ui/leafwiki-ui/src/features/editor/pageEditorStore.ts
@@ -9,6 +9,7 @@ import {
   updatePage,
 } from '@/lib/api/pages'
 import { isPageNotFoundError, mapApiError } from '@/lib/api/errors'
+import i18next from '@/lib/i18n'
 import { useConfigStore } from '@/stores/config'
 import { useTreeStore } from '@/stores/tree'
 import { create } from 'zustand'
@@ -148,7 +149,9 @@ export const usePageEditorStore = create<PageEditorState>((set, get) => ({
     )
     if (Object.keys(frontmatterErrors).length > 0) {
       set({ frontmatterErrors })
-      throw new Error('Please fix metadata errors before saving.')
+      throw new Error(
+        i18next.t('pageEditor.metadataErrorsBeforeSave', { ns: 'editor' }),
+      )
     }
 
     // Only block concurrent auto-saves; manual saves always proceed
@@ -229,7 +232,9 @@ export const usePageEditorStore = create<PageEditorState>((set, get) => ({
           updatedPage?.content === null ||
           updatedPage?.content === undefined
         ) {
-          throw new Error('Updated page content is null or undefined')
+          throw new Error(
+            i18next.t('pageEditor.contentNullFallback', { ns: 'editor' }),
+          )
         }
         state.page.title = updatedPage.title
         state.page.slug = updatedPage.slug
@@ -344,7 +349,10 @@ export const usePageEditorStore = create<PageEditorState>((set, get) => ({
         return
       }
 
-      const mapped = mapApiError(err, 'An unknown error occurred')
+      const mapped = mapApiError(
+        err,
+        i18next.t('pageEditor.unknownErrorFallback', { ns: 'editor' }),
+      )
       set({
         error: mapped.message,
         notFound: false,

--- a/ui/leafwiki-ui/src/features/editor/useToolbarActions.tsx
+++ b/ui/leafwiki-ui/src/features/editor/useToolbarActions.tsx
@@ -13,6 +13,7 @@ import type { EditorView } from '@codemirror/view'
 import { completionStatus } from '@codemirror/autocomplete'
 import { Save, X, Cloud } from 'lucide-react'
 import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useEditorStore } from '@/stores/editor'
 import { useIsMobile } from '@/lib/useIsMobile'
 import { type ToolbarButton, useToolbarStore } from '../toolbar/toolbarStore'
@@ -41,6 +42,7 @@ export function useToolbarActions({
   insertHeading,
   getEditorView,
 }: ToolbarActionsOptions) {
+  const { t } = useTranslation('editor')
   const setButtons = useToolbarStore((state) => state.setButtons)
   const appMode = useAppMode()
   const readOnlyMode = useIsReadOnly()
@@ -65,7 +67,7 @@ export function useToolbarActions({
     const buttons: ToolbarButton[] = [
       {
         id: 'close-editor',
-        label: 'Close Editor',
+        label: t('toolbar.closeEditorButton'),
         hotkey: getShortcutDisplayLabel('editor.page.close', isMacOS),
         icon: <X size={18} />,
         action: closePage,
@@ -74,7 +76,7 @@ export function useToolbarActions({
       },
       {
         id: 'save-page',
-        label: 'Save Page',
+        label: t('toolbar.savePageButton'),
         hotkey: getShortcutDisplayLabel('editor.page.save', isMacOS),
         icon: <Save size={18} />,
         variant: 'default',
@@ -87,7 +89,7 @@ export function useToolbarActions({
     if (!isMobile) {
       buttons.push({
         id: 'toggle-auto-save',
-        label: 'Auto-save',
+        label: t('toolbar.autoSave'),
         hotkey: '',
         icon: <Cloud size={18} />,
         variant: 'outline',
@@ -109,6 +111,7 @@ export function useToolbarActions({
     autoSave,
     toggleAutoSave,
     isMacOS,
+    t,
   ])
 
   // Register hotkeys

--- a/ui/leafwiki-ui/src/features/history/pageHistory.ts
+++ b/ui/leafwiki-ui/src/features/history/pageHistory.ts
@@ -1,4 +1,5 @@
 import { mapApiError, type ApiUiError } from '@/lib/api/errors'
+import i18next from '@/lib/i18n'
 import {
   compareRevisions,
   getLatestRevision,
@@ -109,7 +110,10 @@ async function loadPageHistoryState(
     })
   } catch (err) {
     update({
-      listError: mapApiError(err, 'Failed to load page history'),
+      listError: mapApiError(
+        err,
+        i18next.t('errors.loadListFallback', { ns: 'history' }),
+      ),
       revisions: [],
       nextCursor: '',
       latestRevisionId: null,
@@ -205,7 +209,10 @@ export function usePageHistory(pageId: string | null, enabled = true) {
         if (cancelled) return
         update({
           snapshot: null,
-          previewError: mapApiError(err, 'Failed to load revision preview'),
+          previewError: mapApiError(
+            err,
+            i18next.t('errors.loadPreviewFallback', { ns: 'history' }),
+          ),
         })
       } finally {
         if (!cancelled) {
@@ -252,7 +259,10 @@ export function usePageHistory(pageId: string | null, enabled = true) {
         if (cancelled) return
         update({
           comparison: null,
-          previewError: mapApiError(err, 'Failed to compare revisions'),
+          previewError: mapApiError(
+            err,
+            i18next.t('errors.compareFallback', { ns: 'history' }),
+          ),
         })
       } finally {
         if (!cancelled) {
@@ -288,7 +298,10 @@ export async function loadMorePageHistory() {
     })
   } catch (err) {
     usePageHistoryStore.getState().update({
-      listError: mapApiError(err, 'Failed to load more revisions'),
+      listError: mapApiError(
+        err,
+        i18next.t('errors.loadMoreFallback', { ns: 'history' }),
+      ),
     })
   } finally {
     usePageHistoryStore.getState().update({

--- a/ui/leafwiki-ui/src/features/links/linkstatus_store.ts
+++ b/ui/leafwiki-ui/src/features/links/linkstatus_store.ts
@@ -1,4 +1,5 @@
 import { fetchLinkStatus, type LinkStatusResult } from '@/lib/api/links'
+import i18next from '@/lib/i18n'
 import { create } from 'zustand'
 
 type LinkStatusStore = {
@@ -18,7 +19,11 @@ export const useLinkStatusStore = create<LinkStatusStore>((set) => ({
 
   fetchLinkStatusForPage: async (pageId: string) => {
     if (!pageId) {
-      set({ status: null, loading: false, error: 'Page ID is required' })
+      set({
+        status: null,
+        loading: false,
+        error: i18next.t('backlinks.pageIdRequired', { ns: 'viewer' }),
+      })
       return
     }
     set({ loading: true, error: null })
@@ -27,7 +32,9 @@ export const useLinkStatusStore = create<LinkStatusStore>((set) => ({
       set({ status: data, loading: false })
     } catch (err: unknown) {
       const msg =
-        err instanceof Error ? err.message : 'Failed to fetch link status'
+        err instanceof Error
+          ? err.message
+          : i18next.t('backlinks.fetchFailedFallback', { ns: 'viewer' })
       set({ error: msg, loading: false })
     }
   },

--- a/ui/leafwiki-ui/src/features/preview/Headline.tsx
+++ b/ui/leafwiki-ui/src/features/preview/Headline.tsx
@@ -1,6 +1,7 @@
 import { Paperclip } from 'lucide-react'
 import clsx from 'clsx'
 import { createElement, HTMLAttributes, isValidElement, ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
 
 function containsLink(node: ReactNode): boolean {
   if (node == null || typeof node === 'boolean') return false
@@ -41,10 +42,11 @@ export default function Headline({
   ...props
 }: HeadlineProps) {
   void node
+  const { t } = useTranslation('viewer')
   const tagName = `h${level}` as keyof HTMLElementTagNameMap
   const shouldRenderAnchor = hasGeneratedId === 'true' && !!id
   const hasNestedLink = containsLink(children)
-  const sectionLinkLabel = 'Link to section'
+  const sectionLinkLabel = t('headline.linkToSection')
 
   return createElement(
     tagName,

--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
@@ -1,4 +1,5 @@
 import { useDesignModeStore } from '@/features/designtoggle/designmode'
+import i18next from '@/lib/i18n'
 import { preprocessWikilinks } from '@/lib/preprocessWikilinks'
 import { withBasePath } from '@/lib/routePath'
 import { useTreeStore } from '@/stores/tree'
@@ -194,7 +195,7 @@ class MarkdownPreviewErrorBoundary extends Component<
     if (this.state.hasError) {
       return (
         <div className="border-destructive/40 bg-destructive/5 text-destructive rounded-md border p-4 text-sm">
-          This page contains Markdown that could not be rendered safely.
+          {i18next.t('markdownPreview.renderError', { ns: 'viewer' })}
         </div>
       )
     }

--- a/ui/leafwiki-ui/src/features/preview/MermaidBlock.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MermaidBlock.tsx
@@ -1,4 +1,5 @@
 import { memo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useMermaidInjector } from './useMermaidInjector'
 
 export default memo(function MermaidBlock({
@@ -10,6 +11,7 @@ export default memo(function MermaidBlock({
   dataLine?: string
   theme: 'default' | 'dark'
 }) {
+  const { t } = useTranslation('viewer')
   const containerRef = useRef<HTMLDivElement | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
@@ -28,7 +30,7 @@ export default memo(function MermaidBlock({
         className="border-destructive/40 bg-destructive/5 my-4 max-w-full rounded-md border p-4 whitespace-normal"
       >
         <p className="text-destructive text-sm font-medium">
-          Unable to render Mermaid diagram.
+          {t('mermaid.renderError')}
         </p>
         <p className="text-muted-foreground mt-2 pr-12 text-sm break-words">
           {errorMessage}

--- a/ui/leafwiki-ui/src/features/preview/useMermaidInjector.ts
+++ b/ui/leafwiki-ui/src/features/preview/useMermaidInjector.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import i18next from '@/lib/i18n'
 
 type MermaidDefault = (typeof import('mermaid'))['default']
 
@@ -137,7 +138,8 @@ export function useMermaidInjector({
         const newSvg = template.content.querySelector(
           'svg',
         ) as SVGSVGElement | null
-        if (!newSvg) throw new Error('No SVG element in Mermaid output')
+        if (!newSvg)
+          throw new Error(i18next.t('mermaid.noSvgOutput', { ns: 'viewer' }))
         newSvg.setAttribute('width', '100%')
         newSvg.removeAttribute('height')
         newSvg.setAttribute('preserveAspectRatio', 'xMinYMin meet')

--- a/ui/leafwiki-ui/src/features/tree/TreeDnd.tsx
+++ b/ui/leafwiki-ui/src/features/tree/TreeDnd.tsx
@@ -359,7 +359,8 @@ export function TreeDndProvider({
         <DragOverlay dropAnimation={null} modifiers={[followCursor]}>
           {activeNode ? (
             <div className="tree-dnd__overlay">
-              {activeNode.title || 'Untitled Page'}
+              {activeNode.title ||
+                i18next.t('treeActions.untitledPage', { ns: 'viewer' })}
             </div>
           ) : null}
         </DragOverlay>,

--- a/ui/leafwiki-ui/src/features/tree/TreeNode.tsx
+++ b/ui/leafwiki-ui/src/features/tree/TreeNode.tsx
@@ -11,6 +11,7 @@ import { useDraggable, useDroppable } from '@dnd-kit/core'
 import clsx from 'clsx'
 import { ChevronUp, FilePlus, FolderPlus } from 'lucide-react'
 import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router'
 import { useTreeDndStore } from './treeDndStore'
 import { useTreeNodeActionsMenusStore } from './treeNodeActionsMenus'
@@ -21,6 +22,7 @@ type Props = {
 }
 
 export const TreeNode = React.memo(function TreeNode({ node }: Props) {
+  const { t } = useTranslation('viewer')
   const open = useTreeStore((s) => !!s.openNodeIdSet?.[node.id])
   const isStoreActive = useTreeStore((s) => s.activeNodeId === node.id)
   const toggleNode = useTreeStore((s) => s.toggleNode)
@@ -77,7 +79,7 @@ export const TreeNode = React.memo(function TreeNode({ node }: Props) {
             'tree-node__title--active': isActive,
           })}
         >
-          {node.title || 'Untitled Page'}
+          {node.title || t('treeActions.untitledPage')}
         </span>
       </Link>
     </div>
@@ -153,7 +155,7 @@ export const TreeNode = React.memo(function TreeNode({ node }: Props) {
                       )}
                     />
                   }
-                  tooltip="Create new page"
+                  tooltip={t('treeActions.createNewPageTooltip')}
                   onClick={() =>
                     openDialog(DIALOG_ADD_PAGE, { parentId: node.id })
                   }

--- a/ui/leafwiki-ui/src/features/tree/TreeNodeActionsMenu.tsx
+++ b/ui/leafwiki-ui/src/features/tree/TreeNodeActionsMenu.tsx
@@ -270,7 +270,7 @@ export default function TreeNodeActionsMenu({
         <TreeViewActionButton
           actionName="open-more-actions"
           icon={<MoreVertical size={18} className="tree-node__action-icon" />}
-          tooltip="Open more actions"
+          tooltip={t('toolbar.moreActions')}
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent>

--- a/ui/leafwiki-ui/src/features/tree/TreeView.tsx
+++ b/ui/leafwiki-ui/src/features/tree/TreeView.tsx
@@ -103,13 +103,15 @@ export default function TreeView() {
 
   if (loading)
     return (
-      <p className="tree-view__status tree-view__status--loading">Loading...</p>
+      <p className="tree-view__status tree-view__status--loading">
+        {t('treeActions.loading')}
+      </p>
     )
 
   if (error || !tree)
     return (
       <p className="tree-view__status tree-view__status--error">
-        Error: {error}
+        {t('treeActions.loadErrorPrefix', { error })}
       </p>
     )
 
@@ -125,7 +127,7 @@ export default function TreeView() {
                 size={18}
               />
             }
-            tooltip="Create new page"
+            tooltip={t('treeActions.createNewPageTooltip')}
             onClick={() =>
               openDialog(DIALOG_ADD_PAGE, {
                 parentId: '',
@@ -141,7 +143,7 @@ export default function TreeView() {
                 size={18}
               />
             }
-            tooltip="Create new section"
+            tooltip={t('treeActions.createNewSectionTooltip')}
             onClick={() =>
               openDialog(DIALOG_ADD_PAGE, {
                 parentId: '',

--- a/ui/leafwiki-ui/src/features/users/UserManagement.tsx
+++ b/ui/leafwiki-ui/src/features/users/UserManagement.tsx
@@ -13,14 +13,14 @@ export default function UserManagement() {
   const { t } = useTranslation('users')
   const { users, loadUsers, reset } = useUserStore()
   const [loading, setLoading] = useState(true)
-  useSetTitle({ title: 'User Management' })
+  useSetTitle({ title: t('pageTitle') })
   useToolbarActions()
 
   useEffect(() => {
     loadUsers()
       .catch((err) => {
         console.warn(err)
-        const mapped = mapApiError(err, 'Error loading users')
+        const mapped = mapApiError(err, t('loadErrorFallback'))
         toast.error(mapped.message)
       })
       .finally(() => {
@@ -30,12 +30,12 @@ export default function UserManagement() {
     return () => {
       reset()
     }
-  }, [loadUsers, reset])
+  }, [loadUsers, reset, t])
 
   return (
     <>
       <div className="settings">
-        <h1 className="settings__title">User Management</h1>
+        <h1 className="settings__title">{t('pageTitle')}</h1>
 
         <div className="settings__header-actions">
           <CreateEditUserButton />
@@ -46,13 +46,21 @@ export default function UserManagement() {
             <table className="settings__table">
               <thead className="settings__table-head">
                 <tr>
-                  <th className="settings__table-header-cell">Username</th>
-                  <th className="settings__table-header-cell">Email</th>
-                  <th className="settings__table-header-cell">Role</th>
+                  <th className="settings__table-header-cell">
+                    {t('columns.username')}
+                  </th>
+                  <th className="settings__table-header-cell">
+                    {t('columns.email')}
+                  </th>
+                  <th className="settings__table-header-cell">
+                    {t('columns.role')}
+                  </th>
                   <th className="settings__table-header-cell">
                     {t('totp.column')}
                   </th>
-                  <th className="settings__table-header-cell">Actions</th>
+                  <th className="settings__table-header-cell">
+                    {t('columns.actions')}
+                  </th>
                 </tr>
               </thead>
               <tbody>

--- a/ui/leafwiki-ui/src/features/viewer/EmptySectionChildrenList.tsx
+++ b/ui/leafwiki-ui/src/features/viewer/EmptySectionChildrenList.tsx
@@ -53,7 +53,7 @@ export default function EmptySectionChildrenList({
     <>
       {hasChildren && (
         <nav
-          aria-label={`Subpages of ${page.title}`}
+          aria-label={t('section.subpagesAriaLabel', { title: page.title })}
           className="child-list__section"
         >
           <h2 className="child-list__section-title mb-1">
@@ -82,15 +82,18 @@ export default function EmptySectionChildrenList({
                   <Link to={`/${n.path}`} state={createNavigationVisitState()}>
                     {n.title}
                   </Link>{' '}
-                  {n.kind === NODE_KIND_SECTION && ' (Section)'}
+                  {n.kind === NODE_KIND_SECTION &&
+                    ` ${t('section.sectionSuffix')}`}
                   <br />
                   {/* Last edited info */}
                   <span className="text-muted text-sm">
                     {' '}
-                    Updated{' '}
                     {editorName
-                      ? `by ${editorName} · ${updatedRelative}`
-                      : updatedRelative}
+                      ? t('section.updatedByLabel', {
+                          editor: editorName,
+                          time: updatedRelative,
+                        })
+                      : t('section.updatedLabel', { time: updatedRelative })}
                   </span>
                 </li>
               )
@@ -118,7 +121,7 @@ export default function EmptySectionChildrenList({
       {/* No children - Add Button and allow users to create a new page */}
       {!hasChildren && (
         <nav
-          aria-label={`Subpages of ${page.title}`}
+          aria-label={t('section.subpagesAriaLabel', { title: page.title })}
           className="child-list__section"
         >
           <div>

--- a/ui/leafwiki-ui/src/features/viewer/useToolbarActions.tsx
+++ b/ui/leafwiki-ui/src/features/viewer/useToolbarActions.tsx
@@ -53,7 +53,10 @@ export function useToolbarActions({
   const enableRevision = useConfigStore((state) => state.enableRevision)
   const registerHotkey = useHotKeysStore((s) => s.registerHotkey)
   const unregisterHotkey = useHotKeysStore((s) => s.unregisterHotkey)
-  const itemLabel = pageKind === NODE_KIND_PAGE ? 'Page' : 'Section'
+  const itemLabel =
+    pageKind === NODE_KIND_PAGE
+      ? t('pageToolbar.itemPage')
+      : t('pageToolbar.itemSection')
   const isMacOS =
     typeof navigator !== 'undefined' &&
     /Mac|iPhone|iPad|iPod/.test(navigator.platform)
@@ -67,14 +70,14 @@ export function useToolbarActions({
     const toolbarButtons: ToolbarButton[] = [
       {
         id: 'edit-page',
-        label: `Edit ${itemLabel}`,
+        label: t('pageToolbar.editButton', { item: itemLabel }),
         hotkey: getShortcutDisplayLabel('viewer.page.edit', isMacOS),
         icon: <Pencil size={18} />,
         action: editPage,
       },
       {
         id: 'page-permalink',
-        label: `Share ${itemLabel}`,
+        label: t('pageToolbar.shareButton', { item: itemLabel }),
         hotkey: getShortcutDisplayLabel('viewer.page.permalink', isMacOS),
         icon: <Link2 size={18} />,
         variant: 'outline',
@@ -82,14 +85,14 @@ export function useToolbarActions({
       },
       {
         id: 'print-page',
-        label: `Print ${itemLabel}`,
+        label: t('pageToolbar.printButton', { item: itemLabel }),
         hotkey: getShortcutDisplayLabel('viewer.page.print', isMacOS),
         icon: <Printer size={18} />,
         action: printPage,
       },
       {
         id: 'copy-page',
-        label: `Copy ${itemLabel}`,
+        label: t('pageToolbar.copyButton', { item: itemLabel }),
         hotkey: getShortcutDisplayLabel('viewer.page.copy', isMacOS),
         icon: <Copy size={18} />,
         variant: 'outline',
@@ -105,7 +108,7 @@ export function useToolbarActions({
       },
       {
         id: 'delete-page',
-        label: `Delete ${itemLabel}`,
+        label: t('pageToolbar.deleteButton', { item: itemLabel }),
         hotkey: getShortcutDisplayLabel('viewer.page.delete', isMacOS),
         icon: <Trash2 size={18} />,
         variant: 'outline',
@@ -118,7 +121,7 @@ export function useToolbarActions({
     if (enableRevision) {
       toolbarButtons.splice(2, 0, {
         id: 'page-history',
-        label: `${itemLabel} History`,
+        label: t('pageToolbar.historyButton', { item: itemLabel }),
         hotkey: getShortcutDisplayLabel('viewer.page.history', isMacOS),
         icon: <History size={18} />,
         variant: 'outline',

--- a/ui/leafwiki-ui/src/lib/api/auth.ts
+++ b/ui/leafwiki-ui/src/lib/api/auth.ts
@@ -1,7 +1,10 @@
+import i18next from '@/lib/i18n'
 import { useConfigStore } from '@/stores/config'
 import { useSessionStore } from '@/stores/session'
 import { API_BASE_URL } from '../config'
 import { ApiLocalizedError, isApiLocalizedErrorResponse } from './errors'
+
+const t = (key: string) => i18next.t(key, { ns: 'auth' })
 
 export type AuthResponse = {
   accessTokenExpiresAt: number
@@ -84,7 +87,7 @@ async function postLoginRequest<T>(path: string, body: object): Promise<T> {
     try {
       errorBody = await res.json()
     } catch {
-      throw new Error('Login failed')
+      throw new Error(t('login.errorFallback'))
     }
 
     if (isApiLocalizedErrorResponse(errorBody)) {
@@ -99,7 +102,7 @@ async function postLoginRequest<T>(path: string, body: object): Promise<T> {
       throw new Error((errorBody as { error: string }).error)
     }
 
-    throw new Error('Login failed')
+    throw new Error(t('login.errorFallback'))
   }
 
   return (await res.json()) as T
@@ -211,7 +214,7 @@ export async function fetchWithAuth(
       await ensureRefresh()
     } catch {
       await clearSessionState(sessionLogout)
-      throw new Error('Unauthorized')
+      throw new Error(t('apiErrors.unauthorized'))
     }
   }
 
@@ -223,7 +226,7 @@ export async function fetchWithAuth(
       res = await doFetch()
     } catch {
       await clearSessionState(sessionLogout)
-      throw new Error('Unauthorized')
+      throw new Error(t('apiErrors.unauthorized'))
     }
   }
 
@@ -233,7 +236,7 @@ export async function fetchWithAuth(
     try {
       errorBody = errorText ? JSON.parse(errorText) : null
     } catch {
-      throw new ApiError(errorText || 'Request failed', res.status)
+      throw new ApiError(errorText || t('apiErrors.requestFailed'), res.status)
     }
 
     if (
@@ -264,7 +267,7 @@ export async function fetchWithAuth(
       throw new ApiError((errorBody as { message: string }).message, res.status)
     }
 
-    throw new ApiError('Request failed', res.status)
+    throw new ApiError(t('apiErrors.requestFailed'), res.status)
   }
 
   try {
@@ -334,7 +337,7 @@ async function refreshAccessToken() {
     })
 
     if (!res.ok) {
-      throw new ApiError('Refresh failed', res.status)
+      throw new ApiError(t('apiErrors.refreshFailed'), res.status)
     }
 
     const data: AuthResponse = await res.json()
@@ -342,7 +345,7 @@ async function refreshAccessToken() {
     store.setUser(data.user)
   } catch (error) {
     if (error instanceof DOMException && error.name === 'AbortError') {
-      throw new Error('Refresh timed out')
+      throw new Error(t('apiErrors.refreshTimedOut'))
     }
 
     throw error

--- a/ui/leafwiki-ui/src/lib/api/config.ts
+++ b/ui/leafwiki-ui/src/lib/api/config.ts
@@ -1,4 +1,5 @@
 import type { ApiLocalizedErrorResponse } from './errors'
+import i18next from '@/lib/i18n'
 import { API_BASE_URL } from '../config'
 import {
   ApiLocalizedError,
@@ -32,7 +33,11 @@ export async function getConfig(): Promise<Config> {
   const res = await fetch(`${API_BASE_URL}/api/config`)
   if (!res.ok) {
     const errorText = await res.text()
-    const fallbackMessage = `Could not load config: ${res.status} ${res.statusText}`
+    const fallbackMessage = i18next.t('configLoad.fetchErrorFallback', {
+      ns: 'common',
+      status: res.status,
+      statusText: res.statusText,
+    })
     let errorBody: ConfigErrorResponse | null = null
 
     try {

--- a/ui/leafwiki-ui/src/lib/api/import.ts
+++ b/ui/leafwiki-ui/src/lib/api/import.ts
@@ -1,3 +1,4 @@
+import i18next from '@/lib/i18n'
 import { fetchWithAuth } from './auth'
 
 export type ImportPlan = {
@@ -86,5 +87,7 @@ export async function cancelImportPlan(): Promise<ImportPlan | null> {
     return response as ImportPlan
   }
 
-  throw new Error('Unexpected import cancel response')
+  throw new Error(
+    i18next.t('toast.unexpectedCancelResponse', { ns: 'importer' }),
+  )
 }

--- a/ui/leafwiki-ui/src/lib/api/links.ts
+++ b/ui/leafwiki-ui/src/lib/api/links.ts
@@ -1,3 +1,4 @@
+import i18next from '@/lib/i18n'
 import { fetchWithAuth } from './auth'
 
 export type Backlink = {
@@ -34,6 +35,7 @@ export type LinkStatusResult = {
 export async function fetchLinkStatus(
   pageId: string,
 ): Promise<LinkStatusResult> {
-  if (!pageId) throw new Error('Page ID is required')
+  if (!pageId)
+    throw new Error(i18next.t('backlinks.pageIdRequired', { ns: 'viewer' }))
   return (await fetchWithAuth(`/api/pages/${pageId}/links`)) as LinkStatusResult
 }

--- a/ui/leafwiki-ui/src/lib/handleFieldErrors.ts
+++ b/ui/leafwiki-ui/src/lib/handleFieldErrors.ts
@@ -1,3 +1,4 @@
+import i18next from './i18n'
 import { mapApiError } from './api/errors'
 import { toast } from 'sonner'
 
@@ -16,8 +17,8 @@ type APIError = {
  */
 export function handleFieldErrors(
   err: unknown,
-  setFieldErrors?: (errors: Record<string, string>) => void,
-  fallbackMessage = 'Something went wrong',
+  setFieldErrors: ((errors: Record<string, string>) => void) | undefined,
+  fallbackMessage: string,
 ) {
   const error = err as APIError
 
@@ -29,7 +30,7 @@ export function handleFieldErrors(
       errorMap[e.field] = e.message
     }
     setFieldErrors?.(errorMap)
-    toast.error('Validation failed')
+    toast.error(i18next.t('validation.failedToast', { ns: 'common' }))
   } else {
     const mapped = mapApiError(err, fallbackMessage)
     toast.error(mapped.message)

--- a/ui/leafwiki-ui/src/lib/i18n.ts
+++ b/ui/leafwiki-ui/src/lib/i18n.ts
@@ -5,6 +5,7 @@ import enAssets from '../locales/en/assets.json'
 import enAuth from '../locales/en/auth.json'
 import enBackup from '../locales/en/backup.json'
 import enBranding from '../locales/en/branding.json'
+import enCommon from '../locales/en/common.json'
 import enEditor from '../locales/en/editor.json'
 import enErrors from '../locales/en/errors.json'
 import enHistory from '../locales/en/history.json'
@@ -27,6 +28,7 @@ i18next.use(initReactI18next).init({
       auth: enAuth,
       backup: enBackup,
       branding: enBranding,
+      common: enCommon,
       errors: enErrors,
       editor: enEditor,
       history: enHistory,

--- a/ui/leafwiki-ui/src/lib/registries/index.tsx
+++ b/ui/leafwiki-ui/src/lib/registries/index.tsx
@@ -1,4 +1,5 @@
 import TreeView from '@/features/tree/TreeView'
+import i18next from '@/lib/i18n'
 import { DialogRegistry } from '@/lib/registries/dialogRegistry'
 import { PanelItemRegistry } from '@/lib/registries/panelItemRegistry'
 import { getShortcutDefinition } from '@/lib/shortcuts/shortcutCatalog'
@@ -42,7 +43,7 @@ export const SIDEBAR_SEARCH_PANEL_ID = 'search'
 
 panelItemRegistry.register({
   id: SIDEBAR_TREE_PANEL_ID,
-  label: 'Explorer',
+  label: i18next.t('sidebar.explorerTab', { ns: 'common' }),
   hotkey: getShortcutDefinition('sidebar.explorer.open').keyCombo,
   modes: ['view', 'edit', 'history', 'settings', 'user-management'],
   icon: () => <FolderTree size={16} />,
@@ -53,7 +54,7 @@ panelItemRegistry.register({
 
 panelItemRegistry.register({
   id: SIDEBAR_SEARCH_PANEL_ID,
-  label: 'Search',
+  label: i18next.t('sidebar.searchTab', { ns: 'common' }),
   hotkey: getShortcutDefinition('sidebar.search.open').keyCombo,
   modes: ['view', 'edit', 'history', 'settings', 'user-management'],
   icon: () => <SearchIcon size={16} />,

--- a/ui/leafwiki-ui/src/locales/en/auth.json
+++ b/ui/leafwiki-ui/src/locales/en/auth.json
@@ -18,8 +18,20 @@
       "errorFallback": "Verification failed"
     }
   },
+  "apiErrors": {
+    "unauthorized": "Unauthorized",
+    "requestFailed": "Request failed",
+    "refreshFailed": "Refresh failed",
+    "refreshTimedOut": "Refresh timed out"
+  },
   "userMenu": {
     "userManagement": "User Management",
+    "brandingSettings": "Branding Settings",
+    "import": "Import",
+    "maintenance": "Maintenance",
+    "version": "Version {{version}}",
+    "logout": "Logout",
+    "supportLeafWiki": "Support LeafWiki",
     "changeOwnPassword": "Change Own Password"
   }
 }

--- a/ui/leafwiki-ui/src/locales/en/backup.json
+++ b/ui/leafwiki-ui/src/locales/en/backup.json
@@ -1,5 +1,6 @@
 {
   "pageTitle": "Git Content Backup",
+  "loadStatusErrorFallback": "Failed to load backup status",
   "pageDescription": "Back up wiki page content to a Git repository. This covers content only and does not include full system restore.",
   "sectionTitle": "Git Content Backup",
   "sectionDescription": "Automatically pushes wiki changes to the configured remote Git repository. Configure the target repository and credentials in your server settings.",

--- a/ui/leafwiki-ui/src/locales/en/branding.json
+++ b/ui/leafwiki-ui/src/locales/en/branding.json
@@ -1,5 +1,13 @@
 {
   "pageTitle": "Branding Settings",
+  "storeErrors": {
+    "loadFallback": "Failed to load branding",
+    "updateFallback": "Failed to update branding",
+    "uploadLogoFallback": "Failed to upload logo",
+    "uploadFaviconFallback": "Failed to upload favicon",
+    "deleteLogoFallback": "Failed to delete logo",
+    "deleteFaviconFallback": "Failed to delete favicon"
+  },
   "siteName": {
     "title": "Site Name",
     "description": "The name displayed in the header, page titles, and login screen.",

--- a/ui/leafwiki-ui/src/locales/en/common.json
+++ b/ui/leafwiki-ui/src/locales/en/common.json
@@ -1,0 +1,35 @@
+{
+  "sidebar": {
+    "explorerTab": "Explorer",
+    "searchTab": "Search"
+  },
+  "errorBoundary": {
+    "heading": "Something went wrong",
+    "body": "An unexpected error occurred. Reloading the page usually fixes this.",
+    "reloadButton": "Reload page",
+    "tryRecoverButton": "Try to recover",
+    "detailsSummary": "Error details"
+  },
+  "page404": {
+    "heading": "Page Not Found",
+    "body": "The page you are looking for does not exist.",
+    "createPrompt": "Create the page by clicking the button below.",
+    "createButton": "Create Page"
+  },
+  "unsavedChangesDialog": {
+    "title": "Unsaved Changes",
+    "description": "You have unsaved changes. Are you sure you want to leave this page? Unsaved data will be lost.",
+    "cancelButton": "Cancel",
+    "leaveAnywayButton": "Leave anyway"
+  },
+  "dialog": {
+    "closeSrOnly": "Close"
+  },
+  "validation": {
+    "failedToast": "Validation failed"
+  },
+  "configLoad": {
+    "fetchErrorFallback": "Could not load config: {{status}} {{statusText}}",
+    "errorFallback": "Could not load configuration"
+  }
+}

--- a/ui/leafwiki-ui/src/locales/en/editor.json
+++ b/ui/leafwiki-ui/src/locales/en/editor.json
@@ -23,6 +23,8 @@
     "dateTitleTooltip": "Set title to today's date"
   },
   "toolbar": {
+    "closeEditorButton": "Close Editor",
+    "savePageButton": "Save Page",
     "boldTooltip": "Bold (Ctrl+B)",
     "italicTooltip": "Italic (Ctrl+I)",
     "strikethroughTooltip": "Strikethrough",
@@ -65,18 +67,37 @@
     "saveErrorFallback": "Error saving page",
     "saveAnyway": "Save anyway",
     "conflictAgainMessage": "The page was modified again while saving. Please reload the page and re-apply your changes.",
-    "errorPrefix": "Error: {{error}}"
+    "errorPrefix": "Error: {{error}}",
+    "metadataErrorsBeforeSave": "Please fix metadata errors before saving.",
+    "contentNullFallback": "Updated page content is null or undefined",
+    "unknownErrorFallback": "An unknown error occurred"
   },
   "linkInsertDialog": {
+    "dialogTitle": "Insert Link",
+    "displayTextLabel": "Display Text",
+    "urlLabel": "URL",
     "textPlaceholder": "Link text",
-    "urlPlaceholder": "https:// or search pages…"
+    "urlPlaceholder": "https:// or search pages…",
+    "cancelButton": "Cancel",
+    "insertButton": "Insert"
   },
   "frontmatterPanel": {
+    "metadataTitle": "Metadata",
+    "tagsHeading": "Tags",
+    "propertiesHeading": "Properties",
+    "removeFieldAriaLabel": "Remove frontmatter field {{field}}",
     "addTagPlaceholder": "Add tag",
     "keyPlaceholder": "Key",
     "valuePlaceholder": "Value"
   },
+  "tagInput": {
+    "loading": "Loading…",
+    "noMatchingTags": "No matching tags found.",
+    "removeTagAriaLabel": "Remove tag {{tag}}"
+  },
   "markdownEditor": {
+    "editorTab": "Editor",
+    "previewTab": "Preview",
     "resizeAriaLabel": "Resize editor and preview panes",
     "fileTooLarge": "File too large. Max {{maxSize}} allowed.",
     "uploadedToast": "Uploaded {{filename}}",

--- a/ui/leafwiki-ui/src/locales/en/history.json
+++ b/ui/leafwiki-ui/src/locales/en/history.json
@@ -3,6 +3,12 @@
     "unknown": "Unknown",
     "unknownTime": "Unknown time"
   },
+  "errors": {
+    "loadListFallback": "Failed to load page history",
+    "loadPreviewFallback": "Failed to load revision preview",
+    "compareFallback": "Failed to compare revisions",
+    "loadMoreFallback": "Failed to load more revisions"
+  },
   "trigger": {
     "contentUpdate": "Saved after content update",
     "assetUpdate": "Saved after asset update",

--- a/ui/leafwiki-ui/src/locales/en/importer.json
+++ b/ui/leafwiki-ui/src/locales/en/importer.json
@@ -1,5 +1,20 @@
 {
   "title": "Import",
+  "toast": {
+    "planCreatedSuccess": "Import plan created successfully",
+    "createPlanErrorFallback": "Failed to create import plan",
+    "loadPlanErrorFallback": "Failed to load import plan",
+    "noPlanToExecute": "No import plan to execute",
+    "executeSuccess": "Import completed successfully",
+    "canceledSuccess": "Import canceled",
+    "executionFailedFallback": "Import execution failed",
+    "executeErrorFallback": "Failed to execute import plan",
+    "noPlanToClear": "No import plan to clear",
+    "canceledBeforeCompletion": "Import finished before cancellation completed",
+    "planClearedSuccess": "Import plan cleared",
+    "cancelOrClearErrorFallback": "Failed to cancel or clear import plan",
+    "unexpectedCancelResponse": "Unexpected import cancel response"
+  },
   "planActions": {
     "create": "Create page",
     "update": "Update page",

--- a/ui/leafwiki-ui/src/locales/en/maintenance.json
+++ b/ui/leafwiki-ui/src/locales/en/maintenance.json
@@ -11,6 +11,7 @@
     "error": "Filesystem sync failed",
     "alreadyRunning": "Sync already in progress"
   },
+  "syncJobLostFallback": "Sync job lost — server may have restarted",
   "progress": {
     "label": "Current Phase",
     "tree": "Rebuilding page tree",

--- a/ui/leafwiki-ui/src/locales/en/users.json
+++ b/ui/leafwiki-ui/src/locales/en/users.json
@@ -1,6 +1,14 @@
 {
+  "pageTitle": "User Management",
   "loading": "Loading users...",
+  "loadErrorFallback": "Error loading users",
   "noUsersFound": "No users found.",
+  "columns": {
+    "username": "Username",
+    "email": "Email",
+    "role": "Role",
+    "actions": "Actions"
+  },
   "validation": {
     "passwordTooShort": "Password must be at least 8 characters long",
     "passwordsDoNotMatch": "Passwords do not match"

--- a/ui/leafwiki-ui/src/locales/en/viewer.json
+++ b/ui/leafwiki-ui/src/locales/en/viewer.json
@@ -16,14 +16,27 @@
     "emptyDescriptionEditor": "The section {{title}} does not contain any pages or sections yet. Start by adding a new page or create a new section.",
     "emptyDescriptionReadOnly": "The section {{title}} does not contain any pages or sections yet.",
     "addPage": "Add Page",
-    "addSection": "Add Section"
+    "addSection": "Add Section",
+    "subpagesAriaLabel": "Subpages of {{title}}",
+    "sectionSuffix": "(Section)",
+    "updatedByLabel": "Updated by {{editor}} · {{time}}",
+    "updatedLabel": "Updated {{time}}"
   },
   "markdownPreview": {
     "renderError": "This page contains Markdown that could not be rendered safely.",
     "brokenLinkTooltip": "This page doesn't exist yet."
   },
+  "mermaid": {
+    "renderError": "Unable to render Mermaid diagram.",
+    "noSvgOutput": "No SVG element in Mermaid output"
+  },
+  "headline": {
+    "linkToSection": "Link to section"
+  },
   "backlinks": {
     "errorPrefix": "Error: {{error}}",
+    "pageIdRequired": "Page ID is required",
+    "fetchFailedFallback": "Failed to fetch link status",
     "referencedBy": "Referenced by",
     "loading": "Loading…",
     "noReferences": "No pages reference this page.",
@@ -62,7 +75,22 @@
   "toolbar": {
     "moreActions": "More actions"
   },
+  "pageToolbar": {
+    "itemPage": "Page",
+    "itemSection": "Section",
+    "editButton": "Edit {{item}}",
+    "shareButton": "Share {{item}}",
+    "printButton": "Print {{item}}",
+    "copyButton": "Copy {{item}}",
+    "deleteButton": "Delete {{item}}",
+    "historyButton": "{{item}} History"
+  },
   "treeActions": {
+    "loading": "Loading...",
+    "loadErrorPrefix": "Error: {{error}}",
+    "createNewPageTooltip": "Create new page",
+    "createNewSectionTooltip": "Create new section",
+    "untitledPage": "Untitled Page",
     "convertedToast": "Page converted successfully",
     "conflictRetryMessage": "This page was modified by another user. Please try again.",
     "convertErrorFallback": "Failed to convert page",

--- a/ui/leafwiki-ui/src/stores/backup.ts
+++ b/ui/leafwiki-ui/src/stores/backup.ts
@@ -5,6 +5,7 @@ import {
   triggerForcePush,
   BackupStatusResponse,
 } from '@/lib/api/backup'
+import i18next from '@/lib/i18n'
 
 interface BackupState {
   enabled: boolean
@@ -50,7 +51,10 @@ export const useBackupStore = create<BackupState>((set, get) => ({
         statusError: '',
       })
     } catch {
-      set({ isLoading: false, statusError: 'Failed to load backup status' })
+      set({
+        isLoading: false,
+        statusError: i18next.t('loadStatusErrorFallback', { ns: 'backup' }),
+      })
     }
   },
 

--- a/ui/leafwiki-ui/src/stores/branding.ts
+++ b/ui/leafwiki-ui/src/stores/branding.ts
@@ -1,6 +1,9 @@
 import * as brandingAPI from '@/lib/api/branding'
+import i18next from '@/lib/i18n'
 import { withBasePath } from '@/lib/routePath'
 import { create } from 'zustand'
+
+const t = (key: string) => i18next.t(key, { ns: 'branding' })
 
 type BrandingStore = {
   siteName: string
@@ -59,7 +62,8 @@ export const useBrandingStore = create<BrandingStore>((set) => ({
       })
     } catch (err) {
       set({
-        error: err instanceof Error ? err.message : 'Failed to load branding',
+        error:
+          err instanceof Error ? err.message : t('storeErrors.loadFallback'),
         isLoading: false,
       })
     }
@@ -78,7 +82,8 @@ export const useBrandingStore = create<BrandingStore>((set) => ({
       })
     } catch (err) {
       set({
-        error: err instanceof Error ? err.message : 'Failed to update branding',
+        error:
+          err instanceof Error ? err.message : t('storeErrors.updateFallback'),
         isLoading: false,
       })
       throw err
@@ -96,7 +101,10 @@ export const useBrandingStore = create<BrandingStore>((set) => ({
       })
     } catch (err) {
       set({
-        error: err instanceof Error ? err.message : 'Failed to upload logo',
+        error:
+          err instanceof Error
+            ? err.message
+            : t('storeErrors.uploadLogoFallback'),
       })
       throw err
     } finally {
@@ -116,7 +124,10 @@ export const useBrandingStore = create<BrandingStore>((set) => ({
       })
     } catch (err) {
       set({
-        error: err instanceof Error ? err.message : 'Failed to upload favicon',
+        error:
+          err instanceof Error
+            ? err.message
+            : t('storeErrors.uploadFaviconFallback'),
       })
       throw err
     } finally {
@@ -135,7 +146,10 @@ export const useBrandingStore = create<BrandingStore>((set) => ({
       })
     } catch (err) {
       set({
-        error: err instanceof Error ? err.message : 'Failed to delete logo',
+        error:
+          err instanceof Error
+            ? err.message
+            : t('storeErrors.deleteLogoFallback'),
       })
       throw err
     } finally {
@@ -155,7 +169,10 @@ export const useBrandingStore = create<BrandingStore>((set) => ({
       })
     } catch (err) {
       set({
-        error: err instanceof Error ? err.message : 'Failed to delete favicon',
+        error:
+          err instanceof Error
+            ? err.message
+            : t('storeErrors.deleteFaviconFallback'),
       })
       throw err
     } finally {

--- a/ui/leafwiki-ui/src/stores/config.ts
+++ b/ui/leafwiki-ui/src/stores/config.ts
@@ -1,5 +1,6 @@
 import { getConfig } from '@/lib/api/config'
 import { DEFAULT_MAX_ASSET_UPLOAD_SIZE_BYTES } from '@/lib/config'
+import i18next from '@/lib/i18n'
 import { create } from 'zustand'
 
 type ConfigStore = {
@@ -76,7 +77,7 @@ export const useConfigStore = create<ConfigStore>((set) => ({
         error:
           error instanceof Error
             ? error.message
-            : 'Could not load configuration',
+            : i18next.t('configLoad.errorFallback', { ns: 'common' }),
         hasLoaded: true,
       })
     } finally {

--- a/ui/leafwiki-ui/src/stores/import.ts
+++ b/ui/leafwiki-ui/src/stores/import.ts
@@ -1,9 +1,13 @@
 import * as importAPI from '@/lib/api/import'
 import { ApiError } from '@/lib/api/auth'
 import { mapApiError } from '@/lib/api/errors'
+import i18next from '@/lib/i18n'
 import { toast } from 'sonner'
 import { create } from 'zustand'
 import { useTreeStore } from './tree'
+
+const t = (key: string, opts?: Record<string, unknown>) =>
+  i18next.t(key, { ...opts, ns: 'importer' })
 
 type ImportStore = {
   creatingImportPlan: boolean
@@ -64,11 +68,11 @@ export const useImportStore = create<ImportStore>((set, get) => ({
     set({ creatingImportPlan: true })
     try {
       const importPlan = await importAPI.createImportPlanFromZip(sourcePath)
-      toast.success('Import plan created successfully')
+      toast.success(t('toast.planCreatedSuccess'))
       set({ importPlan, importResult: null })
       return true
     } catch (err) {
-      toast.error(mapApiError(err, 'Failed to create import plan').message)
+      toast.error(mapApiError(err, t('toast.createPlanErrorFallback')).message)
       return false
     } finally {
       set({ creatingImportPlan: false })
@@ -92,7 +96,7 @@ export const useImportStore = create<ImportStore>((set, get) => ({
         })
       }
     } catch (err) {
-      const mapped = mapApiError(err, 'Failed to load import plan')
+      const mapped = mapApiError(err, t('toast.loadPlanErrorFallback'))
       if (
         (err instanceof ApiError && err.status === 404) ||
         mapped.code === 'importer_no_plan'
@@ -109,7 +113,7 @@ export const useImportStore = create<ImportStore>((set, get) => ({
   executeImportPlan: async () => {
     const importPlan = get().importPlan
     if (importPlan === null) {
-      toast.error('No import plan to execute')
+      toast.error(t('toast.noPlanToExecute'))
       return
     }
     try {
@@ -120,13 +124,13 @@ export const useImportStore = create<ImportStore>((set, get) => ({
       currentPlan = await pollImportPlanUntilSettled(currentPlan, set)
 
       if (currentPlan.execution_status === 'completed') {
-        toast.success('Import completed successfully')
+        toast.success(t('toast.executeSuccess'))
         set({
           importPlan: currentPlan,
           importResult: currentPlan.execution_result ?? null,
         })
       } else if (currentPlan.execution_status === 'canceled') {
-        toast.success('Import canceled')
+        toast.success(t('toast.canceledSuccess'))
         set({
           importPlan: currentPlan,
           importResult: currentPlan.execution_result ?? null,
@@ -134,11 +138,11 @@ export const useImportStore = create<ImportStore>((set, get) => ({
       } else if (currentPlan.execution_status === 'failed') {
         set({ importPlan: currentPlan })
         throw new Error(
-          currentPlan.execution_error || 'Import execution failed',
+          currentPlan.execution_error || t('toast.executionFailedFallback'),
         )
       }
     } catch (err) {
-      toast.error(mapApiError(err, 'Failed to execute import plan').message)
+      toast.error(mapApiError(err, t('toast.executeErrorFallback')).message)
     } finally {
       set({ executingImportPlan: false })
       // reload tree
@@ -148,7 +152,7 @@ export const useImportStore = create<ImportStore>((set, get) => ({
   cancelImportPlan: async () => {
     const importPlan = get().importPlan
     if (importPlan === null) {
-      toast.error('No import plan to clear')
+      toast.error(t('toast.noPlanToClear'))
       return false
     }
     try {
@@ -164,8 +168,8 @@ export const useImportStore = create<ImportStore>((set, get) => ({
         const finalPlan = await pollImportPlanUntilSettled(response, set)
         toast.success(
           finalPlan.execution_status === 'canceled'
-            ? 'Import canceled'
-            : 'Import finished before cancellation completed',
+            ? t('toast.canceledSuccess')
+            : t('toast.canceledBeforeCompletion'),
         )
         set({
           importPlan: finalPlan,
@@ -175,12 +179,12 @@ export const useImportStore = create<ImportStore>((set, get) => ({
         return finalPlan.execution_status === 'canceled'
       }
 
-      toast.success('Import plan cleared')
+      toast.success(t('toast.planClearedSuccess'))
       set({ importPlan: null, importResult: null })
       return true
     } catch (err) {
       toast.error(
-        mapApiError(err, 'Failed to cancel or clear import plan').message,
+        mapApiError(err, t('toast.cancelOrClearErrorFallback')).message,
       )
       return false
     } finally {

--- a/ui/leafwiki-ui/src/stores/resync.ts
+++ b/ui/leafwiki-ui/src/stores/resync.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { getResyncStatus, triggerResync } from '@/lib/api/resync'
+import i18next from '@/lib/i18n'
 
 const POLL_INTERVAL_MS = 800
 const POLL_ERROR_LIMIT = 3
@@ -62,7 +63,7 @@ export const useResyncStore = create<ResyncState>((set) => ({
       // running=false without done=true means the job was lost (server restart).
       if (!status.running) {
         set({ isLoading: false, phase: null })
-        throw new Error('Sync job lost — server may have restarted')
+        throw new Error(i18next.t('syncJobLostFallback', { ns: 'maintenance' }))
       }
     }
   },

--- a/ui/leafwiki-ui/src/stores/tree.ts
+++ b/ui/leafwiki-ui/src/stores/tree.ts
@@ -4,6 +4,7 @@ import {
   NODE_KIND_SECTION,
   PageNode,
 } from '@/lib/api/pages'
+import i18next from '@/lib/i18n'
 import { FlatPageSearchItem, buildFlatPageSearchItems } from '@/lib/pageSearch'
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
@@ -285,7 +286,9 @@ export const useTreeStore = create<TreeStore>()(
           if (err instanceof Error) {
             set({ error: err.message })
           } else {
-            set({ error: 'An unknown error occurred' })
+            set({
+              error: i18next.t('common.unknownError', { ns: 'page' }),
+            })
           }
         } finally {
           if (!silent) set({ loading: false })


### PR DESCRIPTION
Migrate leftover hardcoded English strings to react-i18next across tree, editor, viewer, and settings components, and fix API/store fallback errors that bypassed translated toast messages via mapApiError's err.message passthrough. Adds a common.json namespace for cross-cutting UI (error boundary, 404 page, dialog primitives, sidebar tabs).
