### PR TITLE
fix(deps): bump dompurify 3.4.12 -> 3.4.13 (transitive via mermaid)

### DIFF
--- a/ui/leafwiki-ui/package-lock.json
+++ b/ui/leafwiki-ui/package-lock.json
@@ -4535,9 +4535,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"


### PR DESCRIPTION
Patches GHSA-55q2-fjhq-7xh7: IN_PLACE sanitization with an element-removal hook could leave a detached descendant's event handler executable after sanitize() returns.
