### PR TITLE
feat(preview): opt-in line numbers for fenced code blocks

### DIFF
--- a/ui/leafwiki-ui/src/features/preview/MarkdownCodeBlock.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownCodeBlock.tsx
@@ -2,7 +2,12 @@ import { TooltipWrapper } from '@/components/TooltipWrapper'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { Check, Copy } from 'lucide-react'
-import { ClassAttributes, HTMLAttributes, ReactNode, isValidElement } from 'react'
+import {
+  ClassAttributes,
+  HTMLAttributes,
+  ReactNode,
+  isValidElement,
+} from 'react'
 import { useTranslation } from 'react-i18next'
 import { splitHighlightedLines } from './splitHighlightedLines'
 import { readTextContent, useCodeCopy } from './useCodeCopy'

--- a/ui/leafwiki-ui/src/features/preview/MarkdownCodeBlock.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownCodeBlock.tsx
@@ -1,18 +1,24 @@
 import { TooltipWrapper } from '@/components/TooltipWrapper'
 import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 import { Check, Copy } from 'lucide-react'
-import {
-  ClassAttributes,
-  HTMLAttributes,
-  ReactNode,
-  isValidElement,
-} from 'react'
+import { ClassAttributes, HTMLAttributes, ReactNode, isValidElement } from 'react'
 import { useTranslation } from 'react-i18next'
+import { splitHighlightedLines } from './splitHighlightedLines'
 import { readTextContent, useCodeCopy } from './useCodeCopy'
 
 type CodeElementProps = {
   className?: string
   children?: ReactNode
+  'data-line-numbers'?: string | boolean
+}
+
+function hasLineNumbers(props: CodeElementProps): boolean {
+  const flag = props['data-line-numbers']
+  if (flag === true || flag === 'true' || flag === '') {
+    return true
+  }
+  return (props.className ?? '').split(/\s+/).some((cls) => cls.endsWith('='))
 }
 
 export default function MarkdownCodeBlock(
@@ -32,13 +38,25 @@ export default function MarkdownCodeBlock(
     return <pre {...preProps}>{children}</pre>
   }
 
+  const showLineNumbers = hasLineNumbers(child.props)
+
   const isCodeBlock = className.includes('language-') || code.includes('\n')
   if (!isCodeBlock) {
     return <pre {...preProps}>{children}</pre>
   }
 
+  const highlightedChildren = child.props.children
+  const lines = showLineNumbers
+    ? splitHighlightedLines(highlightedChildren)
+    : null
+
   return (
-    <div className="markdown-code-block">
+    <div
+      className={cn(
+        'markdown-code-block',
+        showLineNumbers && 'markdown-code-block--line-numbers',
+      )}
+    >
       <div className="markdown-code-block__actions">
         <TooltipWrapper
           label={
@@ -66,7 +84,30 @@ export default function MarkdownCodeBlock(
         {...preProps}
         className={`custom-scrollbar ${preProps.className ?? ''}`.trim()}
       >
-        {children}
+        {showLineNumbers && lines ? (
+          <code className={className} data-line-numbers="true">
+            <span className="markdown-code-block__lines">
+              {lines.map((line, index) => (
+                <span
+                  key={`code-line-${index + 1}`}
+                  className="markdown-code-block__line"
+                >
+                  <span
+                    className="markdown-code-block__line-number"
+                    aria-hidden="true"
+                  >
+                    {index + 1}
+                  </span>
+                  <span className="markdown-code-block__line-content">
+                    {line.length > 0 ? line : '\n'}
+                  </span>
+                </span>
+              ))}
+            </span>
+          </code>
+        ) : (
+          children
+        )}
       </pre>
     </div>
   )

--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.test.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.test.tsx
@@ -72,6 +72,48 @@ if WinExist("Untitled - Notepad") {
     expect(autohotkeyCodeBlock?.querySelector('.hljs-string')).not.toBeNull()
   })
 
+  it('shows line numbers when the fence language ends with =', () => {
+    const content = `\`\`\`bash=
+echo one
+echo two
+echo three
+\`\`\``
+
+    const { container } = render(<MarkdownPreview content={content} />)
+
+    const block = container.querySelector(
+      '.markdown-code-block--line-numbers',
+    )
+    expect(block).not.toBeNull()
+
+    const lineNumbers = container.querySelectorAll(
+      '.markdown-code-block__line-number',
+    )
+    expect(lineNumbers).toHaveLength(3)
+    expect(lineNumbers[0]?.textContent).toBe('1')
+    expect(lineNumbers[2]?.textContent).toBe('3')
+
+    const highlighted = container.querySelector('code.language-bash.hljs')
+    expect(highlighted).not.toBeNull()
+    expect(highlighted?.getAttribute('data-line-numbers')).toBe('true')
+  })
+
+  it('does not show line numbers for ordinary fences', () => {
+    const content = `\`\`\`bash
+echo one
+echo two
+\`\`\``
+
+    const { container } = render(<MarkdownPreview content={content} />)
+
+    expect(
+      container.querySelector('.markdown-code-block--line-numbers'),
+    ).toBeNull()
+    expect(
+      container.querySelector('.markdown-code-block__line-number'),
+    ).toBeNull()
+  })
+
   it('renders external images from markdown image syntax', () => {
     const { container } = render(
       <MarkdownPreview content="![Remote diagram](https://example.com/diagram.png)" />,

--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.test.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.test.tsx
@@ -81,9 +81,7 @@ echo three
 
     const { container } = render(<MarkdownPreview content={content} />)
 
-    const block = container.querySelector(
-      '.markdown-code-block--line-numbers',
-    )
+    const block = container.querySelector('.markdown-code-block--line-numbers')
     expect(block).not.toBeNull()
 
     const lineNumbers = container.querySelectorAll(

--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.tsx
@@ -42,6 +42,7 @@ import './markdownPreviewCodeTheme.css'
 import MermaidBlock from './MermaidBlock'
 import { normalizeMarkdownListIndentation } from './normalizeMarkdownListIndentation'
 import { normalizeMarkdownBlocks } from './normalizeMarkdownBlocks'
+import { rehypeCodeFenceLineNumbers } from './rehypeCodeFenceLineNumbers'
 import { rehypeLineNumber } from './rehypeLineNumber'
 import { rehypeWhitelistStyles } from './rehypeWhitelistStyles'
 import { syntaxHighlightLanguages } from './syntaxHighlightLanguages'
@@ -68,7 +69,15 @@ const schema = {
       'className',
       'data-leafwiki-generated-id',
       'data-line',
+      'data-line-numbers',
       'style',
+    ],
+    code: [
+      ...(defaultSchema.attributes?.code || []),
+      'className',
+      'class',
+      'data-line',
+      'data-line-numbers',
     ],
     audio: [...(defaultSchema.attributes?.audio || []), 'controls', 'src'],
     video: [
@@ -532,7 +541,10 @@ export default function MarkdownPreview({
       }: MarkdownNodeProp &
         JSX.IntrinsicAttributes &
         ClassAttributes<HTMLElement> &
-        HTMLAttributes<HTMLElement> & { 'data-line'?: string }) => {
+        HTMLAttributes<HTMLElement> & {
+          'data-line'?: string
+          'data-line-numbers'?: string | boolean
+        }) => {
         void node
         const { className, children, 'data-line': dataLine } = props
         if (className?.includes('language-mermaid')) {
@@ -628,6 +640,7 @@ export default function MarkdownPreview({
             rehypePlugins={[
               rehypeRaw,
               rehypeLineNumber,
+              rehypeCodeFenceLineNumbers,
               rehypeWhitelistStyles,
               [rehypeKatex, { output: 'html', strict: 'ignore' }],
               [rehypeSanitize, schema],

--- a/ui/leafwiki-ui/src/features/preview/markdownPreviewCodeTheme.css
+++ b/ui/leafwiki-ui/src/features/preview/markdownPreviewCodeTheme.css
@@ -186,6 +186,50 @@
   padding-right: 3.5rem;
 }
 
+.page-viewer__content .markdown-code-block--line-numbers pre code,
+.markdown-editor__preview .markdown-code-block--line-numbers pre code,
+.page-history__preview-body .markdown-code-block--line-numbers pre code {
+  padding-left: 0;
+}
+
+.page-viewer__content .markdown-code-block__lines,
+.markdown-editor__preview .markdown-code-block__lines,
+.page-history__preview-body .markdown-code-block__lines {
+  display: block;
+  min-width: max-content;
+}
+
+.page-viewer__content .markdown-code-block__line,
+.markdown-editor__preview .markdown-code-block__line,
+.page-history__preview-body .markdown-code-block__line {
+  display: flex;
+  align-items: flex-start;
+  min-height: 1.35em;
+}
+
+.page-viewer__content .markdown-code-block__line-number,
+.markdown-editor__preview .markdown-code-block__line-number,
+.page-history__preview-body .markdown-code-block__line-number {
+  flex: 0 0 auto;
+  min-width: 2.5rem;
+  padding: 0 0.75rem 0 1em;
+  text-align: right;
+  user-select: none;
+  opacity: 0.45;
+  font: inherit;
+  line-height: inherit;
+  border-right: 1px solid
+    color-mix(in oklab, var(--hljs-foreground) 12%, transparent);
+}
+
+.page-viewer__content .markdown-code-block__line-content,
+.markdown-editor__preview .markdown-code-block__line-content,
+.page-history__preview-body .markdown-code-block__line-content {
+  flex: 1 1 auto;
+  padding-left: 0.85rem;
+  white-space: pre;
+}
+
 .page-viewer__content pre,
 .markdown-editor__preview pre,
 .page-history__preview-body pre {

--- a/ui/leafwiki-ui/src/features/preview/markdownPreviewCodeTheme.css
+++ b/ui/leafwiki-ui/src/features/preview/markdownPreviewCodeTheme.css
@@ -195,29 +195,32 @@
 .page-viewer__content .markdown-code-block__lines,
 .markdown-editor__preview .markdown-code-block__lines,
 .page-history__preview-body .markdown-code-block__lines {
-  display: block;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  align-items: start;
   min-width: max-content;
 }
 
 .page-viewer__content .markdown-code-block__line,
 .markdown-editor__preview .markdown-code-block__line,
 .page-history__preview-body .markdown-code-block__line {
-  display: flex;
-  align-items: flex-start;
-  min-height: 1.35em;
+  display: contents;
 }
 
 .page-viewer__content .markdown-code-block__line-number,
 .markdown-editor__preview .markdown-code-block__line-number,
 .page-history__preview-body .markdown-code-block__line-number {
-  flex: 0 0 auto;
+  position: sticky;
+  left: 0;
   min-width: 2.5rem;
+  min-height: 1.35em;
   padding: 0 0.75rem 0 1em;
   text-align: right;
   user-select: none;
   opacity: 0.45;
   font: inherit;
   line-height: inherit;
+  background: var(--hljs-background);
   border-right: 1px solid
     color-mix(in oklab, var(--hljs-foreground) 12%, transparent);
 }
@@ -225,7 +228,7 @@
 .page-viewer__content .markdown-code-block__line-content,
 .markdown-editor__preview .markdown-code-block__line-content,
 .page-history__preview-body .markdown-code-block__line-content {
-  flex: 1 1 auto;
+  min-height: 1.35em;
   padding-left: 0.85rem;
   white-space: pre;
 }

--- a/ui/leafwiki-ui/src/features/preview/rehypeCodeFenceLineNumbers.test.ts
+++ b/ui/leafwiki-ui/src/features/preview/rehypeCodeFenceLineNumbers.test.ts
@@ -2,9 +2,10 @@ import { rehypeCodeFenceLineNumbers } from './rehypeCodeFenceLineNumbers'
 import type { Root } from 'hast'
 
 function run(tree: Root) {
-  const transformer = rehypeCodeFenceLineNumbers() as (
+  const attacher = rehypeCodeFenceLineNumbers as unknown as () => (
     tree: Root,
   ) => void | Root | Promise<void | Root>
+  const transformer = attacher()
   return transformer(tree)
 }
 
@@ -24,7 +25,7 @@ describe('rehypeCodeFenceLineNumbers', () => {
 
     run(tree)
 
-    const code = tree.children[0] as {
+    const code = tree.children[0] as unknown as {
       properties: { className: string[]; 'data-line-numbers'?: string }
     }
     expect(code.properties.className).toEqual(['language-js'])
@@ -46,7 +47,7 @@ describe('rehypeCodeFenceLineNumbers', () => {
 
     run(tree)
 
-    const code = tree.children[0] as {
+    const code = tree.children[0] as unknown as {
       properties: { className: string[]; 'data-line-numbers'?: string }
     }
     expect(code.properties.className).toEqual(['language-js'])

--- a/ui/leafwiki-ui/src/features/preview/rehypeCodeFenceLineNumbers.test.ts
+++ b/ui/leafwiki-ui/src/features/preview/rehypeCodeFenceLineNumbers.test.ts
@@ -1,0 +1,55 @@
+import { rehypeCodeFenceLineNumbers } from './rehypeCodeFenceLineNumbers'
+import type { Root } from 'hast'
+
+function run(tree: Root) {
+  const transformer = rehypeCodeFenceLineNumbers() as (
+    tree: Root,
+  ) => void | Root | Promise<void | Root>
+  return transformer(tree)
+}
+
+describe('rehypeCodeFenceLineNumbers', () => {
+  it('strips trailing = from language class and sets data-line-numbers', () => {
+    const tree: Root = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'code',
+          properties: { className: ['language-js='] },
+          children: [],
+        },
+      ],
+    }
+
+    run(tree)
+
+    const code = tree.children[0] as {
+      properties: { className: string[]; 'data-line-numbers'?: string }
+    }
+    expect(code.properties.className).toEqual(['language-js'])
+    expect(code.properties['data-line-numbers']).toBe('true')
+  })
+
+  it('leaves ordinary language classes alone', () => {
+    const tree: Root = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'code',
+          properties: { className: ['language-js'] },
+          children: [],
+        },
+      ],
+    }
+
+    run(tree)
+
+    const code = tree.children[0] as {
+      properties: { className: string[]; 'data-line-numbers'?: string }
+    }
+    expect(code.properties.className).toEqual(['language-js'])
+    expect(code.properties['data-line-numbers']).toBeUndefined()
+  })
+})

--- a/ui/leafwiki-ui/src/features/preview/rehypeCodeFenceLineNumbers.ts
+++ b/ui/leafwiki-ui/src/features/preview/rehypeCodeFenceLineNumbers.ts
@@ -33,7 +33,9 @@ export const rehypeCodeFenceLineNumbers: Plugin<[], Root> = () => {
         }
         enabled = true
         const withoutMarker = cls.slice(0, -1)
-        return withoutMarker === 'language-' ? 'language-plaintext' : withoutMarker
+        return withoutMarker === 'language-'
+          ? 'language-plaintext'
+          : withoutMarker
       })
 
       if (!enabled) return

--- a/ui/leafwiki-ui/src/features/preview/rehypeCodeFenceLineNumbers.ts
+++ b/ui/leafwiki-ui/src/features/preview/rehypeCodeFenceLineNumbers.ts
@@ -1,0 +1,46 @@
+import type { Element, Root } from 'hast'
+import type { Plugin } from 'unified'
+import { visit } from 'unist-util-visit'
+
+function asClassList(
+  className: string | number | boolean | (string | number)[] | null | undefined,
+): string[] {
+  if (Array.isArray(className)) {
+    return className.map(String)
+  }
+  if (typeof className === 'string') {
+    return className.split(/\s+/).filter(Boolean)
+  }
+  return []
+}
+
+/**
+ * Opt-in code-block line numbers via a trailing `=` on the fence language,
+ * e.g. ```go= or ```=. Strips the marker so highlighting still works and sets
+ * data-line-numbers for the preview renderer.
+ */
+export const rehypeCodeFenceLineNumbers: Plugin<[], Root> = () => {
+  return (tree) => {
+    visit(tree, 'element', (node: Element) => {
+      if (node.tagName !== 'code') return
+
+      const classes = asClassList(node.properties?.className)
+      let enabled = false
+
+      const nextClasses = classes.map((cls) => {
+        if (!cls.startsWith('language-') || !cls.endsWith('=')) {
+          return cls
+        }
+        enabled = true
+        const withoutMarker = cls.slice(0, -1)
+        return withoutMarker === 'language-' ? 'language-plaintext' : withoutMarker
+      })
+
+      if (!enabled) return
+
+      node.properties = node.properties || {}
+      node.properties.className = nextClasses
+      node.properties['data-line-numbers'] = 'true'
+    })
+  }
+}

--- a/ui/leafwiki-ui/src/features/preview/splitHighlightedLines.test.ts
+++ b/ui/leafwiki-ui/src/features/preview/splitHighlightedLines.test.ts
@@ -1,0 +1,15 @@
+import { splitHighlightedLines } from './splitHighlightedLines'
+
+describe('splitHighlightedLines', () => {
+  it('splits plain text on newlines', () => {
+    expect(splitHighlightedLines('a\nb\nc')).toEqual([['a'], ['b'], ['c']])
+  })
+
+  it('drops a trailing empty line from a final newline', () => {
+    expect(splitHighlightedLines('a\nb\n')).toEqual([['a'], ['b']])
+  })
+
+  it('keeps a blank middle line', () => {
+    expect(splitHighlightedLines('a\n\nb')).toEqual([['a'], [], ['b']])
+  })
+})

--- a/ui/leafwiki-ui/src/features/preview/splitHighlightedLines.ts
+++ b/ui/leafwiki-ui/src/features/preview/splitHighlightedLines.ts
@@ -1,0 +1,71 @@
+import { Children, ReactNode, cloneElement, isValidElement } from 'react'
+
+/**
+ * Split highlighted React children into lines, preserving hljs spans.
+ */
+export function splitHighlightedLines(children: ReactNode): ReactNode[][] {
+  const lines: ReactNode[][] = [[]]
+
+  const appendToCurrent = (node: ReactNode) => {
+    lines[lines.length - 1].push(node)
+  }
+
+  const walk = (node: ReactNode): void => {
+    if (node == null || typeof node === 'boolean') {
+      return
+    }
+
+    if (typeof node === 'string' || typeof node === 'number') {
+      const parts = String(node).split('\n')
+      parts.forEach((part, index) => {
+        if (index > 0) {
+          lines.push([])
+        }
+        if (part !== '') {
+          appendToCurrent(part)
+        }
+      })
+      return
+    }
+
+    if (Array.isArray(node) || Children.count(node) > 1) {
+      Children.forEach(node, walk)
+      return
+    }
+
+    if (isValidElement<{ children?: ReactNode }>(node)) {
+      const child = node.props.children
+      if (
+        (typeof child === 'string' || typeof child === 'number') &&
+        String(child).includes('\n')
+      ) {
+        const parts = String(child).split('\n')
+        parts.forEach((part, index) => {
+          if (index > 0) {
+            lines.push([])
+          }
+          if (part !== '') {
+            appendToCurrent(
+              cloneElement(node, { key: `ln-${lines.length}-${index}` }, part),
+            )
+          }
+        })
+        return
+      }
+
+      appendToCurrent(node)
+      return
+    }
+
+    appendToCurrent(node)
+  }
+
+  walk(children)
+
+  // Code fences usually end with a trailing newline; drop the empty last line.
+  if (lines.length > 1 && lines[lines.length - 1].length === 0) {
+    lines.pop()
+  }
+
+  return lines
+}


### PR DESCRIPTION
Adds opt-in line numbers when a fence language ends with `=` (e.g. ```go=```), per #1313.
Closes #1313
