### PR TITLE
test(ui): cover wikiPath resolution helpers

### DIFF
--- a/ui/leafwiki-ui/src/lib/wikiPath.test.ts
+++ b/ui/leafwiki-ui/src/lib/wikiPath.test.ts
@@ -15,7 +15,9 @@ describe('normalizeWikiRoutePath', () => {
   })
 
   it('strips query and hash fragments', () => {
-    expect(normalizeWikiRoutePath('/docs/guide?q=1#section')).toBe('/docs/guide')
+    expect(normalizeWikiRoutePath('/docs/guide?q=1#section')).toBe(
+      '/docs/guide',
+    )
   })
 
   it('keeps root as /', () => {
@@ -25,7 +27,9 @@ describe('normalizeWikiRoutePath', () => {
 
 describe('toWikiLookupPath', () => {
   it('converts absolute wiki routes to tree lookup keys', () => {
-    expect(toWikiLookupPath('/docs/getting-started')).toBe('docs/getting-started')
+    expect(toWikiLookupPath('/docs/getting-started')).toBe(
+      'docs/getting-started',
+    )
     expect(toWikiLookupPath('/')).toBe('')
   })
 })
@@ -34,13 +38,16 @@ describe('getWikiTargetRoutePath', () => {
   it('maps edit and history routes back to the view path', () => {
     expect(getWikiTargetRoutePath('/e/docs/guide')).toBe('/docs/guide')
     expect(getWikiTargetRoutePath('/history/docs/guide')).toBe('/docs/guide')
+    expect(getWikiTargetRoutePath('/history')).toBe('/')
     expect(getWikiTargetRoutePath('/docs/guide')).toBe('/docs/guide')
   })
 })
 
 describe('resolveWikiLinkPath', () => {
   it('resolves relative links with page-as-folder semantics', () => {
-    expect(resolveWikiLinkPath('/docs/guide', 'setup')).toBe('/docs/guide/setup')
+    expect(resolveWikiLinkPath('/docs/guide', 'setup')).toBe(
+      '/docs/guide/setup',
+    )
     expect(resolveWikiLinkPath('/docs/guide', '../other')).toBe('/docs/other')
     expect(resolveWikiLinkPath('/docs/guide', './child/page')).toBe(
       '/docs/guide/child/page',
@@ -65,13 +72,24 @@ describe('getParentWikiRoutePath', () => {
 
 describe('getDeleteRedirectRoutePath', () => {
   it('redirects to the parent when the deleted page is open', () => {
-    expect(getDeleteRedirectRoutePath('/docs/guide', '/docs/guide')).toBe('/docs')
+    expect(getDeleteRedirectRoutePath('/docs/guide', '/docs/guide')).toBe(
+      '/docs',
+    )
+  })
+
+  it('redirects from editor and history routes for the deleted page', () => {
+    expect(getDeleteRedirectRoutePath('/e/docs/guide', '/docs/guide')).toBe(
+      '/docs',
+    )
+    expect(
+      getDeleteRedirectRoutePath('/history/docs/guide', '/docs/guide'),
+    ).toBe('/docs')
   })
 
   it('redirects to the parent when a nested route under the deleted page is open', () => {
-    expect(
-      getDeleteRedirectRoutePath('/docs/guide/setup', '/docs/guide'),
-    ).toBe('/docs')
+    expect(getDeleteRedirectRoutePath('/docs/guide/setup', '/docs/guide')).toBe(
+      '/docs',
+    )
   })
 
   it('keeps the current route when another page is open', () => {

--- a/ui/leafwiki-ui/src/lib/wikiPath.test.ts
+++ b/ui/leafwiki-ui/src/lib/wikiPath.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getDeleteRedirectRoutePath,
+  getParentWikiRoutePath,
+  getWikiTargetRoutePath,
+  normalizeWikiRoutePath,
+  resolveWikiLinkPath,
+  toWikiLookupPath,
+} from './wikiPath'
+
+describe('normalizeWikiRoutePath', () => {
+  it('adds a leading slash and strips trailing slashes', () => {
+    expect(normalizeWikiRoutePath('docs/guide')).toBe('/docs/guide')
+    expect(normalizeWikiRoutePath('/docs/guide/')).toBe('/docs/guide')
+  })
+
+  it('strips query and hash fragments', () => {
+    expect(normalizeWikiRoutePath('/docs/guide?q=1#section')).toBe('/docs/guide')
+  })
+
+  it('keeps root as /', () => {
+    expect(normalizeWikiRoutePath('/')).toBe('/')
+  })
+})
+
+describe('toWikiLookupPath', () => {
+  it('converts absolute wiki routes to tree lookup keys', () => {
+    expect(toWikiLookupPath('/docs/getting-started')).toBe('docs/getting-started')
+    expect(toWikiLookupPath('/')).toBe('')
+  })
+})
+
+describe('getWikiTargetRoutePath', () => {
+  it('maps edit and history routes back to the view path', () => {
+    expect(getWikiTargetRoutePath('/e/docs/guide')).toBe('/docs/guide')
+    expect(getWikiTargetRoutePath('/history/docs/guide')).toBe('/docs/guide')
+    expect(getWikiTargetRoutePath('/docs/guide')).toBe('/docs/guide')
+  })
+})
+
+describe('resolveWikiLinkPath', () => {
+  it('resolves relative links with page-as-folder semantics', () => {
+    expect(resolveWikiLinkPath('/docs/guide', 'setup')).toBe('/docs/guide/setup')
+    expect(resolveWikiLinkPath('/docs/guide', '../other')).toBe('/docs/other')
+    expect(resolveWikiLinkPath('/docs/guide', './child/page')).toBe(
+      '/docs/guide/child/page',
+    )
+  })
+
+  it('resolves absolute wiki paths from the site root', () => {
+    expect(resolveWikiLinkPath('/docs/guide', '/root-page')).toBe('/root-page')
+  })
+})
+
+describe('getParentWikiRoutePath', () => {
+  it('returns / for top-level pages', () => {
+    expect(getParentWikiRoutePath('/docs')).toBe('/')
+    expect(getParentWikiRoutePath('/')).toBe('/')
+  })
+
+  it('returns the parent for nested pages', () => {
+    expect(getParentWikiRoutePath('/docs/guide/setup')).toBe('/docs/guide')
+  })
+})
+
+describe('getDeleteRedirectRoutePath', () => {
+  it('redirects to the parent when the deleted page is open', () => {
+    expect(getDeleteRedirectRoutePath('/docs/guide', '/docs/guide')).toBe('/docs')
+  })
+
+  it('redirects to the parent when a nested route under the deleted page is open', () => {
+    expect(
+      getDeleteRedirectRoutePath('/docs/guide/setup', '/docs/guide'),
+    ).toBe('/docs')
+  })
+
+  it('keeps the current route when another page is open', () => {
+    expect(getDeleteRedirectRoutePath('/docs/other', '/docs/guide')).toBe(
+      '/docs/other',
+    )
+  })
+})


### PR DESCRIPTION
Adds unit tests for wiki path normalization, relative Markdown link resolution, and delete-redirect helpers.
Related to #1236
