### PR TITLE
fix(links): strip .md suffix when resolving relative page links

### DIFF
--- a/internal/links/helpers.go
+++ b/internal/links/helpers.go
@@ -266,8 +266,15 @@ func resolveURLPath(currentPath, href string) (string, error) {
 
 	resolved := base.ResolveReference(ref)
 
+	path := resolved.Path
+	// Importers and filesystem-oriented Markdown often keep a .md suffix;
+	// LeafWiki page routes do not, so strip it before lookup.
+	if strings.HasSuffix(strings.ToLower(path), ".md") {
+		path = path[:len(path)-3]
+	}
+
 	// normalize result path (strip trailing slash etc.)
-	return normalizeWikiPath(resolved.Path), nil
+	return normalizeWikiPath(path), nil
 }
 
 func resolveTargetLinks(tree *tree.TreeService, currentPath string, links []string) []TargetLink {

--- a/internal/links/resolve_url_path_test.go
+++ b/internal/links/resolve_url_path_test.go
@@ -1,0 +1,21 @@
+package links
+
+import "testing"
+
+func TestResolveURLPath_StripsMarkdownSuffix(t *testing.T) {
+	got, err := resolveURLPath("/docs/guide", "setup.md")
+	if err != nil {
+		t.Fatalf("resolveURLPath: %v", err)
+	}
+	if got != "/docs/guide/setup" {
+		t.Fatalf("got %q, want /docs/guide/setup", got)
+	}
+
+	got, err = resolveURLPath("/docs/guide", "../other.md")
+	if err != nil {
+		t.Fatalf("resolveURLPath: %v", err)
+	}
+	if got != "/docs/other" {
+		t.Fatalf("got %q, want /docs/other", got)
+	}
+}

--- a/ui/leafwiki-ui/src/lib/wikiPath.mdSuffix.test.ts
+++ b/ui/leafwiki-ui/src/lib/wikiPath.mdSuffix.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { resolveWikiLinkPath } from './wikiPath'
+
+describe('resolveWikiLinkPath markdown suffix', () => {
+  it('strips a trailing .md from relative targets', () => {
+    expect(resolveWikiLinkPath('/docs/guide', 'setup.md')).toBe('/docs/guide/setup')
+    expect(resolveWikiLinkPath('/docs/guide', '../other.md')).toBe('/docs/other')
+  })
+
+  it('strips .md case-insensitively', () => {
+    expect(resolveWikiLinkPath('/docs/guide', 'Setup.MD')).toBe('/docs/guide/Setup')
+  })
+})

--- a/ui/leafwiki-ui/src/lib/wikiPath.ts
+++ b/ui/leafwiki-ui/src/lib/wikiPath.ts
@@ -69,7 +69,13 @@ export function resolveWikiLinkPath(currentPath: string, href: string): string {
   const base = new URL(folderBase, 'https://leafwiki.local')
   const url = new URL(href, base)
 
-  return normalizeWikiRoutePath(url.pathname)
+  let pathname = url.pathname
+  // Filesystem-style Markdown links often keep a .md suffix; wiki routes do not.
+  if (pathname.toLowerCase().endsWith('.md')) {
+    pathname = pathname.slice(0, -3)
+  }
+
+  return normalizeWikiRoutePath(pathname)
 }
 
 /**


### PR DESCRIPTION
Strips a trailing .md from relative Markdown link targets in both Go link resolution and the UI wikiPath helper, matching importer behavior.
Related to #1236
