### PR TITLE
docs: document API key and user-management-url flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,8 @@ For plain HTTP: add `--allow-insecure=true` so login and CSRF cookies work.
 | `--hide-link-metadata-section`   | Hide backlinks and link status panel                                    | `false`       | –       |
 | `--enable-revision`              | Enable revision history                                                 | `false`       | v0.9.0  |
 | `--enable-link-refactor`         | Enable link rewriting on rename/move                                    | `false`       | v0.9.0  |
+| `--enable-api-key-management`    | Enable experimental API key management                                  | `false`       | v0.12.0 |
+| `--user-management-url`          | External user-management page URL; replaces in-app User Management UI   | `""`          | v0.12.0 |
 | `--max-revision-history`         | Max revisions per page; `0` = unlimited                                 | `100`         | v0.9.0  |
 | `--revision-coalesce-window`     | Window for coalescing rapid successive auto-save revisions by the same author; `0` = disabled | `5m` | v0.11.0 |
 | `--enable-http-remote-user`      | Enable reverse-proxy auth via HTTP header                               | `false`       | v0.10.0 |
@@ -382,6 +384,8 @@ For plain HTTP: add `--allow-insecure=true` so login and CSRF cookies work.
 | `LEAFWIKI_HIDE_LINK_METADATA_SECTION`   | Hide backlinks and link status panel                 | `false`       | –       |
 | `LEAFWIKI_ENABLE_REVISION`              | Revision history                                     | `false`       | v0.9.0  |
 | `LEAFWIKI_ENABLE_LINK_REFACTOR`         | Link rewriting on rename/move                        | `false`       | v0.9.0  |
+| `LEAFWIKI_ENABLE_API_KEY_MANAGEMENT`    | Enable experimental API key management               | `false`       | v0.12.0 |
+| `LEAFWIKI_USER_MANAGEMENT_URL`          | External user-management page URL                    | `""`          | v0.12.0 |
 | `LEAFWIKI_MAX_REVISION_HISTORY`         | Max revisions per page; `0` = unlimited              | `100`         | v0.9.0  |
 | `LEAFWIKI_REVISION_COALESCE_WINDOW`     | Window for coalescing rapid successive auto-save revisions; `0` = disabled | `5m` | v0.11.0 |
 | `LEAFWIKI_ENABLE_HTTP_REMOTE_USER`      | Reverse-proxy auth via header                        | `false`       | v0.10.0 |


### PR DESCRIPTION
Documents --enable-api-key-management and --user-management-url in the README CLI/env tables.
Fixes #1398
