### PR TITLE
docs: fix nginx and Raspberry Pi install guides

### DIFF
--- a/docs/install/nginx.md
+++ b/docs/install/nginx.md
@@ -11,7 +11,8 @@ Run the installation script:
 ```bash
 curl -sL https://raw.githubusercontent.com/perber/leafwiki/main/install.sh -o install.sh
 chmod +x ./install.sh
-sudo ./install.sh --arch arm64 --port 8080 --host 127.0.0.1
+sudo ./install.sh --arch amd64 --port 8080 --host 127.0.0.1
+# Use --arch arm64 on ARM hosts (e.g. some cloud instances / Raspberry Pi).
 ```
 
 Thanks to @Hugo-Galley for providing this installation script!
@@ -55,7 +56,7 @@ sudo systemctl start nginx
 Create a new site configuration file:
 
 ```bash
-sudo nano /etc/nginx/sites-available/demo.leafwiki.com.conf
+sudo nano /etc/nginx/sites-available/wiki.example.com.conf
 ```
 
 Add the following content:
@@ -65,7 +66,7 @@ server {
     listen 80;
     listen [::]:80;
 
-    server_name demo.leafwiki.com;
+    server_name wiki.example.com;
 
     location / {
         proxy_pass         http://127.0.0.1:8080;
@@ -82,13 +83,13 @@ server {
 Enable the site and reload nginx:
 
 ```bash
-sudo ln -s /etc/nginx/sites-available/demo.leafwiki.com.conf /etc/nginx/sites-enabled/demo.leafwiki.com.conf
+sudo ln -s /etc/nginx/sites-available/wiki.example.com.conf /etc/nginx/sites-enabled/wiki.example.com.conf
 sudo nginx -t
 sudo systemctl reload nginx
 ```
 
 Now LeafWiki should be accessible at  
-➡️ `http://demo.leafwiki.com`
+➡️ `http://wiki.example.com`
 
 ---
 
@@ -104,7 +105,7 @@ sudo apt install certbot python3-certbot-nginx -y
 Obtain and install the certificate:
 
 ```bash
-sudo certbot --nginx -d demo.leafwiki.com
+sudo certbot --nginx -d wiki.example.com
 ```
 
 Follow the prompts:
@@ -119,12 +120,12 @@ Follow the prompts:
 ## 5. Final nginx Configuration (with HTTPS)
 
 After Certbot runs, your configuration at  
-`/etc/nginx/sites-available/demo.leafwiki.com.conf`  
+`/etc/nginx/sites-available/wiki.example.com.conf`  
 should look like this:
 
 ```nginx
 server {
-    server_name demo.leafwiki.com;
+    server_name wiki.example.com;
     client_max_body_size 50M;
 
     location / {
@@ -139,27 +140,27 @@ server {
 
     listen [::]:443 ssl ipv6only=on; # managed by Certbot
     listen 443 ssl;                  # managed by Certbot
-    ssl_certificate     /etc/letsencrypt/live/demo.leafwiki.com/fullchain.pem;  # managed by Certbot
-    ssl_certificate_key /etc/letsencrypt/live/demo.leafwiki.com/privkey.pem;    # managed by Certbot
+    ssl_certificate     /etc/letsencrypt/live/wiki.example.com/fullchain.pem;  # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/wiki.example.com/privkey.pem;    # managed by Certbot
     include             /etc/letsencrypt/options-ssl-nginx.conf;                # managed by Certbot
     ssl_dhparam         /etc/letsencrypt/ssl-dhparams.pem;                      # managed by Certbot
 }
 
 server {
-    if ($host = demo.leafwiki.com) {
+    if ($host = wiki.example.com) {
         return 301 https://$host$request_uri;
     } # managed by Certbot
 
     listen 80;
     listen [::]:80;
 
-    server_name demo.leafwiki.com;
+    server_name wiki.example.com;
     return 404; # managed by Certbot
 }
 ```
 
 Now LeafWiki is available securely at:  
-➡️ **https://demo.leafwiki.com**
+➡️ **https://wiki.example.com**
 
 ---
 

--- a/docs/install/raspberry.md
+++ b/docs/install/raspberry.md
@@ -1,14 +1,14 @@
-# Install `Leafwiki` on a Raspberry Pi
+# Install `LeafWiki` on a Raspberry Pi
 
-Short introduction: this file explains how to install Leafwiki on a Raspberry Pi and how to expose it to the Internet using Cloudflare Tunnel.
+Short introduction: this file explains how to install LeafWiki on a Raspberry Pi and how to expose it to the Internet using Cloudflare Tunnel.
 
 ## Project installation
-To begin, you need to install `Leafwiki`. Here is the "quick install" command:
+To begin, you need to install `LeafWiki`. Here is the "quick install" command:
 ```bash
 curl -sL https://raw.githubusercontent.com/perber/leafwiki/main/install.sh -o install.sh && chmod +x ./install.sh && sudo ./install.sh --arch arm64
 ```
 
-Thanks to this command, the Leafwiki service is now installed and should be accessible locally at:
+Thanks to this command, the LeafWiki service is now installed and should be accessible locally at:
 
 http://localhost:8080/
 
@@ -66,8 +66,8 @@ Connect to your Raspberry Pi via SSH and copy/paste the commands shown.
 
 ## Exposing your application
 
-Once the machine and the tunnel are connected, you must register the application to expose, here `Leafwiki`. Fill in the requested information and save the configuration.
+Once the machine and the tunnel are connected, you must register the application to expose, here `LeafWiki`. Fill in the requested information and save the configuration.
 
-Choose the `HTTP` protocol and enter `localhost:8080` to target Leafwiki.
+Choose the `HTTP` protocol and enter `localhost:8080` to target LeafWiki.
 
 ![image-6](../assets/install/raspberry/image-6.png)


### PR DESCRIPTION
Corrects the Ubuntu nginx guide default arch (amd64), uses a generic example hostname, and normalizes LeafWiki branding in the Raspberry Pi guide.
Fixes #1400
