### PR TITLE
feat(page): add section sorting options

### DIFF
--- a/ui/leafwiki-ui/src/features/page/SortPagesDialog.test.tsx
+++ b/ui/leafwiki-ui/src/features/page/SortPagesDialog.test.tsx
@@ -1,0 +1,161 @@
+import { NODE_KIND_PAGE, NODE_KIND_SECTION, sortPages } from '@/lib/api/pages'
+import type { PageNode } from '@/lib/api/pages'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SortPagesDialog } from './SortPagesDialog'
+
+vi.mock('@/components/BaseDialog', () => ({
+  default: ({
+    children,
+    buttons,
+    onConfirm,
+  }: {
+    children?: ReactNode
+    buttons?: { label: string; actionType: string }[]
+    onConfirm: (type: string) => Promise<boolean>
+  }) => (
+    <div>
+      {children}
+      {buttons?.map((button) => (
+        <button
+          key={button.actionType}
+          data-testid={`sort-pages-dialog-button-${button.actionType}`}
+          onClick={() => void onConfirm(button.actionType)}
+        >
+          {button.label}
+        </button>
+      ))}
+    </div>
+  ),
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: {
+    type: '3rdParty',
+    init: () => {},
+  },
+  useTranslation: () => ({
+    t: (key: string) =>
+      ({
+        'sortDialog.ascending': 'A → Z',
+        'sortDialog.descending': 'Z → A',
+        'sortDialog.sectionsFirst': 'Sections First',
+        'sortDialog.sectionsLast': 'Sections Last',
+        'sortDialog.save': 'Save',
+      })[key] ?? key,
+  }),
+}))
+
+vi.mock('@/lib/api/pages', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api/pages')>()
+  return {
+    ...actual,
+    sortPages: vi.fn(),
+  }
+})
+
+vi.mock('@/stores/tree', () => ({
+  useTreeStore: (
+    selector: (state: { reloadTree: () => Promise<void> }) => unknown,
+  ) => selector({ reloadTree: vi.fn() }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn() },
+}))
+
+const child = (
+  id: string,
+  title: string,
+  kind: PageNode['kind'],
+): PageNode => ({
+  id,
+  title,
+  slug: id,
+  path: `/${id}`,
+  version: '1',
+  children: null,
+  kind,
+})
+
+const parent: PageNode = {
+  id: 'root',
+  title: 'Root',
+  slug: 'root',
+  path: '/',
+  version: '1',
+  kind: NODE_KIND_SECTION,
+  children: [
+    child('home', 'Home', NODE_KIND_PAGE),
+    child('guides', 'Guides', NODE_KIND_SECTION),
+    child('about', 'About', NODE_KIND_PAGE),
+    child('development', 'Development', NODE_KIND_SECTION),
+  ],
+}
+
+const displayedTitles = () =>
+  screen
+    .getAllByTestId(/^sort-page-title-/)
+    .map((element) => element.textContent)
+
+describe('SortPagesDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('sorts sections first and saves the grouped order', async () => {
+    const user = userEvent.setup()
+    render(<SortPagesDialog parent={parent} />)
+
+    await user.click(screen.getByTestId('sort-sections-first-button'))
+
+    expect(displayedTitles()).toEqual([
+      'Development',
+      'Guides',
+      'About',
+      'Home',
+    ])
+
+    fireEvent.click(screen.getByTestId('sort-pages-dialog-button-confirm'))
+
+    await waitFor(() => {
+      expect(sortPages).toHaveBeenCalledWith('root', [
+        'development',
+        'guides',
+        'about',
+        'home',
+      ])
+    })
+  })
+
+  it('sorts sections last using the selected descending direction', async () => {
+    const user = userEvent.setup()
+    render(<SortPagesDialog parent={parent} />)
+
+    await user.click(screen.getByTestId('sort-za-button'))
+    await user.click(screen.getByTestId('sort-sections-last-button'))
+
+    expect(displayedTitles()).toEqual([
+      'Home',
+      'About',
+      'Guides',
+      'Development',
+    ])
+  })
+
+  it('keeps the existing alphabetical sort across all children', async () => {
+    const user = userEvent.setup()
+    render(<SortPagesDialog parent={parent} />)
+
+    await user.click(screen.getByTestId('sort-az-button'))
+
+    expect(displayedTitles()).toEqual([
+      'About',
+      'Development',
+      'Guides',
+      'Home',
+    ])
+  })
+})

--- a/ui/leafwiki-ui/src/features/page/SortPagesDialog.tsx
+++ b/ui/leafwiki-ui/src/features/page/SortPagesDialog.tsx
@@ -1,7 +1,8 @@
 // components/page/SortPagesDialog.tsx
 import BaseDialog from '@/components/BaseDialog'
 import { Button } from '@/components/ui/button'
-import { NODE_KIND_PAGE, PageNode, sortPages } from '@/lib/api/pages'
+import { NODE_KIND_PAGE, NODE_KIND_SECTION, sortPages } from '@/lib/api/pages'
+import type { PageNode } from '@/lib/api/pages'
 import { handleFieldErrors } from '@/lib/handleFieldErrors'
 import { DIALOG_SORT_PAGES } from '@/lib/registries'
 import { useTreeStore } from '@/stores/tree'
@@ -111,6 +112,7 @@ export function SortPagesDialog({ parent }: { parent: PageNode }) {
       ? t('common.pageCapitalized')
       : t('common.sectionCapitalized')
   const [order, setOrder] = useState(parent.children?.map((c) => c.id) || [])
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc')
   const [loading, setLoading] = useState(false)
   const [, setFieldErrors] = useState<Record<string, string>>({})
   const reloadTree = useTreeStore((s) => s.reloadTree)
@@ -156,16 +158,38 @@ export function SortPagesDialog({ parent }: { parent: PageNode }) {
     }
   }
 
-  const sortAlphabetically = (direction: 'asc' | 'desc') => {
+  const applySort = (
+    direction: 'asc' | 'desc',
+    sectionPosition?: 'first' | 'last',
+  ) => {
     setOrder((prev) =>
       [...prev].sort((a, b) => {
-        const titleA = nodeMap.get(a)?.title ?? ''
-        const titleB = nodeMap.get(b)?.title ?? ''
+        const nodeA = nodeMap.get(a)
+        const nodeB = nodeMap.get(b)
+
+        if (sectionPosition && nodeA?.kind !== nodeB?.kind) {
+          if (nodeA?.kind === NODE_KIND_SECTION) {
+            return sectionPosition === 'first' ? -1 : 1
+          }
+          return sectionPosition === 'first' ? 1 : -1
+        }
+
+        const titleA = nodeA?.title ?? ''
+        const titleB = nodeB?.title ?? ''
         return direction === 'asc'
           ? titleA.localeCompare(titleB)
           : titleB.localeCompare(titleA)
       }),
     )
+  }
+
+  const sortAlphabetically = (direction: 'asc' | 'desc') => {
+    setSortDirection(direction)
+    applySort(direction)
+  }
+
+  const sortBySectionPosition = (position: 'first' | 'last') => {
+    applySort(sortDirection, position)
   }
 
   const handleSave = async (): Promise<boolean> => {
@@ -236,6 +260,27 @@ export function SortPagesDialog({ parent }: { parent: PageNode }) {
           onClick={() => sortAlphabetically('desc')}
         >
           {t('sortDialog.descending')}
+        </Button>
+      </div>
+      <div className="sort-pages-dialog__toolbar">
+        <span className="sort-pages-dialog__toolbar-label">
+          {t('sortDialog.sortSections')}
+        </span>
+        <Button
+          variant="outline"
+          size="sm"
+          data-testid="sort-sections-first-button"
+          onClick={() => sortBySectionPosition('first')}
+        >
+          {t('sortDialog.sectionsFirst')}
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          data-testid="sort-sections-last-button"
+          onClick={() => sortBySectionPosition('last')}
+        >
+          {t('sortDialog.sectionsLast')}
         </Button>
       </div>
       <DndContext

--- a/ui/leafwiki-ui/src/locales/en/page.json
+++ b/ui/leafwiki-ui/src/locales/en/page.json
@@ -53,11 +53,14 @@
     "sortedToast": "{{item}} children sorted successfully",
     "sortErrorFallback": "Error sorting {{item}} children",
     "title": "Sort {{item}} Children",
-    "description": "Drag items to reorder, use the arrows, or sort alphabetically. Changes are saved after clicking 'Save'.",
+    "description": "Drag items to reorder, use the arrows, or choose a sorting option. Changes are saved after clicking 'Save'.",
     "save": "Save",
     "sortAlphabetically": "Sort alphabetically:",
     "ascending": "A → Z",
-    "descending": "Z → A"
+    "descending": "Z → A",
+    "sortSections": "Group sections:",
+    "sectionsFirst": "Sections First",
+    "sectionsLast": "Sections Last"
   },
   "copyDialog": {
     "slugNotGenerated": "Slug could not be generated. Please enter it manually.",


### PR DESCRIPTION
Fixes #1357.

Adds Sections First and Sections Last actions to the sort dialog. Both options respect the selected A-Z or Z-A direction and save through the existing ordering API.

Tests:

- `npm test -- SortPagesDialog.test.tsx`
- `npm run lint`
- `npm run build`
- Prettier check on changed files
