### PR TITLE
fix(sidebar): make accordion section header clickable, not just chevron

### DIFF
--- a/ui/leafwiki-ui/src/features/sidebar/SidebarAccordionSection.test.tsx
+++ b/ui/leafwiki-ui/src/features/sidebar/SidebarAccordionSection.test.tsx
@@ -77,6 +77,20 @@ describe('SidebarAccordionSection', () => {
     expect(onValueChangeSpy).toHaveBeenCalledWith(['pinned'])
   })
 
+  it('collapses the section when the title area is clicked', () => {
+    const onValueChangeSpy = vi.fn()
+    render(
+      <ControlledAccordion
+        defaultValue={['pinned']}
+        onValueChangeSpy={onValueChangeSpy}
+      />,
+    )
+
+    fireEvent.click(screen.getByText('Pinned'))
+
+    expect(onValueChangeSpy).toHaveBeenCalledWith([])
+  })
+
   it('clicking an action button does not toggle the section', () => {
     const onValueChangeSpy = vi.fn()
     render(

--- a/ui/leafwiki-ui/src/features/sidebar/SidebarAccordionSection.tsx
+++ b/ui/leafwiki-ui/src/features/sidebar/SidebarAccordionSection.tsx
@@ -31,13 +31,15 @@ export function SidebarAccordionSection({
       className={cn('sidebar-accordion-section', className)}
     >
       <AccordionPrimitive.Header className="sidebar-accordion-section__header">
-        <div className="sidebar-accordion-section__title">
-          {icon}
-          <span>{title}</span>
-          {typeof count === 'number' && (
-            <span className="sidebar-accordion-section__count">{count}</span>
-          )}
-        </div>
+        <AccordionPrimitive.Trigger asChild id={undefined}>
+          <button type="button" className="sidebar-accordion-section__title">
+            {icon}
+            <span>{title}</span>
+            {typeof count === 'number' && (
+              <span className="sidebar-accordion-section__count">{count}</span>
+            )}
+          </button>
+        </AccordionPrimitive.Trigger>
         <div className="sidebar-accordion-section__actions">
           {actions}
           <AccordionPrimitive.Trigger asChild>

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -2526,7 +2526,11 @@
   }
 
   .sidebar-accordion-section__title {
-    @apply text-muted flex items-center gap-1 text-xs font-medium tracking-wide uppercase select-none;
+    @apply text-muted hover:text-interface-text flex cursor-pointer items-center gap-1 text-xs font-medium tracking-wide uppercase select-none;
+    background: none;
+    border: none;
+    padding: 0;
+    text-align: left;
   }
 
   .sidebar-accordion-section__count {


### PR DESCRIPTION
Wraps the title/icon area in its own AccordionPrimitive.Trigger, sibling to the existing chevron trigger, so clicking anywhere on the header toggles the section while the actions slot stays independently clickable.
