### PR TITLE
docs: sync .env.example with current configuration surface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,37 +1,86 @@
 # LeafWiki Environment Configuration
-# Copy this file to .env and customize the values
+# Copy this file to .env and customize the values.
+# See README.md for the full list of flags and defaults.
 
-# System architecture: amd64 or arm64
+# System architecture for install.sh: amd64 or arm64
 LEAFWIKI_ARCH=
 
 # LeafWiki version to install (leave empty for latest)
 LEAFWIKI_VERSION=
 
-# Host address on which LeafWiki will be hosted
+# Host / port
 LEAFWIKI_HOST=127.0.0.1
-
-# Port on which LeafWiki will be hosted
 LEAFWIKI_PORT=8080
+# LEAFWIKI_UNIX_SOCKET=
 
-# Allow public read access without authentication (true/false)
-LEAFWIKI_PUBLIC_ACCESS=false
-
-# Directory where LeafWiki data will be stored
+# Data directory
 LEAFWIKI_DATA_DIR=./data
 
-# JWT secret for authentication (required)
+# Auth (required unless LEAFWIKI_DISABLE_AUTH=true)
 LEAFWIKI_JWT_SECRET=
-
-# Admin password (required)
 LEAFWIKI_ADMIN_PASSWORD=
+# LEAFWIKI_ADMIN_USERNAME=admin
+# LEAFWIKI_ADMIN_EMAIL=admin@localhost
 
-# Enable revision history / page history (true/false)
+# Access mode
+LEAFWIKI_PUBLIC_ACCESS=false
+# LEAFWIKI_DISABLE_AUTH=false
+# LEAFWIKI_ALLOW_INSECURE=false
+
+# Tokens
+# LEAFWIKI_ACCESS_TOKEN_TIMEOUT=15m
+# LEAFWIKI_REFRESH_TOKEN_TIMEOUT=168h
+
+# Reverse proxy / SSO
+# LEAFWIKI_BASE_PATH=
+# LEAFWIKI_ENABLE_HTTP_REMOTE_USER=false
+# LEAFWIKI_HTTP_REMOTE_USER_HEADER_NAME=Remote-User
+# LEAFWIKI_TRUSTED_PROXY_IPS=
+# LEAFWIKI_LOGIN_URL=
+# LEAFWIKI_LOGOUT_URL=
+# LEAFWIKI_USER_MANAGEMENT_URL=
+
+# Features
 LEAFWIKI_ENABLE_REVISION=
-
-# Maximum revisions kept per page; 0 means unlimited
 LEAFWIKI_MAX_REVISION_HISTORY=
-
-# Enable link refactoring dialog and rewrite flow (true/false)
+# LEAFWIKI_REVISION_COALESCE_WINDOW=5m
 LEAFWIKI_ENABLE_LINK_REFACTOR=
+# LEAFWIKI_ENABLE_API_KEY_MANAGEMENT=false
+# LEAFWIKI_HIDE_LINK_METADATA_SECTION=false
 
+# Uploads / branding
+# LEAFWIKI_MAX_ASSET_UPLOAD_SIZE=50MiB
+# LEAFWIKI_CUSTOM_STYLESHEET=
+# LEAFWIKI_INJECT_CODE_IN_HEADER=
 
+# TOTP (min 32 bytes when users enable 2FA)
+# LEAFWIKI_TOTP_ENCRYPTION_KEY=
+
+# Metrics
+# LEAFWIKI_ENABLE_METRICS=false
+# LEAFWIKI_METRICS_HOST=127.0.0.1
+# LEAFWIKI_METRICS_PORT=9091
+
+# Snapshots / restore
+# LEAFWIKI_SNAPSHOT=true
+# LEAFWIKI_SNAPSHOT_INTERVAL=24h
+# LEAFWIKI_SNAPSHOT_RETENTION=10
+# LEAFWIKI_SNAPSHOT_DIR=
+# LEAFWIKI_RESTORE_UPLOAD_MAX_SIZE=500MiB
+
+# Git backup (experimental)
+# LEAFWIKI_GIT_BACKUP=false
+# LEAFWIKI_GIT_BACKUP_REMOTE=
+# LEAFWIKI_GIT_BACKUP_BRANCH=main
+# LEAFWIKI_GIT_BACKUP_SSH_KEY=
+# LEAFWIKI_GIT_BACKUP_SSH_KEY_PATH=
+# LEAFWIKI_GIT_BACKUP_SSH_KNOWN_HOSTS=
+# LEAFWIKI_GIT_BACKUP_AUTHOR_NAME=LeafWiki Backup
+# LEAFWIKI_GIT_BACKUP_AUTHOR_EMAIL=backup@leafwiki.local
+# LEAFWIKI_GIT_BACKUP_INTERVAL=60m
+
+# Logging / update check
+# LEAFWIKI_LOG_FORMAT=text
+# LEAFWIKI_LOG_LEVEL=info
+# LEAFWIKI_DISABLE_REQUEST_LOG=false
+# LEAFWIKI_DISABLE_UPDATE_CHECK=false


### PR DESCRIPTION
Expands .env.example so non-interactive installs see the main documented env vars.
Fixes #1399
