### PR TITLE
fix(i18n): replace leftover hardcoded English UI strings

### DIFF
--- a/ui/leafwiki-ui/src/features/editor/frontmatter.ts
+++ b/ui/leafwiki-ui/src/features/editor/frontmatter.ts
@@ -1,3 +1,5 @@
+import i18next from '@/lib/i18n'
+
 const TAGS_KEY_PATTERN = /^tags\s*:\s*(.*)$/
 const FRONTMATTER_KEY_PATTERN = /^([^:\n][^:\n]*?)\s*:\s*(.*)$/
 const INTERNAL_FIELD_PREFIX = 'leafwiki_'
@@ -115,18 +117,18 @@ export function validateEditorFrontmatterMetadata(
 
   for (const tag of tags) {
     if (tag.trim() !== tag) {
-      errors.tags = 'Tags must not contain leading or trailing whitespace.'
+      errors.tags = i18next.t('frontmatterValidation.tagsWhitespace', { ns: 'editor' })
       break
     }
 
     if (tag.trim() === '') {
-      errors.tags = 'Tags must not be empty.'
+      errors.tags = i18next.t('frontmatterValidation.tagsEmpty', { ns: 'editor' })
       break
     }
 
     const key = tag.toLocaleLowerCase()
     if (seenTags.has(key)) {
-      errors.tags = 'Tags must be unique.'
+      errors.tags = i18next.t('frontmatterValidation.tagsUnique', { ns: 'editor' })
       break
     }
     seenTags.add(key)
@@ -140,34 +142,34 @@ export function validateEditorFrontmatterMetadata(
     const trimmedKey = field.key.trim()
 
     if (trimmedKey === '') {
-      errors[keyField] = 'Property key must not be empty.'
+      errors[keyField] = i18next.t('frontmatterValidation.keyEmpty', { ns: 'editor' })
       return
     }
 
     if (trimmedKey !== field.key) {
       errors[keyField] =
-        'Property key must not contain leading or trailing whitespace.'
+        i18next.t('frontmatterValidation.keyWhitespace', { ns: 'editor' })
       return
     }
 
     if (trimmedKey.toLocaleLowerCase().startsWith(INTERNAL_FIELD_PREFIX)) {
-      errors[keyField] = 'Property key uses a reserved prefix.'
+      errors[keyField] = i18next.t('frontmatterValidation.keyReservedPrefix', { ns: 'editor' })
       return
     }
 
     const lowerKey = trimmedKey.toLocaleLowerCase()
     if (lowerKey === 'tags') {
-      errors[keyField] = 'Property key is reserved.'
+      errors[keyField] = i18next.t('frontmatterValidation.keyReserved', { ns: 'editor' })
       return
     }
 
     const dedupeKey = trimmedKey.toLocaleLowerCase()
     const existingIndex = seenKeys.get(dedupeKey)
     if (existingIndex !== undefined) {
-      errors[keyField] = 'Property key must be unique.'
+      errors[keyField] = i18next.t('frontmatterValidation.keyUnique', { ns: 'editor' })
       if (!errors[`properties.${existingIndex}.key`]) {
         errors[`properties.${existingIndex}.key`] =
-          'Property key must be unique.'
+          i18next.t('frontmatterValidation.keyUnique', { ns: 'editor' })
       }
       return
     }
@@ -179,7 +181,7 @@ export function validateEditorFrontmatterMetadata(
 
     if (typeof field.value !== 'string') {
       errors[valueField] =
-        'Property value must be a string, number, boolean, or flat list.'
+        i18next.t('frontmatterValidation.valueType', { ns: 'editor' })
     }
   })
 

--- a/ui/leafwiki-ui/src/features/tree/TreeView.tsx
+++ b/ui/leafwiki-ui/src/features/tree/TreeView.tsx
@@ -160,7 +160,7 @@ export default function TreeView() {
             icon={
               <MoreHorizontal className="tree-view__action-icon" size={18} />
             }
-            tooltip="More actions"
+            tooltip={t('toolbar.moreActions')}
           />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" className="w-44">
@@ -170,7 +170,7 @@ export default function TreeView() {
             data-testid="tree-view-action-button-expand-all"
           >
             <ChevronsDown size={15} />
-            Expand all
+            {t('toolbar.expandAll')}
           </DropdownMenuItem>
           <DropdownMenuItem
             className="cursor-pointer gap-2"
@@ -178,7 +178,7 @@ export default function TreeView() {
             data-testid="tree-view-action-button-collapse-all"
           >
             <ChevronsUp size={15} />
-            Collapse all
+            {t('toolbar.collapseAll')}
           </DropdownMenuItem>
           {!readOnlyMode && tree && (
             <DropdownMenuItem

--- a/ui/leafwiki-ui/src/features/viewer/viewer.ts
+++ b/ui/leafwiki-ui/src/features/viewer/viewer.ts
@@ -2,6 +2,7 @@
 // f.g. loading, error, page data
 
 import { getPageByPath, Page } from '@/lib/api/pages'
+import i18next from '@/lib/i18n'
 import { isPageNotFoundError } from '@/lib/api/errors'
 import { create } from 'zustand'
 import { useProgressbarStore } from '../progressbar/progressbarStore'
@@ -47,7 +48,7 @@ export const useViewerStore = create<ViewerState>((set) => ({
       } else if (err instanceof Error) {
         set({ error: err.message, notFound: false })
       } else {
-        set({ error: 'An unknown error occurred', notFound: false })
+        set({ error: i18next.t('common.unknownError', { ns: 'page' }), notFound: false })
       }
     } finally {
       if (!signal.aborted) {

--- a/ui/leafwiki-ui/src/locales/en/editor.json
+++ b/ui/leafwiki-ui/src/locales/en/editor.json
@@ -107,5 +107,16 @@
     "savedToast": "Saved",
     "versionConflictToast": "Auto-save paused — page was changed by another user. Save manually to continue.",
     "errorFallback": "Auto-save failed"
+  },
+  "frontmatterValidation": {
+    "tagsWhitespace": "Tags must not contain leading or trailing whitespace.",
+    "tagsEmpty": "Tags must not be empty.",
+    "tagsUnique": "Tags must be unique.",
+    "keyEmpty": "Property key must not be empty.",
+    "keyWhitespace": "Property key must not contain leading or trailing whitespace.",
+    "keyReservedPrefix": "Property key uses a reserved prefix.",
+    "keyReserved": "Property key is reserved.",
+    "keyUnique": "Property key must be unique.",
+    "valueType": "Property value must be a string, number, boolean, or flat list."
   }
 }

--- a/ui/leafwiki-ui/src/locales/en/viewer.json
+++ b/ui/leafwiki-ui/src/locales/en/viewer.json
@@ -73,7 +73,9 @@
     "expand": "Expand table of contents"
   },
   "toolbar": {
-    "moreActions": "More actions"
+    "moreActions": "More actions",
+    "expandAll": "Expand all",
+    "collapseAll": "Collapse all"
   },
   "pageToolbar": {
     "itemPage": "Page",


### PR DESCRIPTION
Moves remaining hardcoded English strings in the tree overflow menu, viewer error fallback, and frontmatter validation onto the existing i18n catalogs.
Related to #789
