### PR TITLE
fix(hotkeys): handle shortcuts in capture phase (#1314)

### DIFF
--- a/ui/leafwiki-ui/src/components/HotKeyHandler.test.tsx
+++ b/ui/leafwiki-ui/src/components/HotKeyHandler.test.tsx
@@ -70,6 +70,42 @@ describe('HotKeyHandler', () => {
     useDialogsStore.setState({ dialogType: null, dialogProps: null })
   })
 
+  it('registers the keydown listener in the capture phase', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener')
+    render(<HotKeyHandler />)
+    expect(addSpy).toHaveBeenCalledWith('keydown', expect.any(Function), true)
+    addSpy.mockRestore()
+  })
+
+  it('prevents the default browser action for Ctrl+Alt+P when registered', () => {
+    const action = vi.fn()
+    useHotKeysStore.getState().registerHotkey({
+      keyCombo: 'Mod+Alt+KeyP',
+      enabled: true,
+      mode: ['view'],
+      action,
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/docs/getting-started']}>
+        <HotKeyHandler />
+      </MemoryRouter>,
+    )
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'p',
+      code: 'KeyP',
+      ctrlKey: true,
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    })
+    window.dispatchEvent(event)
+
+    expect(action).toHaveBeenCalledTimes(1)
+    expect(event.defaultPrevented).toBe(true)
+  })
+
   it('switches to the Explorer panel on Ctrl+Shift+E while the search field is focused', async () => {
     renderApp()
 

--- a/ui/leafwiki-ui/src/components/HotKeyHandler.test.tsx
+++ b/ui/leafwiki-ui/src/components/HotKeyHandler.test.tsx
@@ -72,7 +72,11 @@ describe('HotKeyHandler', () => {
 
   it('registers the keydown listener in the capture phase', () => {
     const addSpy = vi.spyOn(window, 'addEventListener')
-    render(<HotKeyHandler />)
+    render(
+      <MemoryRouter initialEntries={['/docs/getting-started']}>
+        <HotKeyHandler />
+      </MemoryRouter>,
+    )
     expect(addSpy).toHaveBeenCalledWith('keydown', expect.any(Function), true)
     addSpy.mockRestore()
   })

--- a/ui/leafwiki-ui/src/components/HotKeyHandler.tsx
+++ b/ui/leafwiki-ui/src/components/HotKeyHandler.tsx
@@ -83,9 +83,12 @@ export function HotKeyHandler() {
   )
 
   useEffect(() => {
-    window.addEventListener('keydown', onKeyDown)
+    // Capture phase so we can preventDefault before the browser handles the
+    // same combo (e.g. Ctrl+Alt+P opening print / private-window shortcuts).
+    // See https://github.com/perber/leafwiki/issues/1314
+    window.addEventListener('keydown', onKeyDown, true)
     return () => {
-      window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('keydown', onKeyDown, true)
     }
   }, [onKeyDown])
 


### PR DESCRIPTION
Register global hotkeys in the capture phase so combos like Ctrl+Alt+P call preventDefault before the browser default.
Fixes #1314
