### PR TITLE
feat(update-check): version + latest-release endpoint (#304)

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ For plain HTTP: add `--allow-insecure=true` so login and CSRF cookies work.
 | `--logout-url`                   | Redirect to an external URL after logout                                | `""`          | v0.12.0 |
 | `--http-remote-user-logout-url`  | ⚠️ Deprecated, use `--logout-url` instead                               | `""`          | v0.10.0 |
 | `--disable-request-log`          | Suppress per-request HTTP access log lines                              | `false`       | v0.10.1 |
+| `--disable-update-check`         | Disable checking GitHub for newer LeafWiki releases (air-gapped)        | `false`       | –       |
 | `--log-format`                   | Log output format: `text` or `json`                                     | `text`        | v0.12.0 |
 | `--totp-encryption-key`          | Key to encrypt per-user TOTP secrets at rest (min 32 bytes); required only once a user enables TOTP | `""` | v0.12.0 |
 | `--enable-metrics`               | Enable the Prometheus `/metrics` endpoint on a separate listener        | `false`       | v0.12.0 |
@@ -391,6 +392,7 @@ For plain HTTP: add `--allow-insecure=true` so login and CSRF cookies work.
 | `LEAFWIKI_LOGOUT_URL`                   | Redirect to an external URL after logout             | `""`          | v0.12.0 |
 | `LEAFWIKI_HTTP_REMOTE_USER_LOGOUT_URL`  | ⚠️ Deprecated, use `LEAFWIKI_LOGOUT_URL` instead     | `""`          | v0.10.0 |
 | `LEAFWIKI_DISABLE_REQUEST_LOG`          | Suppress per-request HTTP access log lines           | `false`       | v0.10.1 |
+| `LEAFWIKI_DISABLE_UPDATE_CHECK`           | Disable checking GitHub for newer releases           | `false`       | –       |
 | `LEAFWIKI_LOG_FORMAT`                   | Log output format: `text` or `json`                  | `text`        | v0.12.0 |
 | `LEAFWIKI_LOG_LEVEL`                    | Log level: `debug`, `info`, `warn`, `error` (env-var only, no CLI flag) | `info` | v0.8.0  |
 | `LEAFWIKI_TOTP_ENCRYPTION_KEY`          | Key to encrypt per-user TOTP secrets at rest (min 32 bytes) | `""`    | v0.12.0 |

--- a/cmd/leafwiki/main.go
+++ b/cmd/leafwiki/main.go
@@ -102,6 +102,7 @@ func writeUsage(w io.Writer) {
 	--user-management-url           URL to an external user-management page; when set, the built-in
 	                                 User Management UI is replaced with a link to this URL (default: "")
 	--disable-request-log           Suppress per-request HTTP access log lines (default: false)
+	--disable-update-check          Disable checking GitHub for newer LeafWiki releases (default: false)
 	--git-backup                   Enable git backup to a remote repository (default: false)
 	--git-backup-author-name       Git commit author name for backups (default: LeafWiki Backup)
 	--git-backup-author-email      Git commit author email for backups (default: backup@leafwiki.local)
@@ -162,6 +163,7 @@ func writeUsage(w io.Writer) {
 	LEAFWIKI_HTTP_REMOTE_USER_LOGOUT_URL  (deprecated: use LEAFWIKI_LOGOUT_URL instead)
 	LEAFWIKI_USER_MANAGEMENT_URL
 	LEAFWIKI_DISABLE_REQUEST_LOG
+	LEAFWIKI_DISABLE_UPDATE_CHECK
 	LEAFWIKI_GIT_BACKUP
 	LEAFWIKI_GIT_BACKUP_AUTHOR_NAME
 	LEAFWIKI_GIT_BACKUP_AUTHOR_EMAIL
@@ -266,6 +268,7 @@ type cliFlags struct {
 	httpRemoteUserLogoutURL *string
 	userManagementURL       *string
 	disableRequestLog       *bool
+	disableUpdateCheck      *bool
 	gitBackup               *bool
 	gitBackupAuthorName     *string
 	gitBackupAuthorEmail    *string
@@ -320,6 +323,7 @@ func registerFlags(fs *flag.FlagSet) *cliFlags {
 		httpRemoteUserLogoutURL: fs.String("http-remote-user-logout-url", "", "deprecated: use --logout-url instead"),
 		userManagementURL:       fs.String("user-management-url", "", "URL to an external user-management page; when set, the built-in User Management UI is replaced with a link to this URL"),
 		disableRequestLog:       fs.Bool("disable-request-log", false, "suppress per-request HTTP access log lines (default: false)"),
+		disableUpdateCheck:      fs.Bool("disable-update-check", false, "disable checking GitHub for newer LeafWiki releases (default: false)"),
 		gitBackup:               fs.Bool("git-backup", false, "enable git backup to a remote repository (default: false)"),
 		gitBackupAuthorName:     fs.String("git-backup-author-name", "", "git commit author name for backups (default: LeafWiki Backup)"),
 		gitBackupAuthorEmail:    fs.String("git-backup-author-email", "", "git commit author email for backups (default: backup@leafwiki.local)"),
@@ -408,6 +412,7 @@ func main() {
 	}
 	userManagementURL := resolveString("user-management-url", *flags.userManagementURL, visited, "LEAFWIKI_USER_MANAGEMENT_URL", "")
 	disableRequestLog := resolveBool("disable-request-log", *flags.disableRequestLog, visited, "LEAFWIKI_DISABLE_REQUEST_LOG")
+	disableUpdateCheck := resolveBool("disable-update-check", *flags.disableUpdateCheck, visited, "LEAFWIKI_DISABLE_UPDATE_CHECK")
 	gitBackupEnabled := resolveBool("git-backup", *flags.gitBackup, visited, "LEAFWIKI_GIT_BACKUP")
 	gitBackupAuthorName := resolveString("git-backup-author-name", *flags.gitBackupAuthorName, visited, "LEAFWIKI_GIT_BACKUP_AUTHOR_NAME", "LeafWiki Backup")
 	gitBackupAuthorEmail := resolveString("git-backup-author-email", *flags.gitBackupAuthorEmail, visited, "LEAFWIKI_GIT_BACKUP_AUTHOR_EMAIL", "backup@leafwiki.local")
@@ -662,12 +667,14 @@ func main() {
 			TrustedProxies: trustedProxies,
 			UserService:    w.UserService,
 		},
-		APIKeyService:     w.APIKeyService(),
-		DisableRequestLog: disableRequestLog,
-		UserManagementURL: userManagementURL,
-		LoginURL:          loginURL,
-		LogoutURL:         logoutURL,
-		WriteGate:         writeGate,
+		APIKeyService:      w.APIKeyService(),
+		DisableRequestLog:  disableRequestLog,
+		UserManagementURL:  userManagementURL,
+		LoginURL:           loginURL,
+		LogoutURL:          logoutURL,
+		WriteGate:          writeGate,
+		Version:            Version,
+		DisableUpdateCheck: disableUpdateCheck,
 	})
 
 	reloadSignals := make(chan os.Signal, 1)

--- a/internal/http/releasecheck/releasecheck.go
+++ b/internal/http/releasecheck/releasecheck.go
@@ -1,0 +1,77 @@
+package releasecheck
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// DefaultLatestReleaseURL is the GitHub Releases API for LeafWiki's latest tag.
+const DefaultLatestReleaseURL = "https://api.github.com/repos/perber/leafwiki/releases/latest"
+
+// LatestRelease is the subset of GitHub release fields LeafWiki exposes to clients.
+type LatestRelease struct {
+	TagName     string `json:"tagName"`
+	Name        string `json:"name"`
+	HTMLURL     string `json:"htmlUrl"`
+	PublishedAt string `json:"publishedAt"`
+}
+
+type githubReleaseResponse struct {
+	TagName     string `json:"tag_name"`
+	Name        string `json:"name"`
+	HTMLURL     string `json:"html_url"`
+	PublishedAt string `json:"published_at"`
+}
+
+// FetchLatestRelease loads the latest published release from the GitHub API.
+// apiURL defaults to DefaultLatestReleaseURL when empty. client defaults to a
+// short-timeout http.Client when nil.
+func FetchLatestRelease(ctx context.Context, client *http.Client, apiURL string) (*LatestRelease, error) {
+	if apiURL == "" {
+		apiURL = DefaultLatestReleaseURL
+	}
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build release request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "LeafWiki-UpdateCheck")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch latest release: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read latest release response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github releases API returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var raw githubReleaseResponse
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("decode latest release response: %w", err)
+	}
+	if strings.TrimSpace(raw.TagName) == "" {
+		return nil, fmt.Errorf("github releases API response missing tag_name")
+	}
+
+	return &LatestRelease{
+		TagName:     raw.TagName,
+		Name:        raw.Name,
+		HTMLURL:     raw.HTMLURL,
+		PublishedAt: raw.PublishedAt,
+	}, nil
+}

--- a/internal/http/releasecheck/releasecheck_test.go
+++ b/internal/http/releasecheck/releasecheck_test.go
@@ -1,0 +1,82 @@
+package releasecheck
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestFetchLatestRelease_ParsesGitHubPayload(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if got := r.Header.Get("Accept"); !strings.Contains(got, "application/vnd.github") {
+			t.Errorf("expected GitHub Accept header, got %q", got)
+		}
+		if r.Header.Get("User-Agent") == "" {
+			t.Error("expected User-Agent header")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"tag_name": "v0.12.0",
+			"name": "LeafWiki v0.12.0",
+			"html_url": "https://github.com/perber/leafwiki/releases/tag/v0.12.0",
+			"published_at": "2026-07-26T15:50:41Z"
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	got, err := FetchLatestRelease(context.Background(), server.Client(), server.URL)
+	if err != nil {
+		t.Fatalf("FetchLatestRelease: %v", err)
+	}
+	if got.TagName != "v0.12.0" {
+		t.Fatalf("tagName=%q, want v0.12.0", got.TagName)
+	}
+	if got.Name != "LeafWiki v0.12.0" {
+		t.Fatalf("name=%q", got.Name)
+	}
+	if !strings.Contains(got.HTMLURL, "/releases/tag/v0.12.0") {
+		t.Fatalf("htmlUrl=%q", got.HTMLURL)
+	}
+	if got.PublishedAt != "2026-07-26T15:50:41Z" {
+		t.Fatalf("publishedAt=%q", got.PublishedAt)
+	}
+}
+
+func TestFetchLatestRelease_NonOKStatus(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "rate limited", http.StatusForbidden)
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := FetchLatestRelease(context.Background(), server.Client(), server.URL)
+	if err == nil {
+		t.Fatal("expected error for non-OK status")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Fatalf("expected status in error, got %v", err)
+	}
+}
+
+func TestFetchLatestRelease_MissingTagName(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"no tag"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := FetchLatestRelease(context.Background(), server.Client(), server.URL)
+	if err == nil {
+		t.Fatal("expected error for missing tag_name")
+	}
+}

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -111,6 +111,10 @@ type RouterOptions struct {
 	LoginURL                string                   // Optional URL the frontend redirects to instead of showing the built-in login form
 	LogoutURL               string                   // Optional URL the frontend redirects to after logout
 	WriteGate               *restore.WriteGate       // Optional; when set, gates mutating requests while a restore is in progress. nil disables the middleware entirely (no snapshot/restore enabled)
+	Version                 string                   // Build version surfaced via /api/config (ldflags-injected in release builds)
+	DisableUpdateCheck      bool                     // When true, /api/get-last-release refuses outbound GitHub checks (air-gapped)
+	UpdateCheckHTTPClient   *http.Client             // Optional HTTP client for release checks; nil uses a short-timeout default
+	UpdateCheckAPIURL       string                   // Optional override of the GitHub latest-release API URL (tests)
 }
 
 // FrontendConfig carries the minimal runtime data required to serve the embedded SPA.

--- a/internal/http/router_test.go
+++ b/internal/http/router_test.go
@@ -1280,6 +1280,105 @@ func TestConfigEndpoint_LoginAndLogoutUrlDefaultToEmpty(t *testing.T) {
 	}
 }
 
+func TestConfigEndpoint_IncludesVersionAndUpdateCheckEnabled(t *testing.T) {
+	w := createWikiTestInstance(t)
+	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
+
+	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
+		PublicAccess:            true,
+		AllowInsecure:           true,
+		AccessTokenTimeout:      15 * time.Minute,
+		RefreshTokenTimeout:     7 * 24 * time.Hour,
+		MaxAssetUploadSizeBytes: assets.DefaultMaxUploadSizeBytes,
+		Version:                 "v0.12.0",
+		DisableUpdateCheck:      false,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected 200 OK, got %d", rec.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Invalid JSON response: %v", err)
+	}
+
+	if resp["version"] != "v0.12.0" {
+		t.Fatalf("Expected version in config response, got %v", resp)
+	}
+	if resp["updateCheckEnabled"] != true {
+		t.Fatalf("Expected updateCheckEnabled=true in config response, got %v", resp)
+	}
+}
+
+func TestGetLastReleaseEndpoint_Disabled(t *testing.T) {
+	w := createWikiTestInstance(t)
+	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
+
+	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
+		PublicAccess:            true,
+		AllowInsecure:           true,
+		AccessTokenTimeout:      15 * time.Minute,
+		RefreshTokenTimeout:     7 * 24 * time.Hour,
+		MaxAssetUploadSizeBytes: assets.DefaultMaxUploadSizeBytes,
+		DisableUpdateCheck:      true,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/get-last-release", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("Expected 403 Forbidden, got %d - %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestGetLastReleaseEndpoint_ReturnsLatestTag(t *testing.T) {
+	w := createWikiTestInstance(t)
+	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.Header().Set("Content-Type", "application/json")
+		_, _ = rw.Write([]byte(`{
+			"tag_name": "v0.12.0",
+			"name": "LeafWiki v0.12.0",
+			"html_url": "https://github.com/perber/leafwiki/releases/tag/v0.12.0",
+			"published_at": "2026-07-26T15:50:41Z"
+		}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
+		PublicAccess:            true,
+		AllowInsecure:           true,
+		AccessTokenTimeout:      15 * time.Minute,
+		RefreshTokenTimeout:     7 * 24 * time.Hour,
+		MaxAssetUploadSizeBytes: assets.DefaultMaxUploadSizeBytes,
+		UpdateCheckHTTPClient:   upstream.Client(),
+		UpdateCheckAPIURL:       upstream.URL,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/get-last-release", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected 200 OK, got %d - %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Invalid JSON response: %v", err)
+	}
+	if resp["tagName"] != "v0.12.0" {
+		t.Fatalf("Expected tagName v0.12.0, got %v", resp)
+	}
+}
+
 func TestRefactorPreviewEndpoint_UsesFrontendJSONShape(t *testing.T) {
 	w := createWikiTestInstance(t)
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)

--- a/internal/wiki/auth/routes.go
+++ b/internal/wiki/auth/routes.go
@@ -12,6 +12,7 @@ import (
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
 	"github.com/perber/wiki/internal/http/middleware/security"
 	"github.com/perber/wiki/internal/http/middleware/utils"
+	"github.com/perber/wiki/internal/http/releasecheck"
 )
 
 const (
@@ -105,6 +106,7 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 
 	// Config endpoint also lives here as it issues the CSRF cookie.
 	nonAuth.GET("/config", r.handleConfig(ctx))
+	nonAuth.GET("/get-last-release", r.handleGetLastRelease(ctx))
 
 	// /auth/me uses optional auth so that unauthenticated callers get 200+null
 	// instead of 401, which would cause browsers behind a Basic Auth reverse
@@ -182,7 +184,36 @@ func (r *Routes) handleConfig(ctx httpinternal.RouterContext) gin.HandlerFunc {
 			"loginUrl":                opts.LoginURL,
 			"logoutUrl":               opts.LogoutURL,
 			"userManagementUrl":       opts.UserManagementURL,
+			"version":                 opts.Version,
+			"updateCheckEnabled":      !opts.DisableUpdateCheck,
 		})
+	}
+}
+
+func (r *Routes) handleGetLastRelease(ctx httpinternal.RouterContext) gin.HandlerFunc {
+	opts := ctx.Opts
+	return func(c *gin.Context) {
+		if opts.DisableUpdateCheck {
+			c.JSON(http.StatusForbidden, gin.H{
+				"error": "Update check is disabled",
+			})
+			return
+		}
+
+		release, err := releasecheck.FetchLatestRelease(
+			c.Request.Context(),
+			opts.UpdateCheckHTTPClient,
+			opts.UpdateCheckAPIURL,
+		)
+		if err != nil {
+			slog.Default().Warn("failed to fetch latest release", "error", err)
+			c.JSON(http.StatusBadGateway, gin.H{
+				"error": "Failed to fetch latest release",
+			})
+			return
+		}
+
+		c.JSON(http.StatusOK, release)
 	}
 }
 


### PR DESCRIPTION
Adds --disable-update-check, surfaces build version on /api/config, and serves /api/get-last-release as a GitHub wrapper for air-gapped opt-out.
Fixes #304
