### PR TITLE
feat(auth): auto-create users from trusted reverse-proxy header (#1330)

### DIFF
--- a/.github/workflows/proxy-auth-e2e.yml
+++ b/.github/workflows/proxy-auth-e2e.yml
@@ -36,6 +36,7 @@ jobs:
         run: go test -v -timeout 60s ./...
         env:
           E2E_PROXY_URL: http://localhost:8095
+          E2E_AUTOCREATE_PROXY_URL: http://localhost:8096
 
       - name: Print stack logs on failure
         if: failure()

--- a/README.md
+++ b/README.md
@@ -331,6 +331,9 @@ For plain HTTP: add `--allow-insecure=true` so login and CSRF cookies work.
 | `--revision-coalesce-window`     | Window for coalescing rapid successive auto-save revisions by the same author; `0` = disabled | `5m` | v0.11.0 |
 | `--enable-http-remote-user`      | Enable reverse-proxy auth via HTTP header                               | `false`       | v0.10.0 |
 | `--http-remote-user-header-name` | Header name carrying the username or email from the proxy               | `Remote-User` | v0.10.0 |
+| `--enable-http-remote-user-auto-create` | Auto-provision users the proxy asserts but LeafWiki doesn't know    | `false`       | v0.13.0 |
+| `--http-remote-user-email-header-name` | Header name carrying the email for auto-created users               | `""`          | v0.13.0 |
+| `--http-remote-user-default-role` | Role assigned to auto-created users; must not be `admin`               | `viewer`      | v0.13.0 |
 | `--trusted-proxy-ips`            | Trusted proxy IPs/CIDRs for remote-user header                          | `""`          | v0.10.0 |
 | `--login-url`                    | Redirect to an external URL instead of the built-in login form          | `""`          | v0.12.0 |
 | `--logout-url`                   | Redirect to an external URL after logout                                | `""`          | v0.12.0 |
@@ -386,6 +389,9 @@ For plain HTTP: add `--allow-insecure=true` so login and CSRF cookies work.
 | `LEAFWIKI_REVISION_COALESCE_WINDOW`     | Window for coalescing rapid successive auto-save revisions; `0` = disabled | `5m` | v0.11.0 |
 | `LEAFWIKI_ENABLE_HTTP_REMOTE_USER`      | Reverse-proxy auth via header                        | `false`       | v0.10.0 |
 | `LEAFWIKI_HTTP_REMOTE_USER_HEADER_NAME` | Username or email header from proxy                  | `Remote-User` | v0.10.0 |
+| `LEAFWIKI_ENABLE_HTTP_REMOTE_USER_AUTO_CREATE` | Auto-provision users the proxy asserts but LeafWiki doesn't know | `false` | v0.13.0 |
+| `LEAFWIKI_HTTP_REMOTE_USER_EMAIL_HEADER_NAME` | Email header for auto-created users            | `""`          | v0.13.0 |
+| `LEAFWIKI_HTTP_REMOTE_USER_DEFAULT_ROLE` | Role assigned to auto-created users; must not be `admin` | `viewer`      | v0.13.0 |
 | `LEAFWIKI_TRUSTED_PROXY_IPS`            | Trusted proxy IPs/CIDRs                              | `""`          | v0.10.0 |
 | `LEAFWIKI_LOGIN_URL`                    | Redirect to an external URL instead of the login form | `""`          | v0.12.0 |
 | `LEAFWIKI_LOGOUT_URL`                   | Redirect to an external URL after logout             | `""`          | v0.12.0 |
@@ -444,12 +450,34 @@ Available since v0.10.0. Use when an upstream proxy authenticates users and forw
 ```
 
 - Only trusts the header from IPs listed in `--trusted-proxy-ips`
-- If the forwarded username or email doesn't match a LeafWiki user, the request is rejected
+- If the forwarded username or email doesn't match a LeafWiki user, the request is rejected — unless `--enable-http-remote-user-auto-create` is set (see below)
 - Do not enable without configuring `--trusted-proxy-ips`
 - `--login-url` and `--logout-url` are independent, optional redirect targets — set either or both to send users to an external IdP instead of the built-in login form / to redirect after logout
 - `--login-url`, `--logout-url`, and `--user-management-url` must all start with `http://` or `https://`; the server refuses to start otherwise (relative paths are not accepted for any of them)
 - ⚠️ `--login-url` takes effect regardless of `--enable-http-remote-user` and has no in-app bypass: once set, *every* unauthenticated visit (including `/login` itself) redirects to it immediately. Double-check the URL before setting it — a wrong or unreachable value locks all users, including admins, out of the built-in login form
 - `--http-remote-user-logout-url` (v0.10.0) is deprecated; use `--logout-url` instead. It still works as a fallback when `--logout-url`/`LEAFWIKI_LOGOUT_URL` isn't set, but a deprecation warning is logged
+
+#### Auto-creating users (v0.13.0)
+
+By default, a proxy-asserted identity with no matching LeafWiki account is rejected (401). Set `--enable-http-remote-user-auto-create=true` to provision one automatically instead:
+
+```bash
+./leafwiki \
+  --jwt-secret=yoursecret \
+  --admin-password=yourpassword \
+  --enable-http-remote-user=true \
+  --http-remote-user-header-name=X-Forwarded-User \
+  --trusted-proxy-ips=127.0.0.1,172.18.0.0/16 \
+  --enable-http-remote-user-auto-create=true \
+  --http-remote-user-email-header-name=X-Forwarded-Email \
+  --http-remote-user-default-role=viewer
+```
+
+- Requires `--enable-http-remote-user` to also be set; the server refuses to start otherwise
+- The value in `--http-remote-user-header-name` becomes the new account's username verbatim, even if it looks like an email address — if your proxy sends an email in that header and you want a distinct, readable username, point `--http-remote-user-email-header-name` at a separate proxy header
+- If `--http-remote-user-email-header-name` isn't set or the header is empty, a non-deliverable placeholder email (`<username>@remote-user.invalid`) is used instead
+- Auto-created accounts get a random password nobody is told — they can only ever authenticate via the trusted proxy, not the built-in login form
+- `--http-remote-user-default-role` **must not be `admin`** — the server refuses to start otherwise. A forged or misrouted header must not be able to mint an admin account by itself; promote an auto-created user to admin manually if needed
 
 ### Unix Socket (v0.11.3)
 

--- a/README.md
+++ b/README.md
@@ -331,9 +331,9 @@ For plain HTTP: add `--allow-insecure=true` so login and CSRF cookies work.
 | `--revision-coalesce-window`     | Window for coalescing rapid successive auto-save revisions by the same author; `0` = disabled | `5m` | v0.11.0 |
 | `--enable-http-remote-user`      | Enable reverse-proxy auth via HTTP header                               | `false`       | v0.10.0 |
 | `--http-remote-user-header-name` | Header name carrying the username or email from the proxy               | `Remote-User` | v0.10.0 |
-| `--enable-http-remote-user-auto-create` | Auto-provision users the proxy asserts but LeafWiki doesn't know    | `false`       | v0.13.0 |
-| `--http-remote-user-email-header-name` | Header name carrying the email for auto-created users               | `""`          | v0.13.0 |
-| `--http-remote-user-default-role` | Role assigned to auto-created users; must not be `admin`               | `viewer`      | v0.13.0 |
+| `--enable-http-remote-user-auto-create` | Auto-provision users the proxy asserts but LeafWiki doesn't know    | `false`    | v0.12.1 |
+| `--http-remote-user-email-header-name` | Header name carrying the email for auto-created users               | `""`        | v0.12.1 |
+| `--http-remote-user-default-role` | Role assigned to auto-created users; must not be `admin`               | `viewer`      | v0.12.1 |
 | `--trusted-proxy-ips`            | Trusted proxy IPs/CIDRs for remote-user header                          | `""`          | v0.10.0 |
 | `--login-url`                    | Redirect to an external URL instead of the built-in login form          | `""`          | v0.12.0 |
 | `--logout-url`                   | Redirect to an external URL after logout                                | `""`          | v0.12.0 |

--- a/cmd/leafwiki/main.go
+++ b/cmd/leafwiki/main.go
@@ -91,9 +91,12 @@ func writeUsage(w io.Writer) {
 	--metrics-port                Port for the metrics listener (default: 9091)
 	--max-revision-history        Maximum revisions kept per page; 0 = unlimited (default: 100)
 	--revision-coalesce-window    Window for coalescing rapid successive saves by the same author (e.g. 5m, 0 = disabled) (default: 5m)
-	--enable-http-remote-user       Enable reverse-proxy authentication via HTTP header (default: false)
-	--http-remote-user-header-name  HTTP header carrying the username from a trusted proxy (default: Remote-User)
-	--trusted-proxy-ips             Comma-separated trusted proxy IPs/CIDRs (e.g. 127.0.0.1,172.18.0.0/16)
+	--enable-http-remote-user               Enable reverse-proxy authentication via HTTP header (default: false)
+	--http-remote-user-header-name          HTTP header carrying the username or email from a trusted proxy (default: Remote-User)
+	--enable-http-remote-user-auto-create   Auto-provision users asserted by the trusted proxy but unknown to LeafWiki (default: false)
+	--http-remote-user-email-header-name    HTTP header carrying the email for auto-created users (default: "")
+	--http-remote-user-default-role         Role assigned to auto-created users; must not be "admin" (default: viewer)
+	--trusted-proxy-ips                     Comma-separated trusted proxy IPs/CIDRs (e.g. 127.0.0.1,172.18.0.0/16)
 	--login-url                     URL the frontend redirects to instead of the built-in login form
 	                                 (e.g. an external SSO/IdP login page) (default: "")
 	--logout-url                    URL the frontend redirects to after logout
@@ -156,6 +159,9 @@ func writeUsage(w io.Writer) {
 	LEAFWIKI_REVISION_COALESCE_WINDOW
 	LEAFWIKI_ENABLE_HTTP_REMOTE_USER
 	LEAFWIKI_HTTP_REMOTE_USER_HEADER_NAME
+	LEAFWIKI_ENABLE_HTTP_REMOTE_USER_AUTO_CREATE
+	LEAFWIKI_HTTP_REMOTE_USER_EMAIL_HEADER_NAME
+	LEAFWIKI_HTTP_REMOTE_USER_DEFAULT_ROLE
 	LEAFWIKI_TRUSTED_PROXY_IPS
 	LEAFWIKI_LOGIN_URL
 	LEAFWIKI_LOGOUT_URL
@@ -231,110 +237,116 @@ func runRestoreSnapshotCommand(dataDir string, args []string) error {
 var gracefulShutdownTimeout = 10 * time.Second
 
 type cliFlags struct {
-	logFormat               *string
-	host                    *string
-	port                    *string
-	unixSocket              *string
-	dataDir                 *string
-	adminUsername           *string
-	adminEmail              *string
-	adminPassword           *string
-	jwtSecret               *string
-	totpEncryptionKey       *string
-	publicAccess            *bool
-	allowInsecure           *bool
-	injectCodeInHeader      *string
-	customStylesheet        *string
-	disableAuth             *bool
-	hideLinkMetadataSection *bool
-	accessTokenTimeout      *time.Duration
-	refreshTokenTimeout     *time.Duration
-	basePath                *string
-	maxAssetUploadSize      *string
-	enableRevision          *bool
-	enableLinkRefactor      *bool
-	enableAPIKeyManagement  *bool
-	enableMetrics           *bool
-	metricsHost             *string
-	metricsPort             *string
-	maxRevisionHistory      *int
-	enableHTTPRemoteUser    *bool
-	httpRemoteUserHeader    *string
-	trustedProxyIPs         *string
-	loginURL                *string
-	logoutURL               *string
-	httpRemoteUserLogoutURL *string
-	userManagementURL       *string
-	disableRequestLog       *bool
-	gitBackup               *bool
-	gitBackupAuthorName     *string
-	gitBackupAuthorEmail    *string
-	gitBackupRemote         *string
-	gitBackupBranch         *string
-	gitBackupSSHKeyPath     *string
-	gitBackupSSHKey         *string
-	gitBackupSSHKnownHosts  *string
-	gitBackupInterval       *time.Duration
-	revisionCoalesceWindow  *time.Duration
-	snapshotEnabled         *bool
-	snapshotInterval        *time.Duration
-	snapshotRetention       *int
-	snapshotDir             *string
-	restoreUploadMaxSize    *string
+	logFormat                      *string
+	host                           *string
+	port                           *string
+	unixSocket                     *string
+	dataDir                        *string
+	adminUsername                  *string
+	adminEmail                     *string
+	adminPassword                  *string
+	jwtSecret                      *string
+	totpEncryptionKey              *string
+	publicAccess                   *bool
+	allowInsecure                  *bool
+	injectCodeInHeader             *string
+	customStylesheet               *string
+	disableAuth                    *bool
+	hideLinkMetadataSection        *bool
+	accessTokenTimeout             *time.Duration
+	refreshTokenTimeout            *time.Duration
+	basePath                       *string
+	maxAssetUploadSize             *string
+	enableRevision                 *bool
+	enableLinkRefactor             *bool
+	enableAPIKeyManagement         *bool
+	enableMetrics                  *bool
+	metricsHost                    *string
+	metricsPort                    *string
+	maxRevisionHistory             *int
+	enableHTTPRemoteUser           *bool
+	httpRemoteUserHeader           *string
+	enableHTTPRemoteUserAutoCreate *bool
+	httpRemoteUserEmailHeader      *string
+	httpRemoteUserDefaultRole      *string
+	trustedProxyIPs                *string
+	loginURL                       *string
+	logoutURL                      *string
+	httpRemoteUserLogoutURL        *string
+	userManagementURL              *string
+	disableRequestLog              *bool
+	gitBackup                      *bool
+	gitBackupAuthorName            *string
+	gitBackupAuthorEmail           *string
+	gitBackupRemote                *string
+	gitBackupBranch                *string
+	gitBackupSSHKeyPath            *string
+	gitBackupSSHKey                *string
+	gitBackupSSHKnownHosts         *string
+	gitBackupInterval              *time.Duration
+	revisionCoalesceWindow         *time.Duration
+	snapshotEnabled                *bool
+	snapshotInterval               *time.Duration
+	snapshotRetention              *int
+	snapshotDir                    *string
+	restoreUploadMaxSize           *string
 }
 
 func registerFlags(fs *flag.FlagSet) *cliFlags {
 	return &cliFlags{
-		logFormat:               fs.String("log-format", "", "log output format: text or json (default: text)"),
-		host:                    fs.String("host", "", "host/IP address to bind the server to (e.g. 127.0.0.1 or 0.0.0.0)"),
-		port:                    fs.String("port", "", "port to run the server on"),
-		unixSocket:              fs.String("unix-socket", "", "path to a unix domain socket to listen on; overrides --host and --port"),
-		dataDir:                 fs.String("data-dir", "", "path to data directory"),
-		adminUsername:           fs.String("admin-username", "", "initial admin username (used only if no admin exists) (default: admin)"),
-		adminEmail:              fs.String("admin-email", "", "initial admin email (used only if no admin exists) (default: admin@localhost)"),
-		adminPassword:           fs.String("admin-password", "", "initial admin password"),
-		jwtSecret:               fs.String("jwt-secret", "", "JWT secret for authentication"),
-		totpEncryptionKey:       fs.String("totp-encryption-key", "", "key to encrypt per-user TOTP secrets at rest, min 32 bytes (leave unset to keep TOTP self-service unavailable)"),
-		publicAccess:            fs.Bool("public-access", false, "allow public access to the wiki with read access (default: false)"),
-		allowInsecure:           fs.Bool("allow-insecure", false, "allow insecure HTTP connections (default: false)"),
-		injectCodeInHeader:      fs.String("inject-code-in-header", "", "raw string injected into <head> (default: \"\")"),
-		customStylesheet:        fs.String("custom-stylesheet", "", "path to a custom CSS file served as /custom.css"),
-		disableAuth:             fs.Bool("disable-auth", false, "disable authentication completely (default: false) (WARNING: only use in trusted networks!)"),
-		hideLinkMetadataSection: fs.Bool("hide-link-metadata-section", false, "hide link metadata section (default: false)"),
-		accessTokenTimeout:      fs.Duration("access-token-timeout", 15*time.Minute, "access token timeout duration (e.g. 24h, 15m) (default: 15m)"),
-		refreshTokenTimeout:     fs.Duration("refresh-token-timeout", 7*24*time.Hour, "refresh token timeout duration (e.g. 168h) (default: 168h)"),
-		basePath:                fs.String("base-path", "", "URL prefix when served behind a reverse proxy (e.g. /wiki)"),
-		maxAssetUploadSize:      fs.String("max-asset-upload-size", "", "maximum size for asset uploads (for example 50MiB, 50MB, 52428800)"),
-		enableRevision:          fs.Bool("enable-revision", false, "enable the revision / page history feature (default: false)"),
-		enableLinkRefactor:      fs.Bool("enable-link-refactor", false, "enable the link refactoring dialog and rewrite flow (default: false)"),
-		enableAPIKeyManagement:  fs.Bool("enable-api-key-management", false, "enable the experimental API key management feature (default: false)"),
-		enableMetrics:           fs.Bool("enable-metrics", false, "enable the Prometheus /metrics endpoint on a separate listener (default: false)"),
-		metricsHost:             fs.String("metrics-host", "", "host/IP address for the Prometheus metrics listener (default: 127.0.0.1)"),
-		metricsPort:             fs.String("metrics-port", "", "port for the Prometheus metrics listener (default: 9091)"),
-		maxRevisionHistory:      fs.Int("max-revision-history", 100, "maximum revisions kept per page; 0 = unlimited (default: 100)"),
-		enableHTTPRemoteUser:    fs.Bool("enable-http-remote-user", false, "enable reverse-proxy authentication via HTTP header (default: false)"),
-		httpRemoteUserHeader:    fs.String("http-remote-user-header-name", "Remote-User", "HTTP header name carrying the username from a trusted proxy (default: Remote-User)"),
-		trustedProxyIPs:         fs.String("trusted-proxy-ips", "", "comma-separated list of trusted proxy IPs/CIDRs (e.g. 127.0.0.1,172.18.0.0/16)"),
-		loginURL:                fs.String("login-url", "", "URL the frontend redirects to instead of the built-in login form (e.g. an external SSO/IdP login page)"),
-		logoutURL:               fs.String("logout-url", "", "URL the frontend redirects to after logout (e.g. an external SSO/IdP logout page)"),
-		httpRemoteUserLogoutURL: fs.String("http-remote-user-logout-url", "", "deprecated: use --logout-url instead"),
-		userManagementURL:       fs.String("user-management-url", "", "URL to an external user-management page; when set, the built-in User Management UI is replaced with a link to this URL"),
-		disableRequestLog:       fs.Bool("disable-request-log", false, "suppress per-request HTTP access log lines (default: false)"),
-		gitBackup:               fs.Bool("git-backup", false, "enable git backup to a remote repository (default: false)"),
-		gitBackupAuthorName:     fs.String("git-backup-author-name", "", "git commit author name for backups (default: LeafWiki Backup)"),
-		gitBackupAuthorEmail:    fs.String("git-backup-author-email", "", "git commit author email for backups (default: backup@leafwiki.local)"),
-		gitBackupRemote:         fs.String("git-backup-remote", "", "git remote URL (SSH) for backups (required when git-backup is enabled)"),
-		gitBackupBranch:         fs.String("git-backup-branch", "", "git branch to push to (default: main)"),
-		gitBackupSSHKeyPath:     fs.String("git-backup-ssh-key-path", "", "path to SSH private key for git backup"),
-		gitBackupSSHKey:         fs.String(gitBackupSSHKeyFlagName, "", "raw SSH private key for git backup (env var preferred)"),
-		gitBackupSSHKnownHosts:  fs.String("git-backup-ssh-known-hosts", "", "path to known_hosts file for SSH host key verification (MITM protection)"),
-		gitBackupInterval:       fs.Duration("git-backup-interval", 60*time.Minute, "git backup interval (e.g. 60m, 2h); 0 = manual-only, no automatic scheduling (default: 60m)"),
-		revisionCoalesceWindow:  fs.Duration("revision-coalesce-window", 5*time.Minute, "window for coalescing rapid successive saves by the same author; 0 = disabled (default: 5m)"),
-		snapshotEnabled:         fs.Bool("snapshot", true, "enable full backup snapshots (ZIP incl. the SQLite database) (default: true)"),
-		snapshotInterval:        fs.Duration("snapshot-interval", 24*time.Hour, "snapshot interval (e.g. 24h, 6h); 0 = manual-only, no automatic scheduling (default: 24h)"),
-		snapshotRetention:       fs.Int("snapshot-retention", 10, "number of most recent snapshots to keep; <= 0 = keep all (default: 10)"),
-		snapshotDir:             fs.String("snapshot-dir", "", "directory to store snapshot ZIPs in (default: <data-dir>/snapshots)"),
-		restoreUploadMaxSize:    fs.String("restore-upload-max-size", "", "maximum size for an uploaded backup ZIP to restore from (for example 500MiB, 500MB, 524288000) (default: 500MiB)"),
+		logFormat:                      fs.String("log-format", "", "log output format: text or json (default: text)"),
+		host:                           fs.String("host", "", "host/IP address to bind the server to (e.g. 127.0.0.1 or 0.0.0.0)"),
+		port:                           fs.String("port", "", "port to run the server on"),
+		unixSocket:                     fs.String("unix-socket", "", "path to a unix domain socket to listen on; overrides --host and --port"),
+		dataDir:                        fs.String("data-dir", "", "path to data directory"),
+		adminUsername:                  fs.String("admin-username", "", "initial admin username (used only if no admin exists) (default: admin)"),
+		adminEmail:                     fs.String("admin-email", "", "initial admin email (used only if no admin exists) (default: admin@localhost)"),
+		adminPassword:                  fs.String("admin-password", "", "initial admin password"),
+		jwtSecret:                      fs.String("jwt-secret", "", "JWT secret for authentication"),
+		totpEncryptionKey:              fs.String("totp-encryption-key", "", "key to encrypt per-user TOTP secrets at rest, min 32 bytes (leave unset to keep TOTP self-service unavailable)"),
+		publicAccess:                   fs.Bool("public-access", false, "allow public access to the wiki with read access (default: false)"),
+		allowInsecure:                  fs.Bool("allow-insecure", false, "allow insecure HTTP connections (default: false)"),
+		injectCodeInHeader:             fs.String("inject-code-in-header", "", "raw string injected into <head> (default: \"\")"),
+		customStylesheet:               fs.String("custom-stylesheet", "", "path to a custom CSS file served as /custom.css"),
+		disableAuth:                    fs.Bool("disable-auth", false, "disable authentication completely (default: false) (WARNING: only use in trusted networks!)"),
+		hideLinkMetadataSection:        fs.Bool("hide-link-metadata-section", false, "hide link metadata section (default: false)"),
+		accessTokenTimeout:             fs.Duration("access-token-timeout", 15*time.Minute, "access token timeout duration (e.g. 24h, 15m) (default: 15m)"),
+		refreshTokenTimeout:            fs.Duration("refresh-token-timeout", 7*24*time.Hour, "refresh token timeout duration (e.g. 168h) (default: 168h)"),
+		basePath:                       fs.String("base-path", "", "URL prefix when served behind a reverse proxy (e.g. /wiki)"),
+		maxAssetUploadSize:             fs.String("max-asset-upload-size", "", "maximum size for asset uploads (for example 50MiB, 50MB, 52428800)"),
+		enableRevision:                 fs.Bool("enable-revision", false, "enable the revision / page history feature (default: false)"),
+		enableLinkRefactor:             fs.Bool("enable-link-refactor", false, "enable the link refactoring dialog and rewrite flow (default: false)"),
+		enableAPIKeyManagement:         fs.Bool("enable-api-key-management", false, "enable the experimental API key management feature (default: false)"),
+		enableMetrics:                  fs.Bool("enable-metrics", false, "enable the Prometheus /metrics endpoint on a separate listener (default: false)"),
+		metricsHost:                    fs.String("metrics-host", "", "host/IP address for the Prometheus metrics listener (default: 127.0.0.1)"),
+		metricsPort:                    fs.String("metrics-port", "", "port for the Prometheus metrics listener (default: 9091)"),
+		maxRevisionHistory:             fs.Int("max-revision-history", 100, "maximum revisions kept per page; 0 = unlimited (default: 100)"),
+		enableHTTPRemoteUser:           fs.Bool("enable-http-remote-user", false, "enable reverse-proxy authentication via HTTP header (default: false)"),
+		httpRemoteUserHeader:           fs.String("http-remote-user-header-name", "Remote-User", "HTTP header name carrying the username or email from a trusted proxy (default: Remote-User)"),
+		enableHTTPRemoteUserAutoCreate: fs.Bool("enable-http-remote-user-auto-create", false, "auto-provision users asserted by the trusted proxy but unknown to LeafWiki (default: false)"),
+		httpRemoteUserEmailHeader:      fs.String("http-remote-user-email-header-name", "", "HTTP header name carrying the email for auto-created users (default: \"\")"),
+		httpRemoteUserDefaultRole:      fs.String("http-remote-user-default-role", "viewer", "role assigned to auto-created users; must not be \"admin\" (default: viewer)"),
+		trustedProxyIPs:                fs.String("trusted-proxy-ips", "", "comma-separated list of trusted proxy IPs/CIDRs (e.g. 127.0.0.1,172.18.0.0/16)"),
+		loginURL:                       fs.String("login-url", "", "URL the frontend redirects to instead of the built-in login form (e.g. an external SSO/IdP login page)"),
+		logoutURL:                      fs.String("logout-url", "", "URL the frontend redirects to after logout (e.g. an external SSO/IdP logout page)"),
+		httpRemoteUserLogoutURL:        fs.String("http-remote-user-logout-url", "", "deprecated: use --logout-url instead"),
+		userManagementURL:              fs.String("user-management-url", "", "URL to an external user-management page; when set, the built-in User Management UI is replaced with a link to this URL"),
+		disableRequestLog:              fs.Bool("disable-request-log", false, "suppress per-request HTTP access log lines (default: false)"),
+		gitBackup:                      fs.Bool("git-backup", false, "enable git backup to a remote repository (default: false)"),
+		gitBackupAuthorName:            fs.String("git-backup-author-name", "", "git commit author name for backups (default: LeafWiki Backup)"),
+		gitBackupAuthorEmail:           fs.String("git-backup-author-email", "", "git commit author email for backups (default: backup@leafwiki.local)"),
+		gitBackupRemote:                fs.String("git-backup-remote", "", "git remote URL (SSH) for backups (required when git-backup is enabled)"),
+		gitBackupBranch:                fs.String("git-backup-branch", "", "git branch to push to (default: main)"),
+		gitBackupSSHKeyPath:            fs.String("git-backup-ssh-key-path", "", "path to SSH private key for git backup"),
+		gitBackupSSHKey:                fs.String(gitBackupSSHKeyFlagName, "", "raw SSH private key for git backup (env var preferred)"),
+		gitBackupSSHKnownHosts:         fs.String("git-backup-ssh-known-hosts", "", "path to known_hosts file for SSH host key verification (MITM protection)"),
+		gitBackupInterval:              fs.Duration("git-backup-interval", 60*time.Minute, "git backup interval (e.g. 60m, 2h); 0 = manual-only, no automatic scheduling (default: 60m)"),
+		revisionCoalesceWindow:         fs.Duration("revision-coalesce-window", 5*time.Minute, "window for coalescing rapid successive saves by the same author; 0 = disabled (default: 5m)"),
+		snapshotEnabled:                fs.Bool("snapshot", true, "enable full backup snapshots (ZIP incl. the SQLite database) (default: true)"),
+		snapshotInterval:               fs.Duration("snapshot-interval", 24*time.Hour, "snapshot interval (e.g. 24h, 6h); 0 = manual-only, no automatic scheduling (default: 24h)"),
+		snapshotRetention:              fs.Int("snapshot-retention", 10, "number of most recent snapshots to keep; <= 0 = keep all (default: 10)"),
+		snapshotDir:                    fs.String("snapshot-dir", "", "directory to store snapshot ZIPs in (default: <data-dir>/snapshots)"),
+		restoreUploadMaxSize:           fs.String("restore-upload-max-size", "", "maximum size for an uploaded backup ZIP to restore from (for example 500MiB, 500MB, 524288000) (default: 500MiB)"),
 	}
 }
 
@@ -399,6 +411,9 @@ func main() {
 	revisionCoalesceWindow := resolveDuration("revision-coalesce-window", *flags.revisionCoalesceWindow, visited, "LEAFWIKI_REVISION_COALESCE_WINDOW")
 	enableHTTPRemoteUser := resolveBool("enable-http-remote-user", *flags.enableHTTPRemoteUser, visited, "LEAFWIKI_ENABLE_HTTP_REMOTE_USER")
 	httpRemoteUserHeader := resolveString("http-remote-user-header-name", *flags.httpRemoteUserHeader, visited, "LEAFWIKI_HTTP_REMOTE_USER_HEADER_NAME", "Remote-User")
+	enableHTTPRemoteUserAutoCreate := resolveBool("enable-http-remote-user-auto-create", *flags.enableHTTPRemoteUserAutoCreate, visited, "LEAFWIKI_ENABLE_HTTP_REMOTE_USER_AUTO_CREATE")
+	httpRemoteUserEmailHeader := resolveString("http-remote-user-email-header-name", *flags.httpRemoteUserEmailHeader, visited, "LEAFWIKI_HTTP_REMOTE_USER_EMAIL_HEADER_NAME", "")
+	httpRemoteUserDefaultRole := resolveString("http-remote-user-default-role", *flags.httpRemoteUserDefaultRole, visited, "LEAFWIKI_HTTP_REMOTE_USER_DEFAULT_ROLE", "viewer")
 	trustedProxyIPsRaw := resolveString("trusted-proxy-ips", *flags.trustedProxyIPs, visited, "LEAFWIKI_TRUSTED_PROXY_IPS", "")
 	loginURL := resolveString("login-url", *flags.loginURL, visited, "LEAFWIKI_LOGIN_URL", "")
 	logoutURL := resolveString("logout-url", *flags.logoutURL, visited, "LEAFWIKI_LOGOUT_URL", "")
@@ -433,6 +448,10 @@ func main() {
 		fail("Invalid HTTP remote user configuration", "error", err)
 	}
 
+	if err := validateHTTPRemoteUserAutoCreateConfig(enableHTTPRemoteUserAutoCreate, enableHTTPRemoteUser, httpRemoteUserDefaultRole); err != nil {
+		fail("Invalid HTTP remote user auto-create configuration", "error", err)
+	}
+
 	if err := validateRedirectURL("login-url", loginURL); err != nil {
 		fail("Invalid login URL configuration", "error", err)
 	}
@@ -447,6 +466,8 @@ func main() {
 		slog.Default().Info("Reverse-proxy authentication enabled",
 			"header", httpRemoteUserHeader,
 			"trusted_proxies", trustedProxyIPsRaw,
+			"auto_create", enableHTTPRemoteUserAutoCreate,
+			"default_role", httpRemoteUserDefaultRole,
 		)
 	}
 	if enableMetrics {
@@ -657,10 +678,13 @@ func main() {
 		SnapshotEnabled:         snapshotEnabled,
 		TOTPAvailable:           w.TOTPService() != nil,
 		HTTPRemoteUser: httpinternal.HTTPRemoteUserConfig{
-			Enabled:        enableHTTPRemoteUser,
-			HeaderName:     httpRemoteUserHeader,
-			TrustedProxies: trustedProxies,
-			UserService:    w.UserService,
+			Enabled:         enableHTTPRemoteUser,
+			HeaderName:      httpRemoteUserHeader,
+			AutoCreate:      enableHTTPRemoteUserAutoCreate,
+			EmailHeaderName: httpRemoteUserEmailHeader,
+			DefaultRole:     httpRemoteUserDefaultRole,
+			TrustedProxies:  trustedProxies,
+			UserService:     w.UserService,
 		},
 		APIKeyService:     w.APIKeyService(),
 		DisableRequestLog: disableRequestLog,
@@ -943,6 +967,26 @@ func validateHTTPRemoteUserConfig(enabled bool, trustedProxyIPsRaw string) error
 	}
 	if !hasTrustedProxy {
 		return fmt.Errorf("--trusted-proxy-ips is required when --enable-http-remote-user is set. Set it using --trusted-proxy-ips or LEAFWIKI_TRUSTED_PROXY_IPS")
+	}
+	return nil
+}
+
+// validateHTTPRemoteUserAutoCreateConfig guards the auto-create opt-in: it requires
+// reverse-proxy auth to already be enabled, and forbids "admin" as the default role so
+// a forged or misrouted proxy header can never mint an admin account by itself. An
+// operator who wants remote-provisioned admins can promote a user manually afterward.
+func validateHTTPRemoteUserAutoCreateConfig(autoCreateEnabled, remoteUserEnabled bool, defaultRole string) error {
+	if !autoCreateEnabled {
+		return nil
+	}
+	if !remoteUserEnabled {
+		return fmt.Errorf("--enable-http-remote-user-auto-create requires --enable-http-remote-user to also be set")
+	}
+	if !auth.IsValidRole(defaultRole) {
+		return fmt.Errorf("--http-remote-user-default-role %q is not a valid role", defaultRole)
+	}
+	if defaultRole == auth.RoleAdmin {
+		return fmt.Errorf("--http-remote-user-default-role must not be %q; promote auto-created users manually instead", auth.RoleAdmin)
 	}
 	return nil
 }

--- a/cmd/leafwiki/main_test.go
+++ b/cmd/leafwiki/main_test.go
@@ -130,6 +130,31 @@ func TestValidateHTTPRemoteUserConfig(t *testing.T) {
 	}
 }
 
+func TestValidateHTTPRemoteUserAutoCreateConfig(t *testing.T) {
+	tests := []struct {
+		name              string
+		autoCreateEnabled bool
+		remoteUserEnabled bool
+		defaultRole       string
+		wantErr           bool
+	}{
+		{"auto-create disabled, everything else irrelevant", false, false, "", false},
+		{"auto-create enabled, remote-user disabled", true, false, "viewer", true},
+		{"auto-create enabled, remote-user enabled, valid role", true, true, "viewer", false},
+		{"auto-create enabled, remote-user enabled, editor role", true, true, "editor", false},
+		{"auto-create enabled, remote-user enabled, admin role forbidden", true, true, "admin", true},
+		{"auto-create enabled, remote-user enabled, invalid role", true, true, "superuser", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateHTTPRemoteUserAutoCreateConfig(tc.autoCreateEnabled, tc.remoteUserEnabled, tc.defaultRole)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validateHTTPRemoteUserAutoCreateConfig(%v, %v, %q) error = %v, wantErr %v", tc.autoCreateEnabled, tc.remoteUserEnabled, tc.defaultRole, err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestValidateRedirectURL(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/e2e-proxy/docker-compose.yml
+++ b/e2e-proxy/docker-compose.yml
@@ -1,4 +1,7 @@
 services:
+  # Default config: reverse-proxy auth enabled, auto-create OFF (the documented
+  # default). Exercises the original "unknown proxy-asserted user is rejected"
+  # behavior end-to-end through the real CLI-flag -> router -> middleware wiring.
   leafwiki:
     build:
       context: ..
@@ -33,6 +36,47 @@ services:
     networks:
       proxy-net:
         ipv4_address: 172.30.0.3
+
+  # Auto-create config: same as above but with --enable-http-remote-user-auto-create
+  # and the email header set, for tests specific to that feature. Kept as a
+  # separate stack (rather than flipping the default one) so the default's
+  # "unknown user -> 401" behavior stays covered end-to-end too.
+  leafwiki-autocreate:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+      args:
+        DISABLE_REFRESH_TOKEN_RATE_LIMIT: "true"
+    command:
+      - "--jwt-secret=proxy-e2e-secret"
+      - "--admin-password=admin"
+      - "--allow-insecure=true"
+      - "--enable-http-remote-user=true"
+      - "--trusted-proxy-ips=172.30.0.0/16"
+      - "--enable-http-remote-user-auto-create=true"
+      - "--http-remote-user-email-header-name=Remote-Email"
+      - "--http-remote-user-default-role=viewer"
+    networks:
+      proxy-net:
+        ipv4_address: 172.30.0.4
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/api/config"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+
+  nginx-autocreate:
+    image: nginx:1.27-alpine
+    volumes:
+      - ./nginx/nginx-autocreate.conf:/etc/nginx/conf.d/default.conf:ro
+    ports:
+      - "8096:80"
+    depends_on:
+      leafwiki-autocreate:
+        condition: service_healthy
+    networks:
+      proxy-net:
+        ipv4_address: 172.30.0.5
 
 networks:
   proxy-net:

--- a/e2e-proxy/nginx/nginx-autocreate.conf
+++ b/e2e-proxy/nginx/nginx-autocreate.conf
@@ -1,0 +1,23 @@
+server {
+    listen 80;
+
+    location / {
+        # Strip any Remote-User/Remote-Email headers that clients might try to
+        # inject directly. We always set them from the X-Test-User/X-Test-Email
+        # headers (test harness) so individual tests can control which identity
+        # is forwarded to LeafWiki. In a real deployment nginx would derive
+        # these from its own auth mechanism.
+        set $proxy_user $http_x_test_user;
+        set $proxy_email $http_x_test_email;
+        proxy_set_header Remote-User $proxy_user;
+        proxy_set_header Remote-Email $proxy_email;
+
+        proxy_pass         http://leafwiki-autocreate:8080;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+
+        # Forward cookies unchanged (needed for CSRF and JWT fallback tests).
+        proxy_pass_header  Set-Cookie;
+    }
+}

--- a/e2e-proxy/proxy_auth_test.go
+++ b/e2e-proxy/proxy_auth_test.go
@@ -2,17 +2,30 @@ package e2eproxy
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
-// doProxy makes a GET request through the nginx proxy.
+// doProxy makes a GET request through the default (auto-create off) nginx proxy.
 // Set testUser to non-empty to populate X-Test-User (nginx converts it to Remote-User).
 func doProxy(t *testing.T, path, testUser string, extraHeaders map[string]string) *http.Response {
 	t.Helper()
-	req, err := http.NewRequest(http.MethodGet, proxyURL+path, nil)
+	return doProxyAt(t, proxyURL, path, testUser, extraHeaders)
+}
+
+// doAutoCreateProxy is doProxy against the auto-create-enabled stack.
+func doAutoCreateProxy(t *testing.T, path, testUser string, extraHeaders map[string]string) *http.Response {
+	t.Helper()
+	return doProxyAt(t, autoCreateProxyURL, path, testUser, extraHeaders)
+}
+
+func doProxyAt(t *testing.T, baseURL, path, testUser string, extraHeaders map[string]string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, baseURL+path, nil)
 	if err != nil {
 		t.Fatalf("build request: %v", err)
 	}
@@ -48,11 +61,16 @@ func assertStatus(t *testing.T, resp *http.Response, want int) {
 }
 
 // loginAdmin obtains an access-token cookie by logging in as admin directly
-// via the proxy (the login endpoint is public and unaffected by proxy auth).
+// via the default proxy (the login endpoint is public and unaffected by proxy auth).
 func loginAdmin(t *testing.T) string {
 	t.Helper()
+	return loginAdminAt(t, proxyURL)
+}
+
+func loginAdminAt(t *testing.T, baseURL string) string {
+	t.Helper()
 	payload := `{"identifier":"admin","password":"admin"}`
-	req, err := http.NewRequest(http.MethodPost, proxyURL+"/api/auth/login", strings.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/api/auth/login", strings.NewReader(payload))
 	if err != nil {
 		t.Fatalf("build login request: %v", err)
 	}
@@ -85,10 +103,102 @@ func TestProxyAuth_ValidUser_Admin(t *testing.T) {
 }
 
 // TestProxyAuth_UnknownUser verifies that a proxy-provided username that does
-// not exist in LeafWiki results in 401.
+// not exist in LeafWiki results in 401 against the default (auto-create off)
+// stack — this is the shipped default and the behavior ADR-0010 promises stays
+// unchanged unless an operator opts in to auto-create.
 func TestProxyAuth_UnknownUser(t *testing.T) {
 	resp := doProxy(t, "/api/users", "no-such-user-xyz", nil)
 	assertStatus(t, resp, http.StatusUnauthorized)
+}
+
+// TestProxyAuth_AutoCreate_ProvisionsUnknownUser verifies that an unknown
+// proxy-asserted identity is auto-provisioned end-to-end through the real
+// nginx + LeafWiki stack (auto-create stack, port 8096), with the configured
+// default role and, when no email is forwarded, the synthesized placeholder
+// email.
+func TestProxyAuth_AutoCreate_ProvisionsUnknownUser(t *testing.T) {
+	username := fmt.Sprintf("e2e-autocreate-%d", time.Now().UnixNano())
+
+	resp := doAutoCreateProxy(t, "/api/config", username, nil)
+	assertStatus(t, resp, http.StatusOK)
+
+	found := findUserViaAdminAPI(t, autoCreateProxyURL, username)
+	if found.Role != "viewer" {
+		t.Errorf("expected auto-created role %q, got %q", "viewer", found.Role)
+	}
+	wantEmail := username + "@remote-user.invalid"
+	if found.Email != wantEmail {
+		t.Errorf("expected synthesized placeholder email %q, got %q", wantEmail, found.Email)
+	}
+}
+
+// TestProxyAuth_AutoCreate_UsesEmailHeader verifies that the optional email
+// header (X-Test-Email -> Remote-Email, mirroring
+// --http-remote-user-email-header-name) is used for the auto-created
+// account's email when present.
+func TestProxyAuth_AutoCreate_UsesEmailHeader(t *testing.T) {
+	username := fmt.Sprintf("e2e-autocreate-email-%d", time.Now().UnixNano())
+	email := username + "@example.com"
+
+	resp := doAutoCreateProxy(t, "/api/config", username, map[string]string{"X-Test-Email": email})
+	assertStatus(t, resp, http.StatusOK)
+
+	found := findUserViaAdminAPI(t, autoCreateProxyURL, username)
+	if found.Email != email {
+		t.Errorf("expected email from Remote-Email header %q, got %q", email, found.Email)
+	}
+}
+
+// TestProxyAuth_AutoCreate_EmailConflictReturns401 verifies that a brand-new
+// identity whose asserted email collides with a different, pre-existing
+// user (here: the stack's own default admin) is rejected with 401 rather
+// than a 500, and that no account is created as a side effect.
+func TestProxyAuth_AutoCreate_EmailConflictReturns401(t *testing.T) {
+	username := fmt.Sprintf("e2e-autocreate-conflict-%d", time.Now().UnixNano())
+
+	resp := doAutoCreateProxy(t, "/api/config", username, map[string]string{"X-Test-Email": "admin@localhost"})
+	assertStatus(t, resp, http.StatusUnauthorized)
+}
+
+type adminAPIUser struct {
+	Username string `json:"username"`
+	Email    string `json:"email"`
+	Role     string `json:"role"`
+}
+
+// findUserViaAdminAPI logs in as admin on baseURL's stack and returns the
+// user matching username from GET /api/users, failing the test if not found.
+func findUserViaAdminAPI(t *testing.T, baseURL, username string) adminAPIUser {
+	t.Helper()
+
+	token := loginAdminAt(t, baseURL)
+	req, err := http.NewRequest(http.MethodGet, baseURL+"/api/users", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.AddCookie(&http.Cookie{Name: "leafwiki_at", Value: token})
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("list users: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("list users failed %d: %s", resp.StatusCode, b)
+	}
+
+	var users []adminAPIUser
+	if err := json.NewDecoder(resp.Body).Decode(&users); err != nil {
+		t.Fatalf("decode users: %v", err)
+	}
+	for _, u := range users {
+		if u.Username == username {
+			return u
+		}
+	}
+	t.Fatalf("expected auto-created user %q to appear in /api/users", username)
+	return adminAPIUser{}
 }
 
 // TestProxyAuth_NoHeader_ProtectedRoute verifies that a request without

--- a/e2e-proxy/setup_test.go
+++ b/e2e-proxy/setup_test.go
@@ -16,8 +16,15 @@ import (
 	"time"
 )
 
-// proxyURL is the nginx entry point (all requests go through the proxy).
+// proxyURL is the nginx entry point for the default-config stack (auto-create
+// off — all requests go through the proxy).
 var proxyURL string
+
+// autoCreateProxyURL is the nginx entry point for the second stack, which runs
+// LeafWiki with --enable-http-remote-user-auto-create=true. Kept as a separate
+// stack/port so the default stack's "unknown user -> 401" behavior stays
+// covered end-to-end, rather than being replaced by the auto-create behavior.
+var autoCreateProxyURL string
 
 // directURL is the LeafWiki port exposed directly, used to verify that the
 // same Remote-User header is rejected when it does not come from nginx.
@@ -28,10 +35,16 @@ var directURL string
 
 func TestMain(m *testing.M) {
 	proxyURL = envOr("E2E_PROXY_URL", "http://localhost:8095")
+	autoCreateProxyURL = envOr("E2E_AUTOCREATE_PROXY_URL", "http://localhost:8096")
 	directURL = envOr("E2E_DIRECT_URL", "")
 
 	if err := waitReachable(proxyURL+"/api/config", 60*time.Second); err != nil {
 		fmt.Fprintf(os.Stderr, "LeafWiki proxy stack not reachable at %s: %v\n", proxyURL, err)
+		fmt.Fprintln(os.Stderr, "Start the stack first:  docker compose up -d --wait")
+		os.Exit(1)
+	}
+	if err := waitReachable(autoCreateProxyURL+"/api/config", 60*time.Second); err != nil {
+		fmt.Fprintf(os.Stderr, "LeafWiki auto-create proxy stack not reachable at %s: %v\n", autoCreateProxyURL, err)
 		fmt.Fprintln(os.Stderr, "Start the stack first:  docker compose up -d --wait")
 		os.Exit(1)
 	}

--- a/internal/core/auth/errors.go
+++ b/internal/core/auth/errors.go
@@ -11,6 +11,7 @@ var ErrLastAdminCannotBeDemoted = errors.New("cannot remove admin role from the 
 var ErrInvalidToken = errors.New("invalid token")
 var ErrSessionManagerNotWired = errors.New("session manager: resolveUser not configured (NewAuthService wires this; a SessionManager built directly must set it before use)")
 var ErrUserAccountLocked = errors.New("account temporarily locked due to too many failed login attempts")
+var ErrRemoteUserEmailConflict = errors.New("remote user auto-create: asserted email belongs to a different existing user")
 
 var ErrAPIKeyNotFound = errors.New("api key not found")
 var ErrAPIKeyInvalid = errors.New("invalid api key")

--- a/internal/core/auth/user_service.go
+++ b/internal/core/auth/user_service.go
@@ -276,14 +276,30 @@ func (s *UserService) GetUserByIdentifier(identifier string) (*User, error) {
 	return user, nil
 }
 
+// lookupRemoteUserByIdentifier resolves identifier as a username, falling
+// back to an email lookup. Unlike GetUserByIdentifier, it does not collapse
+// store errors into ErrUserNotFound: GetOrCreateRemoteUser auto-provisions on
+// ErrUserNotFound, so a transient store error (e.g. a DB hiccup) must not be
+// mistaken for "no such user" and trigger an unwanted account creation.
+func (s *UserService) lookupRemoteUserByIdentifier(identifier string) (*User, error) {
+	user, err := s.store.GetUserByUsername(identifier)
+	if err == nil {
+		return user, nil
+	}
+	if !errors.Is(err, ErrUserNotFound) {
+		return nil, err
+	}
+	return s.store.GetUserByEmail(identifier)
+}
+
 // GetOrCreateRemoteUser resolves identifier (username or email, same lookup as
-// GetUserByIdentifier) to an existing user, auto-provisioning a new one with a
-// random password and defaultRole if none exists. Used by the reverse-proxy
-// auto-create feature: identifier becomes the new user's username verbatim; if
-// email is empty, a non-deliverable placeholder is synthesized under the
-// RFC 2606 reserved ".invalid" TLD.
+// lookupRemoteUserByIdentifier) to an existing user, auto-provisioning a new
+// one with a random password and defaultRole if none exists. Used by the
+// reverse-proxy auto-create feature: identifier becomes the new user's
+// username verbatim; if email is empty, a non-deliverable placeholder is
+// synthesized under the RFC 2606 reserved ".invalid" TLD.
 func (s *UserService) GetOrCreateRemoteUser(identifier, email, defaultRole string) (*User, error) {
-	user, err := s.GetUserByIdentifier(identifier)
+	user, err := s.lookupRemoteUserByIdentifier(identifier)
 	if err == nil {
 		return user, nil
 	}
@@ -309,7 +325,7 @@ func (s *UserService) GetOrCreateRemoteUser(identifier, email, defaultRole strin
 			// different, unrelated existing user (identifier itself was never
 			// created). Disambiguate instead of assuming the race case: only treat
 			// it as recovered if identifier now resolves to a user.
-			if existing, lookupErr := s.GetUserByIdentifier(identifier); lookupErr == nil {
+			if existing, lookupErr := s.lookupRemoteUserByIdentifier(identifier); lookupErr == nil {
 				return existing, nil
 			}
 			return nil, ErrRemoteUserEmailConflict

--- a/internal/core/auth/user_service.go
+++ b/internal/core/auth/user_service.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -273,6 +274,51 @@ func (s *UserService) GetUserByIdentifier(identifier string) (*User, error) {
 		}
 	}
 	return user, nil
+}
+
+// GetOrCreateRemoteUser resolves identifier (username or email, same lookup as
+// GetUserByIdentifier) to an existing user, auto-provisioning a new one with a
+// random password and defaultRole if none exists. Used by the reverse-proxy
+// auto-create feature: identifier becomes the new user's username verbatim; if
+// email is empty, a non-deliverable placeholder is synthesized under the
+// RFC 2606 reserved ".invalid" TLD.
+func (s *UserService) GetOrCreateRemoteUser(identifier, email, defaultRole string) (*User, error) {
+	user, err := s.GetUserByIdentifier(identifier)
+	if err == nil {
+		return user, nil
+	}
+	if !errors.Is(err, ErrUserNotFound) {
+		return nil, err
+	}
+
+	if email == "" {
+		email = identifier + "@remote-user.invalid"
+	}
+
+	password, err := shared.GenerateRandomPassword(32)
+	if err != nil {
+		return nil, err
+	}
+
+	created, err := s.CreateUser(identifier, email, password, defaultRole)
+	if err != nil {
+		if errors.Is(err, ErrUserAlreadyExists) {
+			// CreateUser's ErrUserAlreadyExists means either identifier collided
+			// (we lost a create race against a concurrent request for the same new
+			// identifier — the expected, recoverable case) or email collided with a
+			// different, unrelated existing user (identifier itself was never
+			// created). Disambiguate instead of assuming the race case: only treat
+			// it as recovered if identifier now resolves to a user.
+			if existing, lookupErr := s.GetUserByIdentifier(identifier); lookupErr == nil {
+				return existing, nil
+			}
+			return nil, ErrRemoteUserEmailConflict
+		}
+		return nil, err
+	}
+
+	s.log.Info("remote user auto-provisioned", "userID", created.ID, "username", identifier, "role", defaultRole)
+	return created, nil
 }
 
 func (s *UserService) GetUserByEmailOrUsernameAndPassword(identifier, password string) (*User, error) {

--- a/internal/core/auth/user_service_test.go
+++ b/internal/core/auth/user_service_test.go
@@ -509,6 +509,25 @@ func TestUserService_GetOrCreateRemoteUser_InvalidRolePropagates(t *testing.T) {
 	}
 }
 
+func TestUserService_LookupRemoteUserByIdentifier_StoreErrorPropagates(t *testing.T) {
+	service := setupTestUserService(t)
+	defer test_utils.WrapCloseWithErrorCheck(service.Close, t)
+
+	// Simulate a transient store failure (e.g. a DB hiccup), not a genuine
+	// "user doesn't exist yet". GetOrCreateRemoteUser treats ErrUserNotFound
+	// as the auto-create trigger, so this lookup must surface the real store
+	// error instead of being misclassified as ErrUserNotFound — otherwise a
+	// transient failure would cause a spurious account to be provisioned.
+	if err := service.suspendStore(); err != nil {
+		t.Fatalf("suspendStore failed: %v", err)
+	}
+
+	_, err := service.lookupRemoteUserByIdentifier("henry")
+	if err == nil || errors.Is(err, ErrUserNotFound) {
+		t.Fatalf("expected the underlying store error, not ErrUserNotFound, got: %v", err)
+	}
+}
+
 func TestUserService_GetOrCreateRemoteUser_EmailConflictWithDifferentUserReturnsDistinctError(t *testing.T) {
 	service := setupTestUserService(t)
 	defer test_utils.WrapCloseWithErrorCheck(service.Close, t)

--- a/internal/core/auth/user_service_test.go
+++ b/internal/core/auth/user_service_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"errors"
+	"sync"
 	"testing"
 
 	sharederrors "github.com/perber/wiki/internal/core/shared/errors"
@@ -409,5 +410,184 @@ func TestUserService_DeleteUser_StoreSuspended_ReturnsStoreUnavailable(t *testin
 	localized, ok := sharederrors.AsLocalizedError(err)
 	if !ok || localized.Code != "auth_user_store_unavailable" {
 		t.Fatalf("expected auth_user_store_unavailable, got %v", err)
+	}
+}
+
+func TestUserService_GetOrCreateRemoteUser_CreatesNewUser(t *testing.T) {
+	service := setupTestUserService(t)
+	defer test_utils.WrapCloseWithErrorCheck(service.Close, t)
+
+	user, err := service.GetOrCreateRemoteUser("carol", "carol@example.com", RoleViewer)
+	if err != nil {
+		t.Fatalf("GetOrCreateRemoteUser failed: %v", err)
+	}
+
+	if user.Username != "carol" || user.Email != "carol@example.com" || user.Role != RoleViewer {
+		t.Errorf("User not created with expected data: %+v", user)
+	}
+}
+
+func TestUserService_GetOrCreateRemoteUser_ReturnsExistingUserOnSecondCall(t *testing.T) {
+	service := setupTestUserService(t)
+	defer test_utils.WrapCloseWithErrorCheck(service.Close, t)
+
+	first, err := service.GetOrCreateRemoteUser("carol", "carol@example.com", RoleViewer)
+	if err != nil {
+		t.Fatalf("first GetOrCreateRemoteUser failed: %v", err)
+	}
+
+	second, err := service.GetOrCreateRemoteUser("carol", "carol@example.com", RoleViewer)
+	if err != nil {
+		t.Fatalf("second GetOrCreateRemoteUser failed: %v", err)
+	}
+
+	if second.ID != first.ID {
+		t.Errorf("expected same user on second call, got different IDs: %s vs %s", first.ID, second.ID)
+	}
+
+	users, err := service.GetUsers()
+	if err != nil {
+		t.Fatalf("GetUsers failed: %v", err)
+	}
+	count := 0
+	for _, u := range users {
+		if u.Username == "carol" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly one 'carol' user, got %d", count)
+	}
+}
+
+func TestUserService_GetOrCreateRemoteUser_ReturnsExistingUserByEmail(t *testing.T) {
+	service := setupTestUserService(t)
+	defer test_utils.WrapCloseWithErrorCheck(service.Close, t)
+
+	preexisting, err := service.CreateUser("dave", "dave@example.com", "secure", RoleEditor)
+	if err != nil {
+		t.Fatalf("CreateUser failed: %v", err)
+	}
+
+	// Proxy asserts dave's email, not his username; GetOrCreateRemoteUser must
+	// resolve to the pre-existing account rather than creating a duplicate.
+	resolved, err := service.GetOrCreateRemoteUser("dave@example.com", "", RoleViewer)
+	if err != nil {
+		t.Fatalf("GetOrCreateRemoteUser failed: %v", err)
+	}
+
+	if resolved.ID != preexisting.ID {
+		t.Errorf("expected to resolve pre-existing user %s, got %s", preexisting.ID, resolved.ID)
+	}
+	if resolved.Role != RoleEditor {
+		t.Errorf("expected existing role to be preserved, got %s", resolved.Role)
+	}
+}
+
+func TestUserService_GetOrCreateRemoteUser_SynthesizesPlaceholderEmailWhenNoneGiven(t *testing.T) {
+	service := setupTestUserService(t)
+	defer test_utils.WrapCloseWithErrorCheck(service.Close, t)
+
+	user, err := service.GetOrCreateRemoteUser("erin", "", RoleViewer)
+	if err != nil {
+		t.Fatalf("GetOrCreateRemoteUser failed: %v", err)
+	}
+
+	want := "erin@remote-user.invalid"
+	if user.Email != want {
+		t.Errorf("expected synthesized email %q, got %q", want, user.Email)
+	}
+}
+
+func TestUserService_GetOrCreateRemoteUser_InvalidRolePropagates(t *testing.T) {
+	service := setupTestUserService(t)
+	defer test_utils.WrapCloseWithErrorCheck(service.Close, t)
+
+	_, err := service.GetOrCreateRemoteUser("frank", "frank@example.com", "guest")
+	if err != ErrUserInvalidRole {
+		t.Errorf("expected ErrUserInvalidRole, got: %v", err)
+	}
+}
+
+func TestUserService_GetOrCreateRemoteUser_EmailConflictWithDifferentUserReturnsDistinctError(t *testing.T) {
+	service := setupTestUserService(t)
+	defer test_utils.WrapCloseWithErrorCheck(service.Close, t)
+
+	// A pre-existing, unrelated user already owns this email.
+	_, err := service.CreateUser("dave", "shared@example.com", "secure", RoleEditor)
+	if err != nil {
+		t.Fatalf("CreateUser failed: %v", err)
+	}
+
+	// A brand-new identifier ("newperson") whose asserted email collides with
+	// dave's — not a race on the same identifier, so this must not silently
+	// resolve to dave (account confusion) nor hang the caller with a generic
+	// "not found" after the failed create.
+	_, err = service.GetOrCreateRemoteUser("newperson", "shared@example.com", RoleViewer)
+	if !errors.Is(err, ErrRemoteUserEmailConflict) {
+		t.Errorf("expected ErrRemoteUserEmailConflict, got: %v", err)
+	}
+
+	// "newperson" must not have been created as a side effect.
+	if _, err := service.GetUserByUsername("newperson"); !errors.Is(err, ErrUserNotFound) {
+		t.Errorf("expected 'newperson' to not exist, got err: %v", err)
+	}
+}
+
+func TestUserService_GetOrCreateRemoteUser_ConcurrentCallsCreateExactlyOneUser(t *testing.T) {
+	service := setupTestUserService(t)
+	defer test_utils.WrapCloseWithErrorCheck(service.Close, t)
+
+	const goroutines = 20
+	results := make(chan *User, goroutines)
+	errs := make(chan error, goroutines)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			user, err := service.GetOrCreateRemoteUser("grace", "grace@example.com", RoleViewer)
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- user
+		}()
+	}
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	for err := range errs {
+		t.Errorf("GetOrCreateRemoteUser returned error: %v", err)
+	}
+
+	var firstID string
+	count := 0
+	for user := range results {
+		count++
+		if firstID == "" {
+			firstID = user.ID
+		} else if user.ID != firstID {
+			t.Errorf("expected all concurrent calls to resolve to the same user ID, got %s and %s", firstID, user.ID)
+		}
+	}
+	if count != goroutines {
+		t.Errorf("expected %d results, got %d", goroutines, count)
+	}
+
+	users, err := service.GetUsers()
+	if err != nil {
+		t.Fatalf("GetUsers failed: %v", err)
+	}
+	graceCount := 0
+	for _, u := range users {
+		if u.Username == "grace" {
+			graceCount++
+		}
+	}
+	if graceCount != 1 {
+		t.Errorf("expected exactly one 'grace' user to have been created, got %d", graceCount)
 	}
 }

--- a/internal/http/middleware/auth/reverse_proxy.go
+++ b/internal/http/middleware/auth/reverse_proxy.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -11,8 +12,21 @@ import (
 
 // RemoteUserConfig holds the configuration for reverse-proxy-based authentication.
 type RemoteUserConfig struct {
-	Enabled        bool
-	HeaderName     string
+	Enabled bool
+	// HeaderName carries the identity a trusted proxy asserts (username or email,
+	// resolved via UserService.GetUserByIdentifier).
+	HeaderName string
+	// AutoCreate, when true, provisions a new user for an identifier that has no
+	// matching account instead of rejecting the request with 401. Off by default;
+	// see ADR-0010 for why this is a separate opt-in from Enabled.
+	AutoCreate bool
+	// EmailHeaderName is an optional second header supplying the email address for
+	// newly auto-created users. Only consulted when AutoCreate is true; if empty or
+	// absent, a non-deliverable placeholder is synthesized instead.
+	EmailHeaderName string
+	// DefaultRole is the role assigned to auto-created users. Only meaningful when
+	// AutoCreate is true.
+	DefaultRole    string
 	TrustedProxies *TrustedProxies
 	// UserService is resolved on every request rather than captured once when
 	// the router is built, so it automatically tracks a live restore's
@@ -28,8 +42,11 @@ type RemoteUserConfig struct {
 // Behaviour by case:
 //   - disabled or untrusted source IP → no-op, normal auth applies
 //   - trusted IP, header absent       → no-op (public endpoints remain reachable)
-//   - trusted IP, header present, user found     → user set in context
-//   - trusted IP, header present, user not found → 401 (proxy claims unknown user)
+//   - trusted IP, header present, user found         → user set in context
+//   - trusted IP, header present, user not found,
+//     AutoCreate disabled                            → 401 (proxy claims unknown user)
+//   - trusted IP, header present, user not found,
+//     AutoCreate enabled                             → user is provisioned and set in context
 func InjectRemoteUser(cfg RemoteUserConfig) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if !cfg.Enabled {
@@ -58,11 +75,28 @@ func InjectRemoteUser(cfg RemoteUserConfig) gin.HandlerFunc {
 			return
 		}
 
-		user, err := cfg.UserService().GetUserByIdentifier(identifier)
-		if err != nil {
-			slog.Default().Warn("reverse proxy auth: user not found", "identifier", identifier, "remote_addr", c.Request.RemoteAddr)
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "reverse proxy auth: user not found"})
-			return
+		var user *coreauth.User
+		var err error
+		if cfg.AutoCreate {
+			email := strings.TrimSpace(c.GetHeader(cfg.EmailHeaderName))
+			user, err = cfg.UserService().GetOrCreateRemoteUser(identifier, email, cfg.DefaultRole)
+			if err != nil {
+				if errors.Is(err, coreauth.ErrRemoteUserEmailConflict) {
+					slog.Default().Warn("reverse proxy auth: auto-create blocked, asserted email belongs to a different user", "identifier", identifier, "remote_addr", c.Request.RemoteAddr)
+					c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "reverse proxy auth: user not found"})
+					return
+				}
+				slog.Default().Error("reverse proxy auth: auto-create failed", "identifier", identifier, "remote_addr", c.Request.RemoteAddr, "error", err)
+				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "reverse proxy auth: failed to provision user"})
+				return
+			}
+		} else {
+			user, err = cfg.UserService().GetUserByIdentifier(identifier)
+			if err != nil {
+				slog.Default().Warn("reverse proxy auth: user not found", "identifier", identifier, "remote_addr", c.Request.RemoteAddr)
+				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "reverse proxy auth: user not found"})
+				return
+			}
 		}
 
 		c.Set("user", user)

--- a/internal/http/middleware/auth/reverse_proxy_test.go
+++ b/internal/http/middleware/auth/reverse_proxy_test.go
@@ -379,6 +379,180 @@ func TestInjectRemoteUser_ReflectsLiveRestore(t *testing.T) {
 	}
 }
 
+func TestInjectRemoteUser_AutoCreateDisabled_UnknownUserStill401s(t *testing.T) {
+	f := createProxyFixture(t)
+	cleanupWithErrorCheck(t, "proxy fixture", f.close)
+
+	cfg := authmw.RemoteUserConfig{
+		Enabled:        true,
+		HeaderName:     "Remote-User",
+		AutoCreate:     false,
+		TrustedProxies: mustParseTrustedProxies(t, "127.0.0.1"),
+		UserService:    f.userService,
+	}
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	req.Header.Set("Remote-User", "ghost")
+	w := httptest.NewRecorder()
+
+	proxyRouter(cfg).ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for unknown user with auto-create disabled, got %d", w.Code)
+	}
+}
+
+func TestInjectRemoteUser_AutoCreateEnabled_ProvisionsUnknownUser(t *testing.T) {
+	f := createProxyFixture(t)
+	cleanupWithErrorCheck(t, "proxy fixture", f.close)
+
+	cfg := authmw.RemoteUserConfig{
+		Enabled:        true,
+		HeaderName:     "Remote-User",
+		AutoCreate:     true,
+		DefaultRole:    coreauth.RoleViewer,
+		TrustedProxies: mustParseTrustedProxies(t, "127.0.0.1"),
+		UserService:    f.userService,
+	}
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	req.Header.Set("Remote-User", "newperson")
+	w := httptest.NewRecorder()
+
+	proxyRouter(cfg).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 with auto-create enabled, got %d: %s", w.Code, w.Body.String())
+	}
+	if body := w.Body.String(); body != `{"username":"newperson"}` {
+		t.Errorf("unexpected body: %s", body)
+	}
+
+	user, err := f.userService().GetUserByIdentifier("newperson")
+	if err != nil {
+		t.Fatalf("expected auto-created user to be persisted: %v", err)
+	}
+	if user.Role != coreauth.RoleViewer {
+		t.Errorf("expected auto-created user to have role %q, got %q", coreauth.RoleViewer, user.Role)
+	}
+	if user.Email != "newperson@remote-user.invalid" {
+		t.Errorf("expected synthesized placeholder email, got %q", user.Email)
+	}
+}
+
+func TestInjectRemoteUser_AutoCreateEnabled_UsesEmailHeader(t *testing.T) {
+	f := createProxyFixture(t)
+	cleanupWithErrorCheck(t, "proxy fixture", f.close)
+
+	cfg := authmw.RemoteUserConfig{
+		Enabled:         true,
+		HeaderName:      "Remote-User",
+		AutoCreate:      true,
+		EmailHeaderName: "Remote-Email",
+		DefaultRole:     coreauth.RoleViewer,
+		TrustedProxies:  mustParseTrustedProxies(t, "127.0.0.1"),
+		UserService:     f.userService,
+	}
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	req.Header.Set("Remote-User", "newperson")
+	req.Header.Set("Remote-Email", "newperson@example.com")
+	w := httptest.NewRecorder()
+
+	proxyRouter(cfg).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	user, err := f.userService().GetUserByIdentifier("newperson")
+	if err != nil {
+		t.Fatalf("expected auto-created user to be persisted: %v", err)
+	}
+	if user.Email != "newperson@example.com" {
+		t.Errorf("expected email from Remote-Email header, got %q", user.Email)
+	}
+}
+
+func TestInjectRemoteUser_AutoCreateEnabled_EmailConflictWithDifferentUserReturns401(t *testing.T) {
+	f := createProxyFixture(t)
+	cleanupWithErrorCheck(t, "proxy fixture", f.close)
+
+	cfg := authmw.RemoteUserConfig{
+		Enabled:         true,
+		HeaderName:      "Remote-User",
+		AutoCreate:      true,
+		EmailHeaderName: "Remote-Email",
+		DefaultRole:     coreauth.RoleViewer,
+		TrustedProxies:  mustParseTrustedProxies(t, "127.0.0.1"),
+		UserService:     f.userService,
+	}
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	req.Header.Set("Remote-User", "newperson")
+	// admin@localhost is the fixture's pre-existing default admin's email —
+	// not a race on "newperson", but a genuine conflict with a different user.
+	req.Header.Set("Remote-Email", "admin@localhost")
+	w := httptest.NewRecorder()
+
+	proxyRouter(cfg).ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for email conflict with a different user, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if _, err := f.userService().GetUserByIdentifier("newperson"); err == nil {
+		t.Error("expected 'newperson' to not have been created as a side effect of the conflict")
+	}
+}
+
+func TestInjectRemoteUser_AutoCreateEnabled_SecondRequestReusesSameUser(t *testing.T) {
+	f := createProxyFixture(t)
+	cleanupWithErrorCheck(t, "proxy fixture", f.close)
+
+	cfg := authmw.RemoteUserConfig{
+		Enabled:        true,
+		HeaderName:     "Remote-User",
+		AutoCreate:     true,
+		DefaultRole:    coreauth.RoleViewer,
+		TrustedProxies: mustParseTrustedProxies(t, "127.0.0.1"),
+		UserService:    f.userService,
+	}
+
+	router := proxyRouter(cfg)
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.RemoteAddr = "127.0.0.1:1234"
+		req.Header.Set("Remote-User", "newperson")
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("request %d: expected 200, got %d: %s", i, w.Code, w.Body.String())
+		}
+	}
+
+	users, err := f.userService().GetUsers()
+	if err != nil {
+		t.Fatalf("GetUsers failed: %v", err)
+	}
+	count := 0
+	for _, u := range users {
+		if u.Username == "newperson" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly one 'newperson' user after two requests, got %d", count)
+	}
+}
+
 // TestInjectRemoteUser_WithRequireAuth verifies the full middleware chain:
 // InjectRemoteUser sets the user, then RequireAuth short-circuits JWT validation.
 func TestInjectRemoteUser_WithRequireAuth(t *testing.T) {

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -77,9 +77,12 @@ func disableClientCache(c *gin.Context) {
 
 // HTTPRemoteUserConfig configures reverse-proxy-based authentication.
 type HTTPRemoteUserConfig struct {
-	Enabled        bool
-	HeaderName     string
-	TrustedProxies *auth_middleware.TrustedProxies
+	Enabled         bool
+	HeaderName      string
+	AutoCreate      bool   // Whether to auto-provision users asserted by the proxy but unknown to LeafWiki
+	EmailHeaderName string // Optional header supplying the email for auto-created users
+	DefaultRole     string // Role assigned to auto-created users
+	TrustedProxies  *auth_middleware.TrustedProxies
 	// UserService is resolved on every request rather than captured once
 	// here — see auth_middleware.RemoteUserConfig.UserService.
 	UserService func() *coreauth.UserService
@@ -161,10 +164,13 @@ func NewRouter(registrars []RouteRegistrar, frontendCfg FrontendConfig, opts Rou
 
 	if opts.HTTPRemoteUser.Enabled {
 		base.Use(auth_middleware.InjectRemoteUser(auth_middleware.RemoteUserConfig{
-			Enabled:        opts.HTTPRemoteUser.Enabled,
-			HeaderName:     opts.HTTPRemoteUser.HeaderName,
-			TrustedProxies: opts.HTTPRemoteUser.TrustedProxies,
-			UserService:    opts.HTTPRemoteUser.UserService,
+			Enabled:         opts.HTTPRemoteUser.Enabled,
+			HeaderName:      opts.HTTPRemoteUser.HeaderName,
+			AutoCreate:      opts.HTTPRemoteUser.AutoCreate,
+			EmailHeaderName: opts.HTTPRemoteUser.EmailHeaderName,
+			DefaultRole:     opts.HTTPRemoteUser.DefaultRole,
+			TrustedProxies:  opts.HTTPRemoteUser.TrustedProxies,
+			UserService:     opts.HTTPRemoteUser.UserService,
 		}))
 	}
 


### PR DESCRIPTION
Adds an opt-in --enable-http-remote-user-auto-create flag so a proxy-asserted identity with no matching LeafWiki account gets provisioned instead of rejected (401), with a configurable default role and optional email header. Off by default and layered on top of the existing reverse-proxy header auth (#971); the default role can never be admin, so a misconfigured trusted-proxy allowlist can mint new low-privilege accounts at worst, not admins.
