### PR TITLE
fix(viewer): keep TOC pane mounted to align breadcrumbs and content

### DIFF
--- a/ui/leafwiki-ui/src/features/preview/TocSidePanel.test.tsx
+++ b/ui/leafwiki-ui/src/features/preview/TocSidePanel.test.tsx
@@ -10,6 +10,7 @@ vi.mock('react-i18next', () => ({
       const map: Record<string, string> = {
         'toc.title': 'Table of contents',
         'toc.onThisPage': 'On this page',
+        'toc.empty': 'No headings on this page',
         'toc.collapse': 'Collapse table of contents',
         'toc.expand': 'Expand table of contents',
       }
@@ -68,6 +69,13 @@ describe('TocSidePanel — rendering', () => {
     expect(screen.getByText('Introduction')).toBeInTheDocument()
     expect(screen.getByText('Background')).toBeInTheDocument()
     expect(screen.getByText('Details')).toBeInTheDocument()
+  })
+
+  it('renders an empty state when there are no headings', () => {
+    render(<TocSidePanel entries={[]} />)
+    expect(screen.getByTestId('toc-side-panel-empty')).toHaveTextContent(
+      'No headings on this page',
+    )
   })
 
   it('renders data-testid on each entry button', () => {

--- a/ui/leafwiki-ui/src/features/preview/TocSidePanel.tsx
+++ b/ui/leafwiki-ui/src/features/preview/TocSidePanel.tsx
@@ -77,27 +77,37 @@ export function TocSidePanel({ entries, activeId: externalActiveId }: Props) {
         aria-hidden={collapsed}
         data-testid="toc-side-panel-list"
       >
-        {entries.map((entry) => (
-          <li key={entry.id}>
-            <button
-              className={cn(
-                'page-viewer__toc-panel-entry',
-                getIndentClass(entry.level),
-                activeId === entry.id && 'page-viewer__toc-panel-entry--active',
-              )}
-              onClick={() =>
-                scrollToHeadlineHash(`#${encodeURIComponent(entry.id)}`, {
-                  waitForStableLayout: false,
-                })
-              }
-              title={entry.text}
-              data-testid={`toc-entry-${entry.id}`}
-              tabIndex={collapsed ? -1 : 0}
-            >
-              {entry.text}
-            </button>
+        {entries.length === 0 ? (
+          <li
+            className="page-viewer__toc-panel-empty"
+            data-testid="toc-side-panel-empty"
+          >
+            {t('toc.empty')}
           </li>
-        ))}
+        ) : (
+          entries.map((entry) => (
+            <li key={entry.id}>
+              <button
+                className={cn(
+                  'page-viewer__toc-panel-entry',
+                  getIndentClass(entry.level),
+                  activeId === entry.id &&
+                    'page-viewer__toc-panel-entry--active',
+                )}
+                onClick={() =>
+                  scrollToHeadlineHash(`#${encodeURIComponent(entry.id)}`, {
+                    waitForStableLayout: false,
+                  })
+                }
+                title={entry.text}
+                data-testid={`toc-entry-${entry.id}`}
+                tabIndex={collapsed ? -1 : 0}
+              >
+                {entry.text}
+              </button>
+            </li>
+          ))
+        )}
       </ul>
     </nav>
   )

--- a/ui/leafwiki-ui/src/features/viewer/PageViewer.tsx
+++ b/ui/leafwiki-ui/src/features/viewer/PageViewer.tsx
@@ -144,15 +144,19 @@ export default function PageViewer() {
     [page],
   )
 
-  const showTocButton = tocEntries.length > 3
+  // Always mount the desktop TOC side panel while viewing a page so the
+  // subheader/article column width stays stable across pages (see #1378).
+  // The mobile/dropdown control still only appears for longer TOCs.
+  const showTocSidePanel = Boolean(page && !error)
+  const showTocDropdown = tocEntries.length > 3
   // Single scroll spy for both the dropdown and the side panel.
-  const tocActiveId = useTocScrollSpy(showTocButton ? tocEntries : [])
+  const tocActiveId = useTocScrollSpy(showTocSidePanel ? tocEntries : [])
 
   const toggleTocCollapsed = useTocPanelStore((state) => state.toggleCollapsed)
   const tocCollapsed = useTocPanelStore((state) => state.collapsed)
 
   useEffect(() => {
-    if (!showTocButton) return
+    if (!showTocSidePanel) return
 
     const tocToggleHotkey = createHotkeyDefinition(
       'viewer.toc.toggle',
@@ -161,7 +165,7 @@ export default function PageViewer() {
     registerHotkey(tocToggleHotkey)
 
     return () => unregisterHotkey(tocToggleHotkey.keyCombo)
-  }, [showTocButton, toggleTocCollapsed, registerHotkey, unregisterHotkey])
+  }, [showTocSidePanel, toggleTocCollapsed, registerHotkey, unregisterHotkey])
 
   const editorName = displayUser(page?.metadata?.lastAuthor)
   const updatedRelative = formatRelativeTime(page?.metadata?.updatedAt)
@@ -175,7 +179,7 @@ export default function PageViewer() {
           <div
             className={cn(
               'page-viewer__subheader print:hidden',
-              showTocButton &&
+              showTocSidePanel &&
                 (tocCollapsed
                   ? 'page-viewer__subheader--toc-reserved-collapsed'
                   : 'page-viewer__subheader--toc-reserved'),
@@ -204,7 +208,7 @@ export default function PageViewer() {
                   />
                 )}
               </div>
-              {showTocButton && (
+              {showTocDropdown && (
                 <div className="page-viewer__toc-button">
                   <TocDropdownButton
                     entries={tocEntries}
@@ -220,7 +224,7 @@ export default function PageViewer() {
       : null
 
   const tocPane =
-    showTocButton && page && !error && tocPaneRoot
+    showTocSidePanel && tocPaneRoot
       ? createPortal(
           <TocSidePanel entries={tocEntries} activeId={tocActiveId} />,
           tocPaneRoot,

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -1766,6 +1766,10 @@
     transition: visibility 0s linear 0s;
   }
 
+  .page-viewer__toc-panel-empty {
+    @apply text-interface-text/50 px-1 py-1 text-xs;
+  }
+
   /* No opacity — entries are w-full block elements, so they already track
      .app-layout__toc-pane's width transition frame-by-frame (real flex/block
      reflow, not a separate animation), and overflow-hidden + whitespace-

--- a/ui/leafwiki-ui/src/locales/en/viewer.json
+++ b/ui/leafwiki-ui/src/locales/en/viewer.json
@@ -69,6 +69,7 @@
   "toc": {
     "title": "Table of contents",
     "onThisPage": "On this page",
+    "empty": "No headings on this page",
     "collapse": "Collapse table of contents",
     "expand": "Expand table of contents"
   },


### PR DESCRIPTION
Always mounts the desktop TOC side panel while viewing a page so breadcrumbs and article width no longer jump when TOC presence changes.
Closes #1378