### PR TITLE
fix: stop swallowing store-unavailable errors in API-key and TOTP-log…

### DIFF
--- a/internal/core/auth/apikey_service.go
+++ b/internal/core/auth/apikey_service.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/perber/wiki/internal/core/shared"
+	sharederrors "github.com/perber/wiki/internal/core/shared/errors"
 )
 
 // dummySecretHash is compared against on an unknown-prefix lookup so Resolve
@@ -193,6 +194,24 @@ func (s *APIKeyService) RevokeAPIKey(id string) error {
 	return s.currentStore().Revoke(id)
 }
 
+// AsStoreUnavailableErr reports whether err is a store's own "suspended for
+// live restore" LocalizedError (APIKeyStore's or, via UserService,
+// UserStore's), returning it as a *LocalizedError if so. Resolve uses this to
+// propagate the distinct error instead of collapsing it into ErrAPIKeyInvalid;
+// exported so callers outside this package (e.g. the Bearer-auth middleware)
+// can do the same and read its message, without needing to know the
+// underlying error codes themselves.
+func AsStoreUnavailableErr(err error) (*sharederrors.LocalizedError, bool) {
+	loc, ok := sharederrors.AsLocalizedError(err)
+	if !ok {
+		return nil, false
+	}
+	if loc.Code == ErrCodeAPIKeyStoreUnavailable || loc.Code == userStoreUnavailableCode {
+		return loc, true
+	}
+	return nil, false
+}
+
 // Resolve validates a raw "Authorization: Bearer <token>" value and returns the
 // user the key acts as. The returned user's Role is narrowed to the
 // intersection of the owning user's role and the key's own role (see
@@ -205,7 +224,10 @@ func (s *APIKeyService) RevokeAPIKey(id string) error {
 // the secret is hashed and compared even when the prefix is unknown (against
 // dummySecretHash) — otherwise an unknown prefix would return faster than a
 // known prefix with a wrong secret, leaking exactly the distinction this
-// comment claims is hidden.
+// comment claims is hidden. The one exception is a suspended store (see
+// AsStoreUnavailableErr): that short-circuits before the hash compare, but
+// safely — the response is already distinguishable by status/content (503
+// vs. ErrAPIKeyInvalid), so the early return adds no new timing side-channel.
 func (s *APIKeyService) Resolve(token string) (*User, error) {
 	prefix, secret, ok := parseKeyToken(token)
 	if !ok {
@@ -214,6 +236,9 @@ func (s *APIKeyService) Resolve(token string) (*User, error) {
 
 	store := s.currentStore()
 	key, err := store.GetByPrefix(prefix)
+	if _, ok := AsStoreUnavailableErr(err); ok {
+		return nil, err
+	}
 	found := err == nil
 	if err != nil && err != ErrAPIKeyNotFound {
 		s.log.Warn("api key resolve: prefix lookup failed", "error", err)
@@ -237,6 +262,9 @@ func (s *APIKeyService) Resolve(token string) (*User, error) {
 	}
 
 	owner, err := s.authService.UserService().GetUserByID(key.UserID)
+	if _, ok := AsStoreUnavailableErr(err); ok {
+		return nil, err
+	}
 	if err != nil {
 		s.log.Warn("api key resolve: owner lookup failed", "error", err, "keyID", key.ID)
 		return nil, ErrAPIKeyInvalid

--- a/internal/core/auth/apikey_service_test.go
+++ b/internal/core/auth/apikey_service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	sharederrors "github.com/perber/wiki/internal/core/shared/errors"
 	"github.com/perber/wiki/internal/test_utils"
 )
 
@@ -58,6 +59,64 @@ func TestHashSecret_DeterministicAndDistinct(t *testing.T) {
 	}
 	if h1 == dummySecretHash {
 		t.Fatalf("real secret hash must not collide with the dummy hash used for timing equalization")
+	}
+}
+
+// Regression tests for the bug where Resolve collapsed a suspended store's
+// store-unavailable LocalizedError (either APIKeyStore's own, or UserStore's
+// via the owner lookup) down to the generic ErrAPIKeyInvalid, so a request
+// landing in a live restore's brief suspend window saw a confusing "invalid
+// key" instead of "restore in progress".
+
+func TestAPIKeyService_Resolve_KeyStoreSuspended_ReturnsStoreUnavailable(t *testing.T) {
+	svc, users := setupTestAPIKeyService(t)
+	owner := mustCreateUser(t, users, "suspend-key-store", RoleViewer)
+
+	_, token, err := svc.CreateAPIKey(CreateAPIKeyParams{Name: "k", UserID: owner.ID, CreatedBy: "admin1"})
+	if err != nil {
+		t.Fatalf("CreateAPIKey err: %v", err)
+	}
+
+	if err := svc.PauseForSwap(); err != nil {
+		t.Fatalf("PauseForSwap failed: %v", err)
+	}
+
+	_, err = svc.Resolve(token)
+	if err == nil {
+		t.Fatal("expected an error for a suspended api key store")
+	}
+	if err == ErrAPIKeyInvalid {
+		t.Fatalf("expected the store-unavailable error, not ErrAPIKeyInvalid: %v", err)
+	}
+	localized, ok := sharederrors.AsLocalizedError(err)
+	if !ok || localized.Code != ErrCodeAPIKeyStoreUnavailable {
+		t.Fatalf("expected %s, got %v", ErrCodeAPIKeyStoreUnavailable, err)
+	}
+}
+
+func TestAPIKeyService_Resolve_UserStoreSuspended_ReturnsStoreUnavailable(t *testing.T) {
+	svc, users := setupTestAPIKeyService(t)
+	owner := mustCreateUser(t, users, "suspend-user-store", RoleViewer)
+
+	_, token, err := svc.CreateAPIKey(CreateAPIKeyParams{Name: "k", UserID: owner.ID, CreatedBy: "admin1"})
+	if err != nil {
+		t.Fatalf("CreateAPIKey err: %v", err)
+	}
+
+	if err := users.suspendStore(); err != nil {
+		t.Fatalf("suspendStore failed: %v", err)
+	}
+
+	_, err = svc.Resolve(token)
+	if err == nil {
+		t.Fatal("expected an error for a suspended user store")
+	}
+	if err == ErrAPIKeyInvalid {
+		t.Fatalf("expected the store-unavailable error, not ErrAPIKeyInvalid: %v", err)
+	}
+	localized, ok := sharederrors.AsLocalizedError(err)
+	if !ok || localized.Code != userStoreUnavailableCode {
+		t.Fatalf("expected %s, got %v", userStoreUnavailableCode, err)
 	}
 }
 

--- a/internal/core/auth/apikey_store.go
+++ b/internal/core/auth/apikey_store.go
@@ -104,13 +104,21 @@ func (s *APIKeyStore) suspend() error {
 	return err
 }
 
+// ErrCodeAPIKeyStoreUnavailable identifies errAPIKeyStoreUnavailable's
+// LocalizedError so callers (e.g. APIKeyService.AsStoreUnavailableErr, or the
+// wiki/apikeys HTTP layer's status mapping) can pass it through instead of
+// collapsing it into ErrAPIKeyInvalid. Exported — the sole source of truth
+// for this code, so no other layer needs its own copy of the literal.
+// Mirrors userStoreUnavailableCode.
+const ErrCodeAPIKeyStoreUnavailable = "apikey_store_unavailable"
+
 // errAPIKeyStoreUnavailable is returned while the store is suspended for an
 // in-progress live restore (see APIKeyStore.suspend / APIKeyService.PauseForSwap).
 // A request landing in that window gets this immediately instead of racing a
 // reconnect against the file swap. Mirrors errUserStoreUnavailable.
 func errAPIKeyStoreUnavailable() error {
 	return sharederrors.NewLocalizedError(
-		"apikey_store_unavailable",
+		ErrCodeAPIKeyStoreUnavailable,
 		"The server is restoring from a backup — please try again in a moment",
 		"api key store is suspended for an in-progress restore",
 		nil,

--- a/internal/core/auth/auth_service.go
+++ b/internal/core/auth/auth_service.go
@@ -244,7 +244,7 @@ func (a *AuthService) CompleteTOTPLogin(challengeToken, code string) (*AuthToken
 	users := a.users()
 	user, err := users.GetUserByID(userID)
 	if err != nil {
-		return nil, ErrUserNotFound
+		return nil, err
 	}
 	if !user.TOTPEnabled || user.TOTPSecretEncrypted == "" {
 		// TOTP was disabled after the challenge was issued; it can no longer be completed.

--- a/internal/core/auth/auth_service_test.go
+++ b/internal/core/auth/auth_service_test.go
@@ -179,6 +179,35 @@ func TestAuthService_CompleteTOTPLogin_InvalidCodeRejected(t *testing.T) {
 	}
 }
 
+// Regression test for the bug where CompleteTOTPLogin unconditionally
+// rewrote any GetUserByID error into ErrUserNotFound, discarding the
+// store-unavailable LocalizedError GetUserByID already correctly returns
+// during a live restore's brief suspend window (see mapUserLookupErr).
+func TestAuthService_CompleteTOTPLogin_UserStoreSuspended_ReturnsStoreUnavailable(t *testing.T) {
+	f := setupTOTPTestFixture(t)
+
+	challenge, err := f.authService.Login("testuser", "securepass")
+	if err != nil {
+		t.Fatalf("Login failed: %v", err)
+	}
+
+	if err := f.store.suspend(); err != nil {
+		t.Fatalf("suspend failed: %v", err)
+	}
+
+	_, err = f.authService.CompleteTOTPLogin(challenge.LoginChallengeToken, f.currentCode(t))
+	if err == nil {
+		t.Fatal("expected an error for a suspended user store")
+	}
+	if err == ErrUserNotFound {
+		t.Fatalf("expected the store-unavailable error, not ErrUserNotFound: %v", err)
+	}
+	localized, ok := sharederrors.AsLocalizedError(err)
+	if !ok || localized.Code != userStoreUnavailableCode {
+		t.Fatalf("expected %s, got %v", userStoreUnavailableCode, err)
+	}
+}
+
 func TestAuthService_CompleteTOTPLogin_ChallengeIsSingleUse(t *testing.T) {
 	f := setupTOTPTestFixture(t)
 

--- a/internal/http/middleware/auth/apikey.go
+++ b/internal/http/middleware/auth/apikey.go
@@ -32,6 +32,8 @@ type APIKeyConfig struct {
 //   - LeafWiki-shaped token, rate limited            → 429
 //   - LeafWiki-shaped token, valid                   → user set in context
 //   - LeafWiki-shaped token, invalid/revoked/expired → 401
+//   - LeafWiki-shaped token, store suspended for a
+//     live restore                                   → 503, not counted as a failed attempt
 //
 // Note on writes: every feature's authGroup also runs CSRFMiddleware, which
 // requires a CSRF cookie a pure Bearer client never has — so today, every
@@ -68,6 +70,21 @@ func InjectAPIKeyUser(cfg APIKeyConfig) gin.HandlerFunc {
 		}
 
 		user, err := cfg.Service.Resolve(token)
+		if loc, ok := coreauth.AsStoreUnavailableErr(err); ok {
+			// An in-progress live restore is an operational condition, not a
+			// failed auth attempt. Allow() above already recorded a hit for
+			// this request, so undo it the same way a successful request
+			// would (NotifyResult(key, true)) rather than leaving it counted
+			// — otherwise a sequential, backed-off retry doing exactly what
+			// the 503 asks could still trip the limiter. A burst that already
+			// exceeded Allow()'s own capacity is unaffected either way, same
+			// as it would be for any other error.
+			if cfg.RateLimiter != nil {
+				cfg.RateLimiter.NotifyResult(limiterKey, true)
+			}
+			c.AbortWithStatusJSON(http.StatusServiceUnavailable, gin.H{"error": loc.Message})
+			return
+		}
 		if cfg.RateLimiter != nil {
 			cfg.RateLimiter.NotifyResult(limiterKey, err == nil)
 		}

--- a/internal/http/middleware/auth/apikey_test.go
+++ b/internal/http/middleware/auth/apikey_test.go
@@ -14,6 +14,7 @@ import (
 
 type apiKeyFixture struct {
 	userService *coreauth.UserService
+	authService *coreauth.AuthService
 	keyService  *coreauth.APIKeyService
 	owner       *coreauth.User
 	closeAll    func() error
@@ -48,6 +49,7 @@ func createAPIKeyFixture(t *testing.T) *apiKeyFixture {
 
 	return &apiKeyFixture{
 		userService: userService,
+		authService: authService,
 		keyService:  keyService,
 		owner:       owner,
 		closeAll: func() error {
@@ -211,6 +213,98 @@ func TestInjectAPIKeyUser_RevokedKeyRejected(t *testing.T) {
 
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("expected 401 for revoked key, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// Regression tests for the bug where InjectAPIKeyUser mapped Resolve's
+// store-unavailable LocalizedError (see APIKeyService.IsStoreUnavailableErr)
+// to the same generic 401 as a genuinely invalid key, so a client landing in
+// a live restore's brief suspend window saw a confusing "invalid or expired
+// API key" instead of "restore in progress, retry" — and had the attempt
+// counted against its rate-limit budget on top of that.
+
+func TestInjectAPIKeyUser_KeyStoreSuspended_Returns503(t *testing.T) {
+	f := createAPIKeyFixture(t)
+	cleanupWithErrorCheck(t, "api key fixture", f.closeAll)
+
+	_, token, err := f.keyService.CreateAPIKey(coreauth.CreateAPIKeyParams{
+		Name: "k", UserID: f.owner.ID, CreatedBy: "admin1",
+	})
+	if err != nil {
+		t.Fatalf("CreateAPIKey err: %v", err)
+	}
+
+	if err := f.keyService.PauseForSwap(); err != nil {
+		t.Fatalf("PauseForSwap failed: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+
+	apiKeyRouter(authmw.APIKeyConfig{Service: f.keyService}, nil).ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 for a suspended api key store, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestInjectAPIKeyUser_UserStoreSuspended_Returns503(t *testing.T) {
+	f := createAPIKeyFixture(t)
+	cleanupWithErrorCheck(t, "api key fixture", f.closeAll)
+
+	_, token, err := f.keyService.CreateAPIKey(coreauth.CreateAPIKeyParams{
+		Name: "k", UserID: f.owner.ID, CreatedBy: "admin1",
+	})
+	if err != nil {
+		t.Fatalf("CreateAPIKey err: %v", err)
+	}
+
+	if err := f.authService.PauseUserStoreForSwap(); err != nil {
+		t.Fatalf("PauseUserStoreForSwap failed: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+
+	apiKeyRouter(authmw.APIKeyConfig{Service: f.keyService}, nil).ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 for a suspended user store, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestInjectAPIKeyUser_StoreUnavailable_NotCountedAsFailedAttempt verifies a
+// store-unavailable response never burns rate-limit budget: a legitimate
+// client backing off and retrying during a live restore's brief suspend
+// window must never get 429'd for doing exactly what the 503 asked it to do.
+func TestInjectAPIKeyUser_StoreUnavailable_NotCountedAsFailedAttempt(t *testing.T) {
+	f := createAPIKeyFixture(t)
+	cleanupWithErrorCheck(t, "api key fixture", f.closeAll)
+
+	_, token, err := f.keyService.CreateAPIKey(coreauth.CreateAPIKeyParams{
+		Name: "k", UserID: f.owner.ID, CreatedBy: "admin1",
+	})
+	if err != nil {
+		t.Fatalf("CreateAPIKey err: %v", err)
+	}
+
+	if err := f.keyService.PauseForSwap(); err != nil {
+		t.Fatalf("PauseForSwap failed: %v", err)
+	}
+
+	limiter := security.NewKeyedLimiter(1, time.Minute, true)
+	router := apiKeyRouter(authmw.APIKeyConfig{Service: f.keyService, RateLimiter: limiter}, nil)
+
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		if w.Code != http.StatusServiceUnavailable {
+			t.Fatalf("attempt %d: expected 503, got %d: %s", i+1, w.Code, w.Body.String())
+		}
 	}
 }
 

--- a/internal/wiki/apikeys/errors.go
+++ b/internal/wiki/apikeys/errors.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	sharederrors "github.com/perber/wiki/internal/core/shared/errors"
+	wikiauth "github.com/perber/wiki/internal/wiki/auth"
 )
 
 const (
@@ -86,6 +87,8 @@ func apiKeyErrorStatus(code string) int {
 		return http.StatusConflict
 	case ErrCodeAPIKeysDisabled:
 		return http.StatusForbidden
+	case coreauth.ErrCodeAPIKeyStoreUnavailable, wikiauth.ErrCodeAuthUserStoreUnavailable:
+		return http.StatusServiceUnavailable
 	default:
 		return http.StatusInternalServerError
 	}

--- a/internal/wiki/apikeys/errors_test.go
+++ b/internal/wiki/apikeys/errors_test.go
@@ -1,0 +1,50 @@
+package apikeys
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	coreauth "github.com/perber/wiki/internal/core/auth"
+	sharederrors "github.com/perber/wiki/internal/core/shared/errors"
+	wikiauth "github.com/perber/wiki/internal/wiki/auth"
+)
+
+func TestRespondWithAPIKeyError_StoreUnavailable(t *testing.T) {
+	t.Parallel()
+
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	respondWithAPIKeyError(c, sharederrors.NewLocalizedError(
+		coreauth.ErrCodeAPIKeyStoreUnavailable,
+		"The server is restoring from a backup — please try again in a moment",
+		"api key store is suspended for an in-progress restore",
+		nil,
+	))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+}
+
+func TestRespondWithAPIKeyError_UserStoreUnavailable(t *testing.T) {
+	t.Parallel()
+
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	respondWithAPIKeyError(c, sharederrors.NewLocalizedError(
+		wikiauth.ErrCodeAuthUserStoreUnavailable,
+		"The server is restoring from a backup — please try again in a moment",
+		"user store is suspended for an in-progress restore",
+		nil,
+	))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+}

--- a/internal/wiki/auth/errors.go
+++ b/internal/wiki/auth/errors.go
@@ -61,6 +61,15 @@ func respondWithAuthStatusError(c *gin.Context, status int, code, message, templ
 	})
 }
 
+// isUserStoreUnavailable reports whether err is the user store's own
+// "suspended for live restore" LocalizedError (see errUserStoreUnavailable
+// in internal/core/auth), so callers can bucket it separately from a genuine
+// failure instead of miscounting it as one.
+func isUserStoreUnavailable(err error) bool {
+	loc, ok := sharederrors.AsLocalizedError(err)
+	return ok && loc.Code == ErrCodeAuthUserStoreUnavailable
+}
+
 // respondWithAuthError is the central error handler for auth endpoints.
 func respondWithAuthError(c *gin.Context, err error) {
 	if loc, ok := sharederrors.AsLocalizedError(err); ok {

--- a/internal/wiki/auth/use_cases.go
+++ b/internal/wiki/auth/use_cases.go
@@ -89,9 +89,16 @@ func (uc *CompleteTOTPLoginUseCase) Execute(_ context.Context, in CompleteTOTPLo
 	}
 	token, err := uc.auth.CompleteTOTPLogin(in.LoginChallengeToken, in.Code)
 	if err != nil {
-		if errors.Is(err, coreauth.ErrUserAccountLocked) {
+		switch {
+		case errors.Is(err, coreauth.ErrUserAccountLocked):
 			uc.metrics.IncAuthTOTPVerification("locked")
-		} else {
+		case isUserStoreUnavailable(err):
+			// Not a real verification failure — the user store is suspended
+			// for an in-progress live restore (see errUserStoreUnavailable).
+			// Bucketing this as "invalid" would spike that metric with zero
+			// actual bad codes during every restore.
+			uc.metrics.IncAuthTOTPVerification("unavailable")
+		default:
 			uc.metrics.IncAuthTOTPVerification("invalid")
 		}
 		return nil, err


### PR DESCRIPTION
…in paths

APIKeyService.Resolve and AuthService.CompleteTOTPLogin collapsed a live restore's "store suspended" error into generic not-found/invalid errors, mirroring an earlier UserService bug. Fixed by propagating the distinct LocalizedError instead, plus extending the Bearer-auth middleware (which was otherwise silently discarding the fix) to return 503 without counting the attempt against its rate limiter, and correcting the TOTP-verification metric's bucketing for the same case.
