### PR TITLE
fix: prefer exact title match over route-path for slash-containing wi…

### DIFF
--- a/internal/links/helpers.go
+++ b/internal/links/helpers.go
@@ -120,12 +120,18 @@ func extractWikiLinksFromMarkdown(content string) []string {
 
 // resolveWikiLinkTargets resolves [[Title]] and [[Folder/Title]] targets.
 //
-// Targets containing "/" are first tried as direct route-path lookups
-// ([[Folder/Title]] → /folder/title). If the path lookup fails, the target
-// is retried as a full title (handles titles like "C/C++"). A single title
-// match resolves the link; zero or N>1 matches produce a broken sentinel
-// stored as "wikilink:<target>" so the healing infrastructure can later
-// find and fix the record when a matching page is created.
+// Every target — including one containing "/" — is tried as a title lookup
+// first. A single title match always wins, even for a target like "TCP/IP"
+// or "C/C++ Guide" that also happens to look like a route path; this is
+// deliberate so a wikilink always prefers the page whose actual title
+// matches, rather than silently resolving to an unrelated page that just
+// happens to share a slug path. Only when there is NO title match at all is
+// a slash-containing target retried as a direct route-path lookup
+// ([[Folder/Title]] → /folder/title), which supports nested-path link hints
+// that are not real page titles. An ambiguous title match (N>1) is treated
+// the same as the plain-title case below — broken — rather than falling
+// back to a route-path guess, for consistency: ambiguity is always surfaced
+// as broken, never silently resolved via a different mechanism.
 func resolveWikiLinkTargets(treeService *tree.TreeService, targets []string) []TargetLink {
 	if !treeService.IsLoaded() || len(targets) == 0 {
 		return nil
@@ -134,18 +140,6 @@ func resolveWikiLinkTargets(treeService *tree.TreeService, targets []string) []T
 	var result []TargetLink
 	for _, target := range targets {
 		if strings.Contains(target, "/") {
-			routePath := strings.TrimPrefix(target, "/")
-			page, err := treeService.FindPageByRoutePath(routePath)
-			if err == nil && page != nil {
-				result = append(result, TargetLink{
-					TargetPageID:   page.ID,
-					TargetPagePath: normalizeWikiPath(page.CalculatePath()),
-					Broken:         false,
-				})
-				continue
-			}
-			// Path lookup failed — fall through to title lookup so that
-			// titles containing "/" (e.g. "C/C++") can still be resolved.
 			pages := treeService.FindPagesByTitle(target)
 			if len(pages) == 1 {
 				result = append(result, TargetLink{
@@ -155,11 +149,32 @@ func resolveWikiLinkTargets(treeService *tree.TreeService, targets []string) []T
 				})
 				continue
 			}
-			// Store as a normal broken route path so HealLinksForExactPath
-			// can heal it when the page is later created at that path.
+			if len(pages) == 0 {
+				// No title matches this exact string — retry as a
+				// route-path hint (e.g. [[some/nested/page]]).
+				routePath := strings.TrimPrefix(target, "/")
+				page, err := treeService.FindPageByRoutePath(routePath)
+				if err == nil && page != nil {
+					result = append(result, TargetLink{
+						TargetPageID:   page.ID,
+						TargetPagePath: normalizeWikiPath(page.CalculatePath()),
+						Broken:         false,
+					})
+					continue
+				}
+				// Store as a normal broken route path so
+				// HealLinksForExactPath can heal it when the page is later
+				// created at that path.
+				result = append(result, TargetLink{
+					Broken:         true,
+					TargetPagePath: "/" + routePath,
+				})
+				continue
+			}
+			// N>1 title matches — ambiguous, same as the plain-title case.
 			result = append(result, TargetLink{
 				Broken:         true,
-				TargetPagePath: "/" + routePath,
+				TargetPagePath: wikilinkSentinel(target),
 			})
 			continue
 		}

--- a/internal/links/link_service_test.go
+++ b/internal/links/link_service_test.go
@@ -1468,8 +1468,8 @@ func TestResolveWikiLinkTargets_SlashTitleFallback(t *testing.T) {
 		t.Fatalf("CreateNode: %v", err)
 	}
 
-	// "C/C++ Guide" contains "/" so it tries path lookup first,
-	// then falls back to title lookup.
+	// "C/C++ Guide" contains "/" but is tried as a title first and resolves
+	// directly — no colliding route path exists in this tree.
 	targets := resolveWikiLinkTargets(ts, []string{"C/C++ Guide"})
 	if len(targets) != 1 {
 		t.Fatalf("expected 1 result, got %d", len(targets))
@@ -1479,6 +1479,76 @@ func TestResolveWikiLinkTargets_SlashTitleFallback(t *testing.T) {
 	}
 	if targets[0].TargetPageID != *idPtr {
 		t.Errorf("TargetPageID = %q, want %q", targets[0].TargetPageID, *idPtr)
+	}
+}
+
+// TestResolveWikiLinkTargets_SlashTitle_PrefersTitleOverCollidingRoutePath is
+// the regression test for "WikiLinks Break When the Target Title Contains a
+// Slash": a page titled "TCP/IP" must resolve to itself even when an
+// unrelated route path "tcp/ip" also exists in the tree — before the fix,
+// the route-path lookup was tried first and silently won, resolving the
+// link to the wrong page with Broken staying false.
+func TestResolveWikiLinkTargets_SlashTitle_PrefersTitleOverCollidingRoutePath(t *testing.T) {
+	storageDir := t.TempDir()
+	ts := tree.NewTreeService(storageDir)
+	if err := ts.LoadTree(); err != nil {
+		t.Fatalf("LoadTree: %v", err)
+	}
+
+	// A section slugged "TCP" with a child slugged "IP" — a colliding route
+	// path "TCP/IP" for the unrelated target string "TCP/IP". Slug matching
+	// is case-sensitive (findChildBySlugExactInParentLocked), so the slugs
+	// must match the target's exact casing for the collision to be real.
+	sectionID, err := ts.CreateNode("system", nil, "TCP Docs", "TCP", pageNodeKind())
+	if err != nil {
+		t.Fatalf("CreateNode section: %v", err)
+	}
+	_, err = ts.CreateNode("system", sectionID, "IP Notes", "IP", pageNodeKind())
+	if err != nil {
+		t.Fatalf("CreateNode child: %v", err)
+	}
+
+	// The actually-titled page "TCP/IP", unrelated to the section above.
+	titledIDPtr, err := ts.CreateNode("system", nil, "TCP/IP", "tcp-ip-guide", pageNodeKind())
+	if err != nil {
+		t.Fatalf("CreateNode titled page: %v", err)
+	}
+
+	targets := resolveWikiLinkTargets(ts, []string{"TCP/IP"})
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(targets))
+	}
+	if targets[0].Broken {
+		t.Fatalf("expected resolved link to the titled page, got broken")
+	}
+	if targets[0].TargetPageID != *titledIDPtr {
+		t.Errorf("TargetPageID = %q, want %q (the titled page, not the colliding slug path)", targets[0].TargetPageID, *titledIDPtr)
+	}
+	want := wikilinkSentinel("TCP/IP")
+	if targets[0].TargetPagePath != want {
+		t.Errorf("TargetPagePath = %q, want %q", targets[0].TargetPagePath, want)
+	}
+}
+
+func TestResolveWikiLinkTargets_AmbiguousSlashTitle_ReturnsBroken(t *testing.T) {
+	storageDir := t.TempDir()
+	ts := tree.NewTreeService(storageDir)
+	if err := ts.LoadTree(); err != nil {
+		t.Fatalf("LoadTree: %v", err)
+	}
+	if _, err := ts.CreateNode("system", nil, "TCP/IP", "tcp-ip-a", pageNodeKind()); err != nil {
+		t.Fatalf("CreateNode a: %v", err)
+	}
+	if _, err := ts.CreateNode("system", nil, "TCP/IP", "tcp-ip-b", pageNodeKind()); err != nil {
+		t.Fatalf("CreateNode b: %v", err)
+	}
+
+	targets := resolveWikiLinkTargets(ts, []string{"TCP/IP"})
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(targets))
+	}
+	if !targets[0].Broken {
+		t.Errorf("expected broken link for ambiguous slash-title match")
 	}
 }
 


### PR DESCRIPTION
…kilinks

A [[Title]] wikilink whose title contains a "/" (e.g. [[TCP/IP]]) tried a route-path lookup first, only falling back to a title lookup if that failed. This let an unrelated route path silently shadow a real title match, resolving the link to the wrong page with Broken staying false.

resolveWikiLinkTargets now always tries the title lookup first for every target, including slash-containing ones; route-path lookup is only attempted as a fallback when there are zero title matches, which still supports [[some/nested/page]]-style route hints. An ambiguous title match (N>1) is treated the same as the plain-title case (broken), for consistency.
