### PR TITLE
fix(ui): prefer color emoji fonts in the sans stack

### DIFF
--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -14,7 +14,7 @@
 ------------------------------------------------------- */
 @theme {
   /* Typography + Radii */
-  --font-sans: InterVariable, system-ui, sans-serif;
+  --font-sans: InterVariable, system-ui, "Segoe UI Emoji", "Apple Color Emoji", "Noto Color Emoji", sans-serif;
   --radius: 0.5rem;
   --radius-lg: 0.5rem;
   --radius-md: 0.375rem;

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -14,7 +14,9 @@
 ------------------------------------------------------- */
 @theme {
   /* Typography + Radii */
-  --font-sans: InterVariable, system-ui, "Segoe UI Emoji", "Apple Color Emoji", "Noto Color Emoji", sans-serif;
+  --font-sans:
+    InterVariable, system-ui, 'Segoe UI Emoji', 'Apple Color Emoji',
+    'Noto Color Emoji', sans-serif;
   --radius: 0.5rem;
   --radius-lg: 0.5rem;
   --radius-md: 0.375rem;


### PR DESCRIPTION
Appends color emoji font fallbacks to --font-sans so emoji keep color without using font-variant-emoji (which broke Chrome text).
Addresses #748
