### PR TITLE
chore: gitignore local AI-agent config and loadtest results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,8 @@ ui.zip
 # local embedded frontend output for fast E2E runs
 internal/http/dist/*
 !internal/http/dist/.gitkeep
+
+# local-only AI agent config/docs (never pushed, see CLAUDE.md)
+/CLAUDE.md
+/AGENTS.md
+/.claude/

--- a/loadtest/.gitignore
+++ b/loadtest/.gitignore
@@ -1,0 +1,4 @@
+seed/.session-pool.json
+seed/.admin-session.json
+seed/.writer-accounts.json
+results/


### PR DESCRIPTION
CLAUDE.md, AGENTS.md, and .claude/ are local-only working files and should never be pushed. loadtest/.gitignore mirrors the pattern already used on feature/load-optimization to keep results/ and seed session files out of version control.