### PR TITLE
fix(auth): accept email in reverse-proxy remote-user header (#1351)

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ For plain HTTP: add `--allow-insecure=true` so login and CSRF cookies work.
 | `--max-revision-history`         | Max revisions per page; `0` = unlimited                                 | `100`         | v0.9.0  |
 | `--revision-coalesce-window`     | Window for coalescing rapid successive auto-save revisions by the same author; `0` = disabled | `5m` | v0.11.0 |
 | `--enable-http-remote-user`      | Enable reverse-proxy auth via HTTP header                               | `false`       | v0.10.0 |
-| `--http-remote-user-header-name` | Header name carrying the username from the proxy                        | `Remote-User` | v0.10.0 |
+| `--http-remote-user-header-name` | Header name carrying the username or email from the proxy               | `Remote-User` | v0.10.0 |
 | `--trusted-proxy-ips`            | Trusted proxy IPs/CIDRs for remote-user header                          | `""`          | v0.10.0 |
 | `--login-url`                    | Redirect to an external URL instead of the built-in login form          | `""`          | v0.12.0 |
 | `--logout-url`                   | Redirect to an external URL after logout                                | `""`          | v0.12.0 |
@@ -385,7 +385,7 @@ For plain HTTP: add `--allow-insecure=true` so login and CSRF cookies work.
 | `LEAFWIKI_MAX_REVISION_HISTORY`         | Max revisions per page; `0` = unlimited              | `100`         | v0.9.0  |
 | `LEAFWIKI_REVISION_COALESCE_WINDOW`     | Window for coalescing rapid successive auto-save revisions; `0` = disabled | `5m` | v0.11.0 |
 | `LEAFWIKI_ENABLE_HTTP_REMOTE_USER`      | Reverse-proxy auth via header                        | `false`       | v0.10.0 |
-| `LEAFWIKI_HTTP_REMOTE_USER_HEADER_NAME` | Username header from proxy                           | `Remote-User` | v0.10.0 |
+| `LEAFWIKI_HTTP_REMOTE_USER_HEADER_NAME` | Username or email header from proxy                  | `Remote-User` | v0.10.0 |
 | `LEAFWIKI_TRUSTED_PROXY_IPS`            | Trusted proxy IPs/CIDRs                              | `""`          | v0.10.0 |
 | `LEAFWIKI_LOGIN_URL`                    | Redirect to an external URL instead of the login form | `""`          | v0.12.0 |
 | `LEAFWIKI_LOGOUT_URL`                   | Redirect to an external URL after logout             | `""`          | v0.12.0 |
@@ -430,7 +430,7 @@ Place a `.css` file inside your data directory and pass its path:
 
 ### Reverse-Proxy Authentication
 
-Available since v0.10.0. Use when an upstream proxy authenticates users and forwards the username via HTTP header.
+Available since v0.10.0. Use when an upstream proxy authenticates users and forwards the username or email via HTTP header.
 
 ```bash
 ./leafwiki \
@@ -444,7 +444,7 @@ Available since v0.10.0. Use when an upstream proxy authenticates users and forw
 ```
 
 - Only trusts the header from IPs listed in `--trusted-proxy-ips`
-- If the forwarded username doesn't exist in LeafWiki, the request is rejected
+- If the forwarded username or email doesn't match a LeafWiki user, the request is rejected
 - Do not enable without configuring `--trusted-proxy-ips`
 - `--login-url` and `--logout-url` are independent, optional redirect targets — set either or both to send users to an external IdP instead of the built-in login form / to redirect after logout
 - `--login-url`, `--logout-url`, and `--user-management-url` must all start with `http://` or `https://`; the server refuses to start otherwise (relative paths are not accepted for any of them)

--- a/internal/http/middleware/auth/reverse_proxy.go
+++ b/internal/http/middleware/auth/reverse_proxy.go
@@ -17,9 +17,9 @@ type RemoteUserConfig struct {
 	UserService    *coreauth.UserService
 }
 
-// InjectRemoteUser reads a username from a configured HTTP header when the request
-// originates from a trusted proxy IP. On success it stores the resolved user in the
-// Gin context so that RequireAuth can short-circuit JWT validation.
+// InjectRemoteUser reads a username or email from a configured HTTP header when the
+// request originates from a trusted proxy IP. On success it stores the resolved user
+// in the Gin context so that RequireAuth can short-circuit JWT validation.
 //
 // Behaviour by case:
 //   - disabled or untrusted source IP → no-op, normal auth applies
@@ -45,8 +45,8 @@ func InjectRemoteUser(cfg RemoteUserConfig) gin.HandlerFunc {
 			return
 		}
 
-		username := strings.TrimSpace(c.GetHeader(cfg.HeaderName))
-		if username == "" {
+		identifier := strings.TrimSpace(c.GetHeader(cfg.HeaderName))
+		if identifier == "" {
 			slog.Default().Debug("reverse proxy auth: trusted proxy sent no user header, skipping", "remote_addr", c.Request.RemoteAddr, "header", cfg.HeaderName)
 			// Trusted proxy but no header — let public endpoints work normally;
 			// RequireAuth will reject unauthenticated access to protected routes.
@@ -54,9 +54,9 @@ func InjectRemoteUser(cfg RemoteUserConfig) gin.HandlerFunc {
 			return
 		}
 
-		user, err := cfg.UserService.GetUserByUsername(username)
+		user, err := cfg.UserService.GetUserByIdentifier(identifier)
 		if err != nil {
-			slog.Default().Warn("reverse proxy auth: user not found", "username", username, "remote_addr", c.Request.RemoteAddr)
+			slog.Default().Warn("reverse proxy auth: user not found", "identifier", identifier, "remote_addr", c.Request.RemoteAddr)
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "reverse proxy auth: user not found"})
 			return
 		}

--- a/internal/http/middleware/auth/reverse_proxy_test.go
+++ b/internal/http/middleware/auth/reverse_proxy_test.go
@@ -169,6 +169,33 @@ func TestInjectRemoteUser_TrustedIP_ValidUser(t *testing.T) {
 	}
 }
 
+func TestInjectRemoteUser_TrustedIP_ValidUser_ByEmail(t *testing.T) {
+	f := createProxyFixture(t)
+	cleanupWithErrorCheck(t, "proxy fixture", f.close)
+
+	cfg := authmw.RemoteUserConfig{
+		Enabled:        true,
+		HeaderName:     "Remote-User",
+		TrustedProxies: mustParseTrustedProxies(t, "127.0.0.1"),
+		UserService:    f.userService,
+	}
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	// default admin's email (see InitDefaultAdmin), not its username
+	req.Header.Set("Remote-User", "admin@localhost")
+	w := httptest.NewRecorder()
+
+	proxyRouter(cfg).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 when header carries the user's email, got %d: %s", w.Code, w.Body.String())
+	}
+	if body := w.Body.String(); body != `{"username":"admin"}` {
+		t.Errorf("unexpected body: %s", body)
+	}
+}
+
 func TestInjectRemoteUser_TrustedIP_UnknownUser(t *testing.T) {
 	f := createProxyFixture(t)
 	cleanupWithErrorCheck(t, "proxy fixture", f.close)


### PR DESCRIPTION
InjectRemoteUser now resolves the header value via UserService.GetUserByIdentifier (username, falling back to email) instead of GetUserByUsername, so proxies that only know the user's email (e.g. Cloudflare Access's Cf-Access-Authenticated-User-Email) can authenticate against LeafWiki.
