### PR TITLE
feat(preview): add inline code copy action

### DIFF
--- a/ui/leafwiki-ui/src/components/TooltipWrapper.tsx
+++ b/ui/leafwiki-ui/src/components/TooltipWrapper.tsx
@@ -13,6 +13,7 @@ type Props = {
   parentClassName?: string
   side?: 'left' | 'right' | 'top' | 'bottom'
   align?: 'start' | 'center' | 'end'
+  asChild?: boolean
 }
 
 export function TooltipWrapper({
@@ -21,19 +22,28 @@ export function TooltipWrapper({
   side,
   align,
   parentClassName,
+  asChild = false,
 }: Props) {
   const tooltipSide = side || 'top'
   const tooltipAlign = align || 'start'
   const isMobile = useIsMobile()
 
   if (isMobile) {
-    return <div className={clsx('flex', parentClassName)}>{children}</div>
+    return asChild ? (
+      <>{children}</>
+    ) : (
+      <div className={clsx('flex', parentClassName)}>{children}</div>
+    )
   }
 
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <div className={clsx('flex', parentClassName)}>{children}</div>
+        {asChild ? (
+          children
+        ) : (
+          <div className={clsx('flex', parentClassName)}>{children}</div>
+        )}
       </TooltipTrigger>
       <TooltipContent
         side={tooltipSide}

--- a/ui/leafwiki-ui/src/features/preview/MarkdownCodeBlock.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownCodeBlock.tsx
@@ -1,37 +1,18 @@
 import { TooltipWrapper } from '@/components/TooltipWrapper'
 import { Button } from '@/components/ui/button'
-import copy from 'copy-to-clipboard'
 import { Check, Copy } from 'lucide-react'
 import {
   ClassAttributes,
   HTMLAttributes,
   ReactNode,
   isValidElement,
-  useEffect,
-  useState,
 } from 'react'
 import { useTranslation } from 'react-i18next'
-import { toast } from 'sonner'
+import { readTextContent, useCodeCopy } from './useCodeCopy'
 
 type CodeElementProps = {
   className?: string
   children?: ReactNode
-}
-
-function readTextContent(node: ReactNode): string {
-  if (typeof node === 'string' || typeof node === 'number') {
-    return String(node)
-  }
-
-  if (Array.isArray(node)) {
-    return node.map(readTextContent).join('')
-  }
-
-  if (isValidElement<{ children?: ReactNode }>(node)) {
-    return readTextContent(node.props.children)
-  }
-
-  return ''
 }
 
 export default function MarkdownCodeBlock(
@@ -41,42 +22,19 @@ export default function MarkdownCodeBlock(
   const { t } = useTranslation('viewer')
   const { children, node, ...preProps } = props
   void node
-  const [copied, setCopied] = useState(false)
   const child = Array.isArray(children) ? children[0] : children
+  const childIsCodeElement = isValidElement<CodeElementProps>(child)
+  const className = childIsCodeElement ? (child.props.className ?? '') : ''
+  const code = childIsCodeElement ? readTextContent(child.props.children) : ''
+  const { copied, copyCode } = useCodeCopy(code)
 
-  useEffect(() => {
-    if (!copied) return
-
-    const timeoutId = window.setTimeout(() => {
-      setCopied(false)
-    }, 2000)
-
-    return () => {
-      window.clearTimeout(timeoutId)
-    }
-  }, [copied])
-
-  if (!isValidElement<CodeElementProps>(child)) {
+  if (!childIsCodeElement) {
     return <pre {...preProps}>{children}</pre>
   }
-
-  const className = child.props.className ?? ''
-  const code = readTextContent(child.props.children)
 
   const isCodeBlock = className.includes('language-') || code.includes('\n')
   if (!isCodeBlock) {
     return <pre {...preProps}>{children}</pre>
-  }
-
-  const handleCopy = () => {
-    const copiedSuccessfully = copy(code)
-    if (!copiedSuccessfully) {
-      toast.error(t('codeBlock.copyErrorToast'))
-      return
-    }
-
-    setCopied(true)
-    toast.success(t('codeBlock.copiedToast'))
   }
 
   return (
@@ -92,7 +50,7 @@ export default function MarkdownCodeBlock(
             variant="outline"
             size="icon"
             className="markdown-code-block__copy-button"
-            onClick={handleCopy}
+            onClick={copyCode}
             aria-label={
               copied
                 ? t('codeBlock.copiedAriaLabel')

--- a/ui/leafwiki-ui/src/features/preview/MarkdownInlineCode.test.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownInlineCode.test.tsx
@@ -1,0 +1,92 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { toast } from 'sonner'
+import MarkdownInlineCode from './MarkdownInlineCode'
+
+const { copyMock } = vi.hoisted(() => ({ copyMock: vi.fn() }))
+
+vi.mock('copy-to-clipboard', () => ({ default: copyMock }))
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      ({
+        'codeBlock.copiedAriaLabel': 'Code copied',
+        'codeBlock.copiedToast': 'Code copied',
+        'codeBlock.copiedTooltip': 'Copied',
+        'codeBlock.copyAriaLabel': 'Copy code',
+        'codeBlock.copyErrorToast': 'Could not copy code',
+        'codeBlock.copyTooltip': 'Copy code',
+      })[key] ?? key,
+  }),
+}))
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}))
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => children,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => children,
+  TooltipContent: ({ children }: { children: ReactNode }) => children,
+}))
+
+describe('MarkdownInlineCode', () => {
+  beforeEach(() => {
+    copyMock.mockReset()
+    copyMock.mockReturnValue(true)
+    vi.mocked(toast.error).mockReset()
+    vi.mocked(toast.success).mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('copies only the rendered code text and shows temporary feedback', () => {
+    vi.useFakeTimers()
+    render(
+      <MarkdownInlineCode>
+        npm <strong>run</strong> test
+      </MarkdownInlineCode>,
+    )
+
+    const button = screen.getByTestId('markdown-inline-code-copy-button')
+    fireEvent.click(button)
+
+    expect(copyMock).toHaveBeenCalledWith('npm run test')
+    expect(toast.success).toHaveBeenCalled()
+    expect(button).toHaveAttribute('aria-label', 'Code copied')
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    expect(button).toHaveAttribute('aria-label', 'Copy code')
+  })
+
+  it('reports clipboard failures without showing copied feedback', () => {
+    copyMock.mockReturnValue(false)
+    render(<MarkdownInlineCode>npm test</MarkdownInlineCode>)
+
+    const button = screen.getByTestId('markdown-inline-code-copy-button')
+    fireEvent.click(button)
+
+    expect(toast.error).toHaveBeenCalled()
+    expect(toast.success).not.toHaveBeenCalled()
+    expect(button).toHaveAttribute('aria-label', 'Copy code')
+  })
+
+  it('does not trigger surrounding click handlers', () => {
+    const onParentClick = vi.fn()
+    render(
+      <a href="/target" onClick={onParentClick}>
+        <MarkdownInlineCode>npm test</MarkdownInlineCode>
+      </a>,
+    )
+
+    const button = screen.getByTestId('markdown-inline-code-copy-button')
+    expect(fireEvent.click(button)).toBe(false)
+    expect(onParentClick).not.toHaveBeenCalled()
+    expect(copyMock).toHaveBeenCalledWith('npm test')
+  })
+})

--- a/ui/leafwiki-ui/src/features/preview/MarkdownInlineCode.test.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownInlineCode.test.tsx
@@ -25,10 +25,24 @@ vi.mock('sonner', () => ({
     success: vi.fn(),
   },
 }))
-vi.mock('@/components/ui/tooltip', () => ({
-  Tooltip: ({ children }: { children: ReactNode }) => children,
-  TooltipTrigger: ({ children }: { children: ReactNode }) => children,
-  TooltipContent: ({ children }: { children: ReactNode }) => children,
+vi.mock('@/components/TooltipWrapper', () => ({
+  TooltipWrapper: ({
+    children,
+    label,
+    asChild,
+  }: {
+    children: ReactNode
+    label: string
+    asChild?: boolean
+  }) => (
+    <span
+      data-testid="inline-code-tooltip"
+      data-label={label}
+      data-as-child={String(asChild)}
+    >
+      {children}
+    </span>
+  ),
 }))
 
 describe('MarkdownInlineCode', () => {
@@ -52,16 +66,21 @@ describe('MarkdownInlineCode', () => {
     )
 
     const button = screen.getByTestId('markdown-inline-code-copy-button')
+    const tooltip = screen.getByTestId('inline-code-tooltip')
+    expect(tooltip).toHaveAttribute('data-label', 'Copy code')
+    expect(tooltip).toHaveAttribute('data-as-child', 'true')
     fireEvent.click(button)
 
     expect(copyMock).toHaveBeenCalledWith('npm run test')
     expect(toast.success).toHaveBeenCalled()
     expect(button).toHaveAttribute('aria-label', 'Code copied')
+    expect(tooltip).toHaveAttribute('data-label', 'Copied')
 
     act(() => {
       vi.advanceTimersByTime(2000)
     })
     expect(button).toHaveAttribute('aria-label', 'Copy code')
+    expect(tooltip).toHaveAttribute('data-label', 'Copy code')
   })
 
   it('reports clipboard failures without showing copied feedback', () => {

--- a/ui/leafwiki-ui/src/features/preview/MarkdownInlineCode.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownInlineCode.tsx
@@ -1,9 +1,5 @@
+import { TooltipWrapper } from '@/components/TooltipWrapper'
 import { Button } from '@/components/ui/button'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
 import { Check, Copy } from 'lucide-react'
 import { ClassAttributes, HTMLAttributes, MouseEvent, ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -32,28 +28,28 @@ export default function MarkdownInlineCode({
       <code {...codeProps} className={`inline-code ${className ?? ''}`.trim()}>
         {children}
       </code>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            type="button"
-            variant="outline"
-            size="icon"
-            className="markdown-inline-code__copy-button"
-            onClick={handleCopy}
-            aria-label={
-              copied
-                ? t('codeBlock.copiedAriaLabel')
-                : t('codeBlock.copyAriaLabel')
-            }
-            data-testid="markdown-inline-code-copy-button"
-          >
-            {copied ? <Check /> : <Copy />}
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="top" align="center">
-          {copied ? t('codeBlock.copiedTooltip') : t('codeBlock.copyTooltip')}
-        </TooltipContent>
-      </Tooltip>
+      <TooltipWrapper
+        label={
+          copied ? t('codeBlock.copiedTooltip') : t('codeBlock.copyTooltip')
+        }
+        asChild
+      >
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="markdown-inline-code__copy-button"
+          onClick={handleCopy}
+          aria-label={
+            copied
+              ? t('codeBlock.copiedAriaLabel')
+              : t('codeBlock.copyAriaLabel')
+          }
+          data-testid="markdown-inline-code-copy-button"
+        >
+          {copied ? <Check /> : <Copy />}
+        </Button>
+      </TooltipWrapper>
     </span>
   )
 }

--- a/ui/leafwiki-ui/src/features/preview/MarkdownInlineCode.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownInlineCode.tsx
@@ -1,0 +1,59 @@
+import { Button } from '@/components/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { Check, Copy } from 'lucide-react'
+import { ClassAttributes, HTMLAttributes, MouseEvent, ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { readTextContent, useCodeCopy } from './useCodeCopy'
+
+type Props = ClassAttributes<HTMLElement> &
+  HTMLAttributes<HTMLElement> & { children?: ReactNode }
+
+export default function MarkdownInlineCode({
+  children,
+  className,
+  ...codeProps
+}: Props) {
+  const { t } = useTranslation('viewer')
+  const code = readTextContent(children)
+  const { copied, copyCode } = useCodeCopy(code)
+
+  const handleCopy = (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    copyCode()
+  }
+
+  return (
+    <span className="markdown-inline-code">
+      <code {...codeProps} className={`inline-code ${className ?? ''}`.trim()}>
+        {children}
+      </code>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="markdown-inline-code__copy-button"
+            onClick={handleCopy}
+            aria-label={
+              copied
+                ? t('codeBlock.copiedAriaLabel')
+                : t('codeBlock.copyAriaLabel')
+            }
+            data-testid="markdown-inline-code-copy-button"
+          >
+            {copied ? <Check /> : <Copy />}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top" align="center">
+          {copied ? t('codeBlock.copiedTooltip') : t('codeBlock.copyTooltip')}
+        </TooltipContent>
+      </Tooltip>
+    </span>
+  )
+}

--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.test.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { useDesignModeStore } from '@/features/designtoggle/designmode'
 import MarkdownPreview from './MarkdownPreview'
 
@@ -91,5 +92,21 @@ if WinExist("Untitled - Notepad") {
     expect(image).not.toBeNull()
     expect(image?.getAttribute('src')).toBe('https://example.com/banner.png')
     expect(image?.getAttribute('alt')).toBe('Remote banner')
+  })
+
+  it('renders inline code with its copy action', () => {
+    const { container } = render(
+      <TooltipProvider>
+        <MarkdownPreview content="Use `npm run build` here." />
+      </TooltipProvider>,
+    )
+
+    const inlineCode = container.querySelector('.markdown-inline-code')
+    expect(inlineCode?.textContent).toContain('npm run build')
+    expect(
+      inlineCode?.querySelector(
+        '[data-testid="markdown-inline-code-copy-button"]',
+      ),
+    ).not.toBeNull()
   })
 })

--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
@@ -35,6 +35,7 @@ import remarkMath from 'remark-math'
 import { extractTocEntries } from './extractTocEntries'
 import Headline from './Headline'
 import MarkdownCodeBlock from './MarkdownCodeBlock'
+import MarkdownInlineCode from './MarkdownInlineCode'
 import { MarkdownImage } from './MarkdownImage'
 import { MarkdownLink } from './MarkdownLink'
 import './markdownPreviewCodeTheme.css'
@@ -560,9 +561,9 @@ export default function MarkdownPreview({
           return <code data-line={dataLine}>{children}</code>
         }
         return (
-          <code data-line={dataLine} className="inline-code">
+          <MarkdownInlineCode data-line={dataLine} className={className}>
             {children}
-          </code>
+          </MarkdownInlineCode>
         )
       },
     }),

--- a/ui/leafwiki-ui/src/features/preview/markdownPreviewCodeTheme.css
+++ b/ui/leafwiki-ui/src/features/preview/markdownPreviewCodeTheme.css
@@ -5,9 +5,39 @@
 .page-viewer__content .inline-code,
 .markdown-editor__preview .inline-code {
   border-radius: 0.25rem;
-  padding: 0.25rem 0.5rem;
+  padding: 0.25rem 1.75rem 0.25rem 0.5rem;
   font-size: 0.75rem;
   font-weight: 500;
+}
+
+.markdown-inline-code {
+  position: relative;
+  display: inline-block;
+}
+
+.markdown-inline-code__copy-button {
+  position: absolute;
+  top: 50%;
+  right: 0.25rem;
+  height: 1.25rem;
+  width: 1.25rem;
+  transform: translateY(-50%);
+  border: 0;
+  border-radius: 0.125rem;
+  padding: 0;
+  opacity: 0;
+  box-shadow: none;
+}
+
+.markdown-inline-code:hover .markdown-inline-code__copy-button,
+.markdown-inline-code:focus-within .markdown-inline-code__copy-button {
+  opacity: 1;
+}
+
+@media (hover: none) {
+  .markdown-inline-code__copy-button {
+    opacity: 0.7;
+  }
 }
 
 :root:not(.dark) .page-viewer__content .inline-code,

--- a/ui/leafwiki-ui/src/features/preview/markdownPreviewCodeTheme.css
+++ b/ui/leafwiki-ui/src/features/preview/markdownPreviewCodeTheme.css
@@ -5,7 +5,7 @@
 .page-viewer__content .inline-code,
 .markdown-editor__preview .inline-code {
   border-radius: 0.25rem;
-  padding: 0.25rem 1.75rem 0.25rem 0.5rem;
+  padding: 0.25rem 0.5rem;
   font-size: 0.75rem;
   font-weight: 500;
 }

--- a/ui/leafwiki-ui/src/features/preview/markdownPreviewCodeTheme.css
+++ b/ui/leafwiki-ui/src/features/preview/markdownPreviewCodeTheme.css
@@ -22,13 +22,14 @@
   height: 1.25rem;
   width: 1.25rem;
   transform: translateY(-50%);
-  border-radius: 0.125rem;
+  border-radius: var(--radius-sm);
   padding: 0;
   border-color: color-mix(in oklab, var(--hljs-foreground) 12%, transparent);
   background: color-mix(in oklab, var(--hljs-background) 92%, transparent);
   color: var(--hljs-foreground);
   opacity: 0;
   box-shadow: none;
+  transition: opacity 200ms;
 }
 
 .markdown-inline-code__copy-button:hover {

--- a/ui/leafwiki-ui/src/features/preview/markdownPreviewCodeTheme.css
+++ b/ui/leafwiki-ui/src/features/preview/markdownPreviewCodeTheme.css
@@ -22,11 +22,18 @@
   height: 1.25rem;
   width: 1.25rem;
   transform: translateY(-50%);
-  border: 0;
   border-radius: 0.125rem;
   padding: 0;
+  border-color: color-mix(in oklab, var(--hljs-foreground) 12%, transparent);
+  background: color-mix(in oklab, var(--hljs-background) 92%, transparent);
+  color: var(--hljs-foreground);
   opacity: 0;
   box-shadow: none;
+}
+
+.markdown-inline-code__copy-button:hover {
+  background: color-mix(in oklab, var(--hljs-background) 82%, white 10%);
+  color: var(--hljs-foreground);
 }
 
 .markdown-inline-code:hover .markdown-inline-code__copy-button,

--- a/ui/leafwiki-ui/src/features/preview/useCodeCopy.ts
+++ b/ui/leafwiki-ui/src/features/preview/useCodeCopy.ts
@@ -1,0 +1,55 @@
+import copy from 'copy-to-clipboard'
+import {
+  ReactNode,
+  isValidElement,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+export function readTextContent(node: ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node)
+  }
+
+  if (Array.isArray(node)) {
+    return node.map(readTextContent).join('')
+  }
+
+  if (isValidElement<{ children?: ReactNode }>(node)) {
+    return readTextContent(node.props.children)
+  }
+
+  return ''
+}
+
+export function useCodeCopy(code: string) {
+  const { t } = useTranslation('viewer')
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    if (!copied) return
+
+    const timeoutId = window.setTimeout(() => {
+      setCopied(false)
+    }, 2000)
+
+    return () => {
+      window.clearTimeout(timeoutId)
+    }
+  }, [copied])
+
+  const copyCode = useCallback(() => {
+    if (!copy(code)) {
+      toast.error(t('codeBlock.copyErrorToast'))
+      return
+    }
+
+    setCopied(true)
+    toast.success(t('codeBlock.copiedToast'))
+  }, [code, t])
+
+  return { copied, copyCode }
+}


### PR DESCRIPTION
## Summary

- add a compact copy action to inline code that appears on hover or keyboard focus
- reuse shared clipboard and feedback behavior for inline and fenced code
- prevent the copy action from activating surrounding links or click handlers
- cover successful copies, failures, temporary feedback, and event isolation

## Validation

- targeted preview tests: 8 passed
- `npm run build`
- `npm run lint`
- `git diff --check`
- full `npm test -- --run`: 284 passed, 1 failed in `HotKeyHandler.test.tsx`; the same full-suite-only failure reproduces on a clean latest `main` (280 passed, 1 failed), while that test passes in isolation

Fixes #1358

AI assistance: Codex was used to help investigate, implement, and test this change.