### PR TITLE
fix(ui): rename Git backup Push now to Sync now

### DIFF
--- a/ui/leafwiki-ui/src/locales/en/backup.json
+++ b/ui/leafwiki-ui/src/locales/en/backup.json
@@ -18,9 +18,9 @@
   "forcePushButton": "Force Push",
   "hintDisabled": "Git backup is not enabled. To enable it, configure a remote repository in your server environment settings.",
   "manualSectionTitle": "Manual Backup",
-  "manualSectionDescription": "Trigger an immediate push of all current wiki content to the remote repository without waiting for the next scheduled sync.",
-  "pushNow": "Push now",
-  "pushing": "Pushing…",
+  "manualSectionDescription": "Trigger an immediate sync (pull then push) of all current wiki content with the remote repository without waiting for the next scheduled sync.",
+  "pushNow": "Sync now",
+  "pushing": "Syncing…",
   "menuLabel": "Git Content Backup",
   "warningAriaLabel": "Backup warning",
   "tooltip": {


### PR DESCRIPTION
## Related issue
Fixes #1422

## What changed
Renames the Git Content Backup button from Push now to Sync now, since it pulls before push.

## Checklist
- [x] I discussed the approach on the linked issue before starting (or this is a trivial fix: typo, docs, obvious one-liner)
- [x] This PR is focused on a single change
- [x] I ran `npm run format` in `ui/leafwiki-ui` (and in `e2e` if e2e tests changed)
- [x] I updated documentation if needed
