### PR TITLE
fix: Stop forced logout when auth mode is unconfirmed after a config load …

### DIFF
--- a/ui/leafwiki-ui/src/lib/api/auth.test.ts
+++ b/ui/leafwiki-ui/src/lib/api/auth.test.ts
@@ -1,0 +1,244 @@
+import '@/lib/i18n'
+import { useConfigStore } from '@/stores/config'
+import { useSessionStore } from '@/stores/session'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ensureRefresh, fetchWithAuth } from './auth'
+
+type MockResponseSpec = {
+  status: number
+  body?: unknown
+}
+
+// Maps a request path suffix (e.g. '/api/auth/refresh-token') to one response,
+// or a queue of responses consumed in order across repeated calls to the same
+// path (used to simulate "401 then a successful retry").
+function createFetchMock(
+  routes: Record<string, MockResponseSpec | MockResponseSpec[]>,
+) {
+  const queues = new Map<string, MockResponseSpec[]>(
+    Object.entries(routes).map(([path, spec]) => [
+      path,
+      Array.isArray(spec) ? [...spec] : [spec],
+    ]),
+  )
+
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    const path = Object.keys(routes).find((p) => url.endsWith(p))
+    if (!path) {
+      return new Response(JSON.stringify({ error: 'unmapped_route' }), {
+        status: 404,
+      })
+    }
+    const queue = queues.get(path)!
+    const spec = queue.length > 1 ? queue.shift()! : queue[0]
+    return new Response(JSON.stringify(spec.body ?? {}), {
+      status: spec.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  })
+}
+
+function calledPaths(fetchMock: ReturnType<typeof createFetchMock>): string[] {
+  return fetchMock.mock.calls.map(([input]) =>
+    typeof input === 'string' ? input : String(input),
+  )
+}
+
+const testUser = {
+  id: 'user-1',
+  username: 'ivan',
+  email: 'ivan@example.com',
+  role: 'admin' as const,
+  totpEnabled: false,
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('ensureRefresh', () => {
+  beforeEach(() => {
+    useConfigStore.setState({
+      authDisabled: false,
+      httpRemoteUserEnabled: false,
+      configLoadSucceeded: true,
+    })
+    useSessionStore.setState({ user: null, accessTokenExpiresAt: null })
+  })
+
+  it('TestEnsureRefresh_ConfigLoadNotSucceeded_StillAttemptsRefresh', async () => {
+    // Deliberate: attempting the call is harmless by itself (worst case one
+    // wasted 422). Skipping it here entirely would permanently disable
+    // refresh for session-auth deployments that hit one bad /api/config
+    // fetch — see the comment on ensureRefresh() for the full reasoning.
+    useConfigStore.setState({ configLoadSucceeded: false })
+    const fetchMock = createFetchMock({
+      '/api/auth/refresh-token': { status: 422 },
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(ensureRefresh()).rejects.toThrow()
+
+    expect(
+      calledPaths(fetchMock).some((p) => p.endsWith('/api/auth/refresh-token')),
+    ).toBe(true)
+  })
+
+  it('TestEnsureRefresh_HttpRemoteUserEnabled_DoesNotCallRefreshEndpoint', async () => {
+    useConfigStore.setState({
+      httpRemoteUserEnabled: true,
+      configLoadSucceeded: true,
+    })
+    const fetchMock = createFetchMock({})
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(ensureRefresh()).resolves.toBeUndefined()
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('TestEnsureRefresh_AuthDisabled_DoesNotCallRefreshEndpoint', async () => {
+    useConfigStore.setState({ authDisabled: true })
+    const fetchMock = createFetchMock({})
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(ensureRefresh()).resolves.toBeUndefined()
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('TestEnsureRefresh_SessionAuthConfirmed_CallsRefreshEndpoint', async () => {
+    const fetchMock = createFetchMock({
+      '/api/auth/refresh-token': {
+        status: 200,
+        body: {
+          accessTokenExpiresAt: Math.floor(Date.now() / 1000) + 3600,
+          message: 'ok',
+          user: testUser,
+        },
+      },
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await ensureRefresh()
+
+    expect(
+      calledPaths(fetchMock).some((p) => p.endsWith('/api/auth/refresh-token')),
+    ).toBe(true)
+  })
+})
+
+describe('fetchWithAuth', () => {
+  beforeEach(() => {
+    useConfigStore.setState({
+      authDisabled: false,
+      httpRemoteUserEnabled: false,
+      configLoadSucceeded: true,
+      hasLoaded: true,
+    })
+    useSessionStore.setState({ user: null, accessTokenExpiresAt: null })
+  })
+
+  it('TestFetchWithAuth_ConfigLoadFailed_PreemptiveRefreshFails_RequestStillSucceeds', async () => {
+    // Reproduces the exact reported scenario (GitHub #1407): config failed to
+    // load, a user is persisted from a prior header-auth session (so
+    // accessTokenExpiresAt is null and shouldRefreshBeforeRequest fires on
+    // every request), the speculative refresh 422s like it always would for
+    // header-auth — but the real request must still go through and succeed,
+    // and must not force a logout / touch the CSRF cookie.
+    useConfigStore.setState({ configLoadSucceeded: false })
+    useSessionStore.setState({ user: testUser, accessTokenExpiresAt: null })
+
+    const fetchMock = createFetchMock({
+      '/api/some/path': { status: 200, body: { ok: true } },
+      '/api/auth/refresh-token': { status: 422 },
+      '/api/auth/logout': { status: 200 },
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchWithAuth('/api/some/path')
+
+    expect(result).toEqual({ ok: true })
+    const paths = calledPaths(fetchMock)
+    expect(paths.some((p) => p.endsWith('/api/auth/refresh-token'))).toBe(true)
+    expect(paths.some((p) => p.endsWith('/api/auth/logout'))).toBe(false)
+    expect(useSessionStore.getState().user).toEqual(testUser)
+  })
+
+  it('TestFetchWithAuth_ConfigLoadFailed_Genuine401_SurfacesErrorWithoutLogout', async () => {
+    useConfigStore.setState({ configLoadSucceeded: false })
+    useSessionStore.setState({
+      user: testUser,
+      // Far enough in the future that shouldRefreshBeforeRequest skips the
+      // preemptive path, isolating this test to the 401-retry branch.
+      accessTokenExpiresAt: Math.floor(Date.now() / 1000) + 3600,
+    })
+
+    const fetchMock = createFetchMock({
+      '/api/some/path': { status: 401 },
+      '/api/auth/refresh-token': { status: 422 },
+      '/api/auth/logout': { status: 200 },
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchWithAuth('/api/some/path')).rejects.toThrow()
+
+    expect(
+      calledPaths(fetchMock).some((p) => p.endsWith('/api/auth/logout')),
+    ).toBe(false)
+    expect(useSessionStore.getState().user).toEqual(testUser)
+  })
+
+  it('TestFetchWithAuth_SessionAuthConfirmed_401RetryStillWorks', async () => {
+    useConfigStore.setState({ configLoadSucceeded: true })
+    useSessionStore.setState({
+      user: testUser,
+      accessTokenExpiresAt: Math.floor(Date.now() / 1000) + 3600,
+    })
+
+    const fetchMock = createFetchMock({
+      '/api/some/path': [{ status: 401 }, { status: 200, body: { ok: true } }],
+      '/api/auth/refresh-token': {
+        status: 200,
+        body: {
+          accessTokenExpiresAt: Math.floor(Date.now() / 1000) + 3600,
+          message: 'ok',
+          user: testUser,
+        },
+      },
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchWithAuth('/api/some/path')
+
+    expect(result).toEqual({ ok: true })
+    expect(
+      calledPaths(fetchMock).filter((p) =>
+        p.endsWith('/api/auth/refresh-token'),
+      ),
+    ).toHaveLength(1)
+  })
+
+  it('TestFetchWithAuth_SessionAuthConfirmed_ExpiredTokenStillForcesLogout', async () => {
+    useConfigStore.setState({ configLoadSucceeded: true })
+    useSessionStore.setState({
+      user: testUser,
+      accessTokenExpiresAt: Math.floor(Date.now() / 1000) + 3600,
+    })
+
+    const fetchMock = createFetchMock({
+      '/api/some/path': { status: 401 },
+      '/api/auth/refresh-token': { status: 422 },
+      '/api/auth/logout': { status: 200 },
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchWithAuth('/api/some/path')).rejects.toThrow()
+
+    expect(
+      calledPaths(fetchMock).some((p) => p.endsWith('/api/auth/logout')),
+    ).toBe(true)
+    expect(useSessionStore.getState().user).toBeNull()
+  })
+})

--- a/ui/leafwiki-ui/src/lib/api/auth.test.ts
+++ b/ui/leafwiki-ui/src/lib/api/auth.test.ts
@@ -67,7 +67,7 @@ describe('ensureRefresh', () => {
     useSessionStore.setState({ user: null, accessTokenExpiresAt: null })
   })
 
-  it('TestEnsureRefresh_ConfigLoadNotSucceeded_StillAttemptsRefresh', async () => {
+  it('still attempts refresh when config is not confirmed (may be a wasted 422)', async () => {
     // Deliberate: attempting the call is harmless by itself (worst case one
     // wasted 422). Skipping it here entirely would permanently disable
     // refresh for session-auth deployments that hit one bad /api/config
@@ -85,7 +85,7 @@ describe('ensureRefresh', () => {
     ).toBe(true)
   })
 
-  it('TestEnsureRefresh_HttpRemoteUserEnabled_DoesNotCallRefreshEndpoint', async () => {
+  it('does not call the refresh endpoint when httpRemoteUserEnabled is true', async () => {
     useConfigStore.setState({
       httpRemoteUserEnabled: true,
       configLoadSucceeded: true,
@@ -98,7 +98,7 @@ describe('ensureRefresh', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it('TestEnsureRefresh_AuthDisabled_DoesNotCallRefreshEndpoint', async () => {
+  it('does not call the refresh endpoint when auth is disabled', async () => {
     useConfigStore.setState({ authDisabled: true })
     const fetchMock = createFetchMock({})
     vi.stubGlobal('fetch', fetchMock)
@@ -108,7 +108,7 @@ describe('ensureRefresh', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it('TestEnsureRefresh_SessionAuthConfirmed_CallsRefreshEndpoint', async () => {
+  it('calls the refresh endpoint for a confirmed session-auth deployment', async () => {
     const fetchMock = createFetchMock({
       '/api/auth/refresh-token': {
         status: 200,
@@ -140,7 +140,7 @@ describe('fetchWithAuth', () => {
     useSessionStore.setState({ user: null, accessTokenExpiresAt: null })
   })
 
-  it('TestFetchWithAuth_ConfigLoadFailed_PreemptiveRefreshFails_RequestStillSucceeds', async () => {
+  it('still succeeds when a preemptive refresh fails and config has not loaded', async () => {
     // Reproduces the exact reported scenario (GitHub #1407): config failed to
     // load, a user is persisted from a prior header-auth session (so
     // accessTokenExpiresAt is null and shouldRefreshBeforeRequest fires on
@@ -166,7 +166,7 @@ describe('fetchWithAuth', () => {
     expect(useSessionStore.getState().user).toEqual(testUser)
   })
 
-  it('TestFetchWithAuth_ConfigLoadFailed_Genuine401_SurfacesErrorWithoutLogout', async () => {
+  it('surfaces a genuine 401 as an error without forcing logout when config has not loaded', async () => {
     useConfigStore.setState({ configLoadSucceeded: false })
     useSessionStore.setState({
       user: testUser,
@@ -190,7 +190,7 @@ describe('fetchWithAuth', () => {
     expect(useSessionStore.getState().user).toEqual(testUser)
   })
 
-  it('TestFetchWithAuth_SessionAuthConfirmed_401RetryStillWorks', async () => {
+  it('retries and succeeds after a 401 for a confirmed session-auth deployment', async () => {
     useConfigStore.setState({ configLoadSucceeded: true })
     useSessionStore.setState({
       user: testUser,
@@ -220,7 +220,7 @@ describe('fetchWithAuth', () => {
     ).toHaveLength(1)
   })
 
-  it('TestFetchWithAuth_SessionAuthConfirmed_ExpiredTokenStillForcesLogout', async () => {
+  it('still forces a logout when a confirmed session token is genuinely expired', async () => {
     useConfigStore.setState({ configLoadSucceeded: true })
     useSessionStore.setState({
       user: testUser,

--- a/ui/leafwiki-ui/src/lib/api/auth.ts
+++ b/ui/leafwiki-ui/src/lib/api/auth.ts
@@ -170,6 +170,7 @@ export async function fetchWithAuth(
   const config = useConfigStore.getState()
   const authDisabled = config.authDisabled
   const httpRemoteUserEnabled = config.httpRemoteUserEnabled
+  const configLoadSucceeded = config.configLoadSucceeded
 
   const headers = new Headers(options.headers || {})
   if (!(options.body instanceof FormData)) {
@@ -213,8 +214,19 @@ export async function fetchWithAuth(
     try {
       await ensureRefresh()
     } catch {
-      await clearSessionState(sessionLogout)
-      throw new Error(t('apiErrors.unauthorized'))
+      // A refresh failure only proves the session is really gone once the
+      // auth mode is confirmed (configLoadSucceeded) — otherwise this could
+      // just as easily be a header-auth deployment whose refresh-token call
+      // was always going to 422 (accessTokenExpiresAt is never set in that
+      // mode, so the check above fires on every request). Forcing this
+      // request to fail on that guess — instead of letting the real request
+      // decide, the same way it already does when httpRemoteUserEnabled is
+      // *confirmed* true — is what caused GitHub #1407 (spurious
+      // CSRF-token-missing logouts, autosave breaking mid-edit).
+      if (configLoadSucceeded) {
+        await clearSessionState(sessionLogout)
+        throw new Error(t('apiErrors.unauthorized'))
+      }
     }
   }
 
@@ -225,8 +237,14 @@ export async function fetchWithAuth(
       await ensureRefresh()
       res = await doFetch()
     } catch {
-      await clearSessionState(sessionLogout)
-      throw new Error(t('apiErrors.unauthorized'))
+      if (configLoadSucceeded) {
+        await clearSessionState(sessionLogout)
+        throw new Error(t('apiErrors.unauthorized'))
+      }
+      // Unconfirmed mode: don't force a logout, but don't fabricate success
+      // either — `res` still holds the original 401 from above, so it falls
+      // through to the generic !res.ok handling below and surfaces as a
+      // normal error instead of a silent retry loop.
     }
   }
 
@@ -308,8 +326,18 @@ async function clearSessionState(sessionLogout: () => Promise<void>) {
 }
 
 export function ensureRefresh(): Promise<void> {
-  const { authDisabled } = useConfigStore.getState()
-  if (authDisabled) {
+  const { authDisabled, httpRemoteUserEnabled } = useConfigStore.getState()
+  // Session-token refresh only applies to session/JWT auth — skip it
+  // whenever that's confirmed false, instead of relying on every caller to
+  // have already checked httpRemoteUserEnabled itself. Deliberately NOT
+  // gated on configLoadSucceeded: attempting a refresh while the auth mode
+  // is still unconfirmed is harmless by itself (worst case one wasted call),
+  // and skipping it here entirely would permanently disable refresh for
+  // session-auth deployments that hit one bad /api/config fetch. The actual
+  // risk — treating an unconfirmed-mode refresh failure as confirmed
+  // unauthorized and forcing a logout — is guarded at the reaction site in
+  // fetchWithAuth instead, not here.
+  if (authDisabled || httpRemoteUserEnabled) {
     return Promise.resolve()
   }
 

--- a/ui/leafwiki-ui/src/lib/bootstrapAuth.test.ts
+++ b/ui/leafwiki-ui/src/lib/bootstrapAuth.test.ts
@@ -1,0 +1,104 @@
+import { useConfigStore } from '@/stores/config'
+import { useSessionStore } from '@/stores/session'
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+import { ApiError, ensureRefresh, fetchMe } from './api/auth'
+import { useBootstrapAuth } from './bootstrapAuth'
+
+vi.mock('./api/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./api/auth')>()
+  return {
+    ...actual,
+    fetchMe: vi.fn(),
+    ensureRefresh: vi.fn(),
+  }
+})
+
+const testUser = {
+  id: 'user-1',
+  username: 'ivan',
+  email: 'ivan@example.com',
+  role: 'admin' as const,
+  totpEnabled: false,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  ;(fetchMe as Mock).mockResolvedValue(null)
+  ;(ensureRefresh as Mock).mockResolvedValue(undefined)
+  useConfigStore.setState({
+    hasLoaded: true,
+    configLoadSucceeded: true,
+    httpRemoteUserEnabled: false,
+    authDisabled: false,
+  })
+  useSessionStore.setState({ user: null, accessTokenExpiresAt: null })
+})
+
+describe('useBootstrapAuth', () => {
+  it('TestUseBootstrapAuth_ConfigLoadFailed_CallsFetchMeNotEnsureRefresh', async () => {
+    useConfigStore.setState({
+      configLoadSucceeded: false,
+      httpRemoteUserEnabled: false,
+    })
+    useSessionStore.setState({ user: testUser })
+
+    renderHook(() => useBootstrapAuth(true))
+
+    await waitFor(() => expect(fetchMe).toHaveBeenCalled())
+    expect(ensureRefresh).not.toHaveBeenCalled()
+  })
+
+  it('TestUseBootstrapAuth_HttpRemoteUserEnabled_CallsFetchMe', async () => {
+    useConfigStore.setState({
+      configLoadSucceeded: true,
+      httpRemoteUserEnabled: true,
+    })
+
+    renderHook(() => useBootstrapAuth(true))
+
+    await waitFor(() => expect(fetchMe).toHaveBeenCalled())
+    expect(ensureRefresh).not.toHaveBeenCalled()
+  })
+
+  it('TestUseBootstrapAuth_SessionAuthConfirmed_CallsEnsureRefresh', async () => {
+    useConfigStore.setState({
+      configLoadSucceeded: true,
+      httpRemoteUserEnabled: false,
+    })
+
+    renderHook(() => useBootstrapAuth(true))
+
+    await waitFor(() => expect(ensureRefresh).toHaveBeenCalled())
+    expect(fetchMe).not.toHaveBeenCalled()
+  })
+
+  it('TestUseBootstrapAuth_HttpRemoteUserEnabled_FetchMeAuthFailure_ClearsUser', async () => {
+    useConfigStore.setState({
+      configLoadSucceeded: true,
+      httpRemoteUserEnabled: true,
+    })
+    useSessionStore.setState({ user: testUser })
+    ;(fetchMe as Mock).mockRejectedValue(new ApiError('unauthorized', 401))
+
+    renderHook(() => useBootstrapAuth(true))
+
+    await waitFor(() => expect(useSessionStore.getState().user).toBeNull())
+  })
+
+  it('TestUseBootstrapAuth_HttpRemoteUserEnabled_FetchMeServerError_PreservesUser', async () => {
+    useConfigStore.setState({
+      configLoadSucceeded: true,
+      httpRemoteUserEnabled: true,
+    })
+    useSessionStore.setState({ user: testUser })
+    ;(fetchMe as Mock).mockRejectedValue(new Error('network error'))
+
+    renderHook(() => useBootstrapAuth(true))
+
+    await waitFor(() =>
+      expect(useSessionStore.getState().isRefreshing).toBe(false),
+    )
+    expect(useSessionStore.getState().user).toEqual(testUser)
+  })
+})

--- a/ui/leafwiki-ui/src/lib/bootstrapAuth.test.ts
+++ b/ui/leafwiki-ui/src/lib/bootstrapAuth.test.ts
@@ -36,7 +36,7 @@ beforeEach(() => {
 })
 
 describe('useBootstrapAuth', () => {
-  it('TestUseBootstrapAuth_ConfigLoadFailed_CallsFetchMeNotEnsureRefresh', async () => {
+  it('calls fetchMe (not ensureRefresh) when config failed to load', async () => {
     useConfigStore.setState({
       configLoadSucceeded: false,
       httpRemoteUserEnabled: false,
@@ -49,7 +49,7 @@ describe('useBootstrapAuth', () => {
     expect(ensureRefresh).not.toHaveBeenCalled()
   })
 
-  it('TestUseBootstrapAuth_HttpRemoteUserEnabled_CallsFetchMe', async () => {
+  it('calls fetchMe when httpRemoteUserEnabled is true', async () => {
     useConfigStore.setState({
       configLoadSucceeded: true,
       httpRemoteUserEnabled: true,
@@ -61,7 +61,7 @@ describe('useBootstrapAuth', () => {
     expect(ensureRefresh).not.toHaveBeenCalled()
   })
 
-  it('TestUseBootstrapAuth_SessionAuthConfirmed_CallsEnsureRefresh', async () => {
+  it('calls ensureRefresh for a confirmed session-auth deployment', async () => {
     useConfigStore.setState({
       configLoadSucceeded: true,
       httpRemoteUserEnabled: false,
@@ -73,7 +73,7 @@ describe('useBootstrapAuth', () => {
     expect(fetchMe).not.toHaveBeenCalled()
   })
 
-  it('TestUseBootstrapAuth_HttpRemoteUserEnabled_FetchMeAuthFailure_ClearsUser', async () => {
+  it('clears the user when fetchMe fails with an auth error', async () => {
     useConfigStore.setState({
       configLoadSucceeded: true,
       httpRemoteUserEnabled: true,
@@ -86,7 +86,7 @@ describe('useBootstrapAuth', () => {
     await waitFor(() => expect(useSessionStore.getState().user).toBeNull())
   })
 
-  it('TestUseBootstrapAuth_HttpRemoteUserEnabled_FetchMeServerError_PreservesUser', async () => {
+  it('preserves the user when fetchMe fails with a server/network error', async () => {
     useConfigStore.setState({
       configLoadSucceeded: true,
       httpRemoteUserEnabled: true,

--- a/ui/leafwiki-ui/src/lib/bootstrapAuth.ts
+++ b/ui/leafwiki-ui/src/lib/bootstrapAuth.ts
@@ -7,6 +7,7 @@ export function useBootstrapAuth(enabled = true) {
   const setUser = useSessionStore((s) => s.setUser)
   const setRefreshing = useSessionStore((s) => s.setRefreshing)
   const httpRemoteUserEnabled = useConfigStore((s) => s.httpRemoteUserEnabled)
+  const configLoadSucceeded = useConfigStore((s) => s.configLoadSucceeded)
 
   useEffect(() => {
     if (!enabled) {
@@ -18,9 +19,12 @@ export function useBootstrapAuth(enabled = true) {
     ;(async () => {
       setRefreshing(true)
       try {
-        if (httpRemoteUserEnabled) {
+        if (httpRemoteUserEnabled || !configLoadSucceeded) {
           // Proxy manages the session — resolve the current user via /api/auth/me.
-          // Token refresh does not apply in this mode.
+          // Token refresh does not apply in this mode. Also used when the auth
+          // mode isn't confirmed yet (config failed to load): /api/auth/me
+          // works regardless of mode, so it's a safe way to check identity
+          // without risking a wrong-mode refresh-token call.
           const user = await fetchMe()
           if (!cancelled) setUser(user)
         } else {
@@ -43,5 +47,11 @@ export function useBootstrapAuth(enabled = true) {
     return () => {
       cancelled = true
     }
-  }, [setUser, setRefreshing, enabled, httpRemoteUserEnabled])
+  }, [
+    setUser,
+    setRefreshing,
+    enabled,
+    httpRemoteUserEnabled,
+    configLoadSucceeded,
+  ])
 }

--- a/ui/leafwiki-ui/src/lib/sleep.ts
+++ b/ui/leafwiki-ui/src/lib/sleep.ts
@@ -1,0 +1,3 @@
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms))
+}

--- a/ui/leafwiki-ui/src/stores/config.test.ts
+++ b/ui/leafwiki-ui/src/stores/config.test.ts
@@ -47,7 +47,7 @@ afterEach(() => {
 })
 
 describe('loadConfig retry', () => {
-  it('TestLoadConfig_TransientFailureThenSuccess_RetriesAndSucceeds', async () => {
+  it('retries and succeeds after a transient /api/config failure', async () => {
     ;(configApi.getConfig as Mock)
       .mockRejectedValueOnce(new Error('network blip'))
       .mockResolvedValueOnce(baseConfig)
@@ -62,7 +62,7 @@ describe('loadConfig retry', () => {
     expect(configApi.getConfig).toHaveBeenCalledTimes(2)
   })
 
-  it('TestLoadConfig_PersistentFailure_GivesUpWithConfigLoadSucceededFalse', async () => {
+  it('gives up with configLoadSucceeded false after repeated failures', async () => {
     ;(configApi.getConfig as Mock).mockRejectedValue(new Error('down'))
 
     const loadPromise = useConfigStore.getState().loadConfig()
@@ -75,7 +75,7 @@ describe('loadConfig retry', () => {
     expect((configApi.getConfig as Mock).mock.calls.length).toBeGreaterThan(1)
   })
 
-  it('TestLoadConfig_ImmediateSuccess_DoesNotRetry', async () => {
+  it('does not retry when the first attempt succeeds', async () => {
     ;(configApi.getConfig as Mock).mockResolvedValueOnce(baseConfig)
 
     await useConfigStore.getState().loadConfig()

--- a/ui/leafwiki-ui/src/stores/config.test.ts
+++ b/ui/leafwiki-ui/src/stores/config.test.ts
@@ -1,0 +1,86 @@
+import * as configApi from '@/lib/api/config'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from 'vitest'
+import { useConfigStore } from './config'
+
+vi.mock('@/lib/api/config', () => ({
+  getConfig: vi.fn(),
+}))
+
+const baseConfig = {
+  publicAccess: false,
+  hideLinkMetadataSection: false,
+  authDisabled: false,
+  maxAssetUploadSizeBytes: 1000,
+  enableRevision: false,
+  enableLinkRefactor: false,
+  enableApiKeyManagement: false,
+  gitBackupEnabled: false,
+  snapshotEnabled: false,
+  totpAvailable: false,
+  httpRemoteUserEnabled: true,
+  loginUrl: '',
+  logoutUrl: '',
+  userManagementUrl: '',
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  vi.useFakeTimers()
+  useConfigStore.setState({
+    hasLoaded: false,
+    configLoadSucceeded: false,
+    httpRemoteUserEnabled: false,
+    error: null,
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('loadConfig retry', () => {
+  it('TestLoadConfig_TransientFailureThenSuccess_RetriesAndSucceeds', async () => {
+    ;(configApi.getConfig as Mock)
+      .mockRejectedValueOnce(new Error('network blip'))
+      .mockResolvedValueOnce(baseConfig)
+
+    const loadPromise = useConfigStore.getState().loadConfig()
+    await vi.runAllTimersAsync()
+    await loadPromise
+
+    expect(useConfigStore.getState().configLoadSucceeded).toBe(true)
+    expect(useConfigStore.getState().hasLoaded).toBe(true)
+    expect(useConfigStore.getState().httpRemoteUserEnabled).toBe(true)
+    expect(configApi.getConfig).toHaveBeenCalledTimes(2)
+  })
+
+  it('TestLoadConfig_PersistentFailure_GivesUpWithConfigLoadSucceededFalse', async () => {
+    ;(configApi.getConfig as Mock).mockRejectedValue(new Error('down'))
+
+    const loadPromise = useConfigStore.getState().loadConfig()
+    await vi.runAllTimersAsync()
+    await loadPromise
+
+    expect(useConfigStore.getState().configLoadSucceeded).toBe(false)
+    expect(useConfigStore.getState().hasLoaded).toBe(true)
+    expect(useConfigStore.getState().httpRemoteUserEnabled).toBe(false)
+    expect((configApi.getConfig as Mock).mock.calls.length).toBeGreaterThan(1)
+  })
+
+  it('TestLoadConfig_ImmediateSuccess_DoesNotRetry', async () => {
+    ;(configApi.getConfig as Mock).mockResolvedValueOnce(baseConfig)
+
+    await useConfigStore.getState().loadConfig()
+
+    expect(useConfigStore.getState().configLoadSucceeded).toBe(true)
+    expect(configApi.getConfig).toHaveBeenCalledTimes(1)
+  })
+})

--- a/ui/leafwiki-ui/src/stores/config.ts
+++ b/ui/leafwiki-ui/src/stores/config.ts
@@ -1,6 +1,7 @@
 import { getConfig } from '@/lib/api/config'
 import { DEFAULT_MAX_ASSET_UPLOAD_SIZE_BYTES } from '@/lib/config'
 import i18next from '@/lib/i18n'
+import { sleep } from '@/lib/sleep'
 import { create } from 'zustand'
 
 type ConfigStore = {
@@ -21,8 +22,25 @@ type ConfigStore = {
   error: string | null
   loading: boolean
   hasLoaded: boolean
+  // True only after a *successful* /api/config fetch — distinct from
+  // hasLoaded, which also becomes true after a failed attempt (so the UI can
+  // stop showing the boot spinner). Consumers that would otherwise treat a
+  // failed session-token refresh as confirmed-unauthorized (and force a
+  // logout) must gate that reaction on this, not on hasLoaded — while the
+  // auth mode is unconfirmed, a refresh failure could just as easily mean
+  // "this is actually a header-auth deployment with no refresh cookie" as
+  // "the session really expired," and guessing wrong destroys a valid
+  // header-auth session (see lib/api/auth.ts's fetchWithAuth).
+  configLoadSucceeded: boolean
   loadConfig: () => Promise<void>
 }
+
+// A single failed attempt would otherwise leave configLoadSucceeded false —
+// and the auth mode unconfirmed — for the tab's whole life (loadConfig only
+// ever runs once, from App.tsx's mount effect). Bounded retry shrinks that
+// window to a few seconds for the common transient-blip case.
+const CONFIG_LOAD_MAX_ATTEMPTS = 3
+const CONFIG_LOAD_RETRY_DELAYS_MS = [500, 1000]
 
 export const useConfigStore = create<ConfigStore>((set) => ({
   publicAccess: false,
@@ -42,46 +60,64 @@ export const useConfigStore = create<ConfigStore>((set) => ({
   error: null,
   loading: false,
   hasLoaded: false,
+  configLoadSucceeded: false,
 
   loadConfig: async () => {
     set({ loading: true, error: null })
-    try {
-      const config = await getConfig()
-      const maxAssetUploadSizeBytes = Number.isFinite(
-        config.maxAssetUploadSizeBytes,
-      )
-        ? config.maxAssetUploadSizeBytes
-        : DEFAULT_MAX_ASSET_UPLOAD_SIZE_BYTES
 
-      set({
-        publicAccess: config.publicAccess,
-        hideLinkMetadataSection: config.hideLinkMetadataSection,
-        authDisabled: config.authDisabled,
-        maxAssetUploadSizeBytes,
-        enableRevision: config.enableRevision ?? false,
-        enableLinkRefactor: config.enableLinkRefactor ?? false,
-        enableApiKeyManagement: config.enableApiKeyManagement ?? false,
-        gitBackupEnabled: config.gitBackupEnabled ?? false,
-        snapshotEnabled: config.snapshotEnabled ?? false,
-        totpAvailable: config.totpAvailable ?? false,
-        httpRemoteUserEnabled: config.httpRemoteUserEnabled ?? false,
-        loginUrl: config.loginUrl ?? '',
-        logoutUrl: config.logoutUrl ?? '',
-        userManagementUrl: config.userManagementUrl ?? '',
-        error: null,
-        hasLoaded: true,
-      })
-    } catch (error) {
-      console.warn('Error loading configuration:', error)
-      set({
-        error:
-          error instanceof Error
-            ? error.message
-            : i18next.t('configLoad.errorFallback', { ns: 'common' }),
-        hasLoaded: true,
-      })
-    } finally {
-      set({ loading: false })
+    for (let attempt = 1; attempt <= CONFIG_LOAD_MAX_ATTEMPTS; attempt++) {
+      try {
+        const config = await getConfig()
+        const maxAssetUploadSizeBytes = Number.isFinite(
+          config.maxAssetUploadSizeBytes,
+        )
+          ? config.maxAssetUploadSizeBytes
+          : DEFAULT_MAX_ASSET_UPLOAD_SIZE_BYTES
+
+        set({
+          publicAccess: config.publicAccess,
+          hideLinkMetadataSection: config.hideLinkMetadataSection,
+          authDisabled: config.authDisabled,
+          maxAssetUploadSizeBytes,
+          enableRevision: config.enableRevision ?? false,
+          enableLinkRefactor: config.enableLinkRefactor ?? false,
+          enableApiKeyManagement: config.enableApiKeyManagement ?? false,
+          gitBackupEnabled: config.gitBackupEnabled ?? false,
+          snapshotEnabled: config.snapshotEnabled ?? false,
+          totpAvailable: config.totpAvailable ?? false,
+          httpRemoteUserEnabled: config.httpRemoteUserEnabled ?? false,
+          loginUrl: config.loginUrl ?? '',
+          logoutUrl: config.logoutUrl ?? '',
+          userManagementUrl: config.userManagementUrl ?? '',
+          error: null,
+          hasLoaded: true,
+          configLoadSucceeded: true,
+          loading: false,
+        })
+        return
+      } catch (error) {
+        if (attempt === CONFIG_LOAD_MAX_ATTEMPTS) {
+          console.warn(
+            `Error loading configuration (attempt ${attempt}/${CONFIG_LOAD_MAX_ATTEMPTS}, giving up):`,
+            error,
+          )
+          set({
+            error:
+              error instanceof Error
+                ? error.message
+                : i18next.t('configLoad.errorFallback', { ns: 'common' }),
+            hasLoaded: true,
+            configLoadSucceeded: false,
+            loading: false,
+          })
+          return
+        }
+        console.warn(
+          `Error loading configuration (attempt ${attempt}/${CONFIG_LOAD_MAX_ATTEMPTS}, retrying):`,
+          error,
+        )
+        await sleep(CONFIG_LOAD_RETRY_DELAYS_MS[attempt - 1])
+      }
     }
   },
 }))

--- a/ui/leafwiki-ui/src/stores/import.ts
+++ b/ui/leafwiki-ui/src/stores/import.ts
@@ -2,6 +2,7 @@ import * as importAPI from '@/lib/api/import'
 import { ApiError } from '@/lib/api/auth'
 import { mapApiError } from '@/lib/api/errors'
 import i18next from '@/lib/i18n'
+import { sleep } from '@/lib/sleep'
 import { toast } from 'sonner'
 import { create } from 'zustand'
 import { useTreeStore } from './tree'
@@ -24,10 +25,6 @@ type ImportStore = {
 
 const IMPORT_POLL_INTERVAL_MS = 1000
 const IMPORT_POLL_RETRY_LIMIT = 3
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => window.setTimeout(resolve, ms))
-}
 
 async function pollImportPlanUntilSettled(
   initialPlan: importAPI.ImportPlan,

--- a/ui/leafwiki-ui/src/stores/restore.ts
+++ b/ui/leafwiki-ui/src/stores/restore.ts
@@ -8,6 +8,7 @@ import {
   RestoreStatus,
 } from '@/lib/api/restore'
 import { getResyncStatus } from '@/lib/api/resync'
+import { sleep } from '@/lib/sleep'
 
 const POLL_INTERVAL_MS = 800
 const POLL_ERROR_LIMIT = 3
@@ -31,10 +32,6 @@ interface RestoreState {
   trigger: (id: string) => Promise<void>
   triggerUpload: (file: File) => Promise<void>
   selfRestart: () => Promise<void>
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => window.setTimeout(resolve, ms))
 }
 
 export const useRestoreStore = create<RestoreState>((set) => ({

--- a/ui/leafwiki-ui/src/stores/resync.ts
+++ b/ui/leafwiki-ui/src/stores/resync.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { getResyncStatus, triggerResync } from '@/lib/api/resync'
 import i18next from '@/lib/i18n'
+import { sleep } from '@/lib/sleep'
 
 const POLL_INTERVAL_MS = 800
 const POLL_ERROR_LIMIT = 3
@@ -9,10 +10,6 @@ interface ResyncState {
   isLoading: boolean
   phase: string | null
   trigger: () => Promise<void>
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => window.setTimeout(resolve, ms))
 }
 
 export const useResyncStore = create<ResyncState>((set) => ({


### PR DESCRIPTION
…failure

Fixes spurious "CSRF token missing" logouts for header/proxy-auth deployments (#1407): a failed /api/config fetch left httpRemoteUserEnabled stuck at its wrong `false` default, causing the app to guess session-auth, call refresh-token, and force-logout on the resulting 422. Adds bounded retry to loadConfig() and only treats a refresh failure as confirmed unauthorized once the auth mode is actually known.

