### PR TITLE
docs: align README keyboard shortcuts with shortcut catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,7 +570,6 @@ For most setups, prefer `--public-access` for read-only public access and the vi
 | Delete page           | `Ctrl + Delete` / `Cmd + Delete`       |
 | Bold                  | `Ctrl + B` / `Cmd + B`                 |
 | Italic                | `Ctrl + I` / `Cmd + I`                 |
-| Inline code           | `Ctrl+Backtick` / `Cmd+Backtick`           |
 | Insert link           | `Ctrl + K` / `Cmd + K`                 |
 | Headline 1–3          | `Ctrl + Alt + 1–3` / `Cmd + Alt + 1–3` |
 

--- a/README.md
+++ b/README.md
@@ -556,17 +556,28 @@ For most setups, prefer `--public-access` for read-only public access and the vi
 
 | Action                | Shortcut                               |
 |-----------------------|----------------------------------------|
+| Shortcuts help        | `Ctrl + /` / `Cmd + /`                 |
 | Edit mode             | `Ctrl + E` / `Cmd + E`                 |
 | Save                  | `Ctrl + S` / `Cmd + S`                 |
 | Search                | `Ctrl + Shift + F` / `Cmd + Shift + F` |
 | Navigation pane       | `Ctrl + Shift + E` / `Cmd + Shift + E` |
 | Go to page            | `Ctrl + Alt + P` / `Cmd + Option + P`  |
+| Toggle TOC            | `Ctrl + Shift + O` / `Cmd + Shift + O` |
+| Copy page link        | `Ctrl + Shift + S` / `Cmd + Shift + S` |
+| Share / permalink     | `Ctrl + Shift + L` / `Cmd + Shift + L` |
+| Page history          | `Ctrl + H` / `Cmd + H`                 |
+| Print page            | `Ctrl + P` / `Cmd + P`                 |
+| Delete page           | `Ctrl + Delete` / `Cmd + Delete`       |
 | Bold                  | `Ctrl + B` / `Cmd + B`                 |
 | Italic                | `Ctrl + I` / `Cmd + I`                 |
+| Inline code           | `Ctrl+Backtick` / `Cmd+Backtick`           |
+| Insert link           | `Ctrl + K` / `Cmd + K`                 |
 | Headline 1–3          | `Ctrl + Alt + 1–3` / `Cmd + Alt + 1–3` |
 
 `Ctrl+V` / `Cmd+V` for pasting images and files works in the editor.  
 `Esc` closes modals, dialogs, and edit mode.
+
+Press `Ctrl+/` / `Cmd+/` in the app for the full in-product shortcuts list.
 
 ---
 


### PR DESCRIPTION
Expands the README shortcuts table to match the in-app shortcut catalog.
Related to #1112
