### PR TITLE
fix(preview): remove dead inline-code pseudo-element reset

### DIFF
--- a/ui/leafwiki-ui/src/features/preview/markdownPreviewCodeTheme.css
+++ b/ui/leafwiki-ui/src/features/preview/markdownPreviewCodeTheme.css
@@ -10,13 +10,6 @@
   font-weight: 500;
 }
 
-.page-viewer__content .inline-code::after,
-.page-viewer__content .inline-code::before,
-.markdown-editor__preview .inline-code::after,
-.markdown-editor__preview .inline-code::before {
-  content: '';
-}
-
 :root:not(.dark) .page-viewer__content .inline-code,
 :root:not(.dark) .markdown-editor__preview .inline-code {
   background: hsl(var(--surface-alt)) !important;


### PR DESCRIPTION
The .inline-code::before/::after { content: '' } rule was a leftover guard against @tailwindcss/typography's default backtick pseudo content, but .prose is never applied to the viewer/editor preview surfaces, so the rule was a no-op visually while still generating an empty generated-content box on every inline code span.

That empty box is the likely cause of #1345: when an inline code span wraps across lines, Safari can strand the trailing empty fragment alone on the next line, looking like an invisible orphaned "suffix". Removing the unused content declaration means no pseudo-element is generated at all.
