### PR TITLE
feat(auth): allow disabling password min-length via flag/env

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ For plain HTTP: add `--allow-insecure=true` so login and CSRF cookies work.
 | `--base-path`                    | URL prefix for reverse proxy setups (e.g. `/wiki`)                      | `""`          | v0.8.2  |
 | `--allow-insecure`               | ⚠️ Enables HTTP for auth cookies (required for plain HTTP)              | `false`       | v0.7.0  |
 | `--disable-auth`                 | ⚠️ Disable all authentication (internal networks only)                  | `false`       | v0.7.0  |
+| `--allow-weak-passwords`         | ⚠️ Allow passwords shorter than 8 characters (trusted private networks only) | `false`  | –       |
 | `--access-token-timeout`         | Access token duration (e.g. `24h`, `15m`)                               | `15m`         | v0.7.0  |
 | `--refresh-token-timeout`        | Refresh token duration (e.g. `168h`)                                    | `168h`        | v0.7.0  |
 | `--max-asset-upload-size`        | Max upload size (e.g. `50MiB`, `52428800`)                              | `50MiB`       | v0.8.5  |
@@ -377,6 +378,7 @@ For plain HTTP: add `--allow-insecure=true` so login and CSRF cookies work.
 | `LEAFWIKI_BASE_PATH`                    | URL prefix for reverse proxy                         | `""`          | v0.8.2  |
 | `LEAFWIKI_ALLOW_INSECURE`               | ⚠️ HTTP auth cookies                                 | `false`       | v0.7.0  |
 | `LEAFWIKI_DISABLE_AUTH`                 | ⚠️ Disable authentication                            | `false`       | v0.7.0  |
+| `LEAFWIKI_ALLOW_WEAK_PASSWORDS`         | ⚠️ Allow passwords shorter than 8 characters         | `false`       | –       |
 | `LEAFWIKI_ACCESS_TOKEN_TIMEOUT`         | Access token duration                                | `15m`         | v0.7.0  |
 | `LEAFWIKI_REFRESH_TOKEN_TIMEOUT`        | Refresh token duration                               | `168h`        | v0.7.0  |
 | `LEAFWIKI_MAX_ASSET_UPLOAD_SIZE`        | Max upload size                                      | `50MiB`       | v0.8.5  |

--- a/cmd/leafwiki/main.go
+++ b/cmd/leafwiki/main.go
@@ -80,6 +80,7 @@ func writeUsage(w io.Writer) {
 	--custom-stylesheet      Path to a .css file inside the data dir, served publicly as /custom.css
 	                         (or <base-path>/custom.css when --base-path is set) (default: "")
 	--disable-auth                Disable authentication completely (default: false) (WARNING: only use in trusted networks!)
+	--allow-weak-passwords        Allow passwords shorter than 8 characters (default: false) (WARNING: only use on trusted private networks!)
 	--hide-link-metadata-section  Hide link metadata section in the frontend UI (default: false)
 	--base-path                   URL prefix when served behind a reverse proxy (e.g. /wiki) (default: "")
 	--max-asset-upload-size       Maximum size for asset uploads (for example 50MiB, 50MB, 52428800) (default: 50MiB)
@@ -146,6 +147,7 @@ func writeUsage(w io.Writer) {
 	LEAFWIKI_ACCESS_TOKEN_TIMEOUT
 	LEAFWIKI_REFRESH_TOKEN_TIMEOUT
 	LEAFWIKI_DISABLE_AUTH
+	LEAFWIKI_ALLOW_WEAK_PASSWORDS
 	LEAFWIKI_HIDE_LINK_METADATA_SECTION
 	LEAFWIKI_BASE_PATH
 	LEAFWIKI_MAX_ASSET_UPLOAD_SIZE
@@ -252,6 +254,7 @@ type cliFlags struct {
 	injectCodeInHeader             *string
 	customStylesheet               *string
 	disableAuth                    *bool
+	allowWeakPasswords             *bool
 	hideLinkMetadataSection        *bool
 	accessTokenTimeout             *time.Duration
 	refreshTokenTimeout            *time.Duration
@@ -309,6 +312,7 @@ func registerFlags(fs *flag.FlagSet) *cliFlags {
 		injectCodeInHeader:             fs.String("inject-code-in-header", "", "raw string injected into <head> (default: \"\")"),
 		customStylesheet:               fs.String("custom-stylesheet", "", "path to a custom CSS file served as /custom.css"),
 		disableAuth:                    fs.Bool("disable-auth", false, "disable authentication completely (default: false) (WARNING: only use in trusted networks!)"),
+		allowWeakPasswords:             fs.Bool("allow-weak-passwords", false, "allow passwords shorter than 8 characters when creating or changing passwords (default: false) (WARNING: only use on trusted private networks!)"),
 		hideLinkMetadataSection:        fs.Bool("hide-link-metadata-section", false, "hide link metadata section (default: false)"),
 		accessTokenTimeout:             fs.Duration("access-token-timeout", 15*time.Minute, "access token timeout duration (e.g. 24h, 15m) (default: 15m)"),
 		refreshTokenTimeout:            fs.Duration("refresh-token-timeout", 7*24*time.Hour, "refresh token timeout duration (e.g. 168h) (default: 168h)"),
@@ -392,6 +396,7 @@ func main() {
 	refreshTokenTimeout := resolveDuration("refresh-token-timeout", *flags.refreshTokenTimeout, visited, "LEAFWIKI_REFRESH_TOKEN_TIMEOUT")
 	// If disable-auth is set, later logic will override publicAccess accordingly
 	disableAuth := resolveBool("disable-auth", *flags.disableAuth, visited, "LEAFWIKI_DISABLE_AUTH")
+	allowWeakPasswords := resolveBool("allow-weak-passwords", *flags.allowWeakPasswords, visited, "LEAFWIKI_ALLOW_WEAK_PASSWORDS")
 	basePath := normalizeBasePath(resolveString("base-path", *flags.basePath, visited, "LEAFWIKI_BASE_PATH", ""))
 	maxAssetUploadSize := parseByteSize(
 		resolveString("max-asset-upload-size", *flags.maxAssetUploadSize, visited, "LEAFWIKI_MAX_ASSET_UPLOAD_SIZE", "50MiB"),
@@ -561,6 +566,7 @@ func main() {
 		AccessTokenTimeout:     accessTokenTimeout,
 		RefreshTokenTimeout:    refreshTokenTimeout,
 		AuthDisabled:           disableAuth,
+		AllowWeakPasswords:     allowWeakPasswords,
 		EnableRevision:         enableRevision,
 		EnableAPIKeyManagement: enableAPIKeyManagement,
 		MaxRevisionHistory:     maxRevisionHistory,
@@ -668,6 +674,7 @@ func main() {
 		AccessTokenTimeout:      accessTokenTimeout,
 		RefreshTokenTimeout:     refreshTokenTimeout,
 		AuthDisabled:            disableAuth,
+		AllowWeakPasswords:      allowWeakPasswords,
 		BasePath:                basePath,
 		MaxAssetUploadSizeBytes: maxAssetUploadSize,
 		EnableRevision:          enableRevision,

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -98,6 +98,7 @@ type RouterOptions struct {
 	RefreshTokenTimeout     time.Duration            // Duration for refresh token validity
 	HideLinkMetadataSection bool                     // Whether to hide the link metadata section in the frontend UI
 	AuthDisabled            bool                     // Whether authentication is disabled
+	AllowWeakPasswords      bool                     // Whether passwords shorter than 8 characters are allowed (surfaced via /api/config)
 	BasePath                string                   // URL prefix when served behind a reverse proxy (e.g. "/wiki")
 	MaxAssetUploadSizeBytes int64                    // Maximum allowed size in bytes for asset uploads
 	EnableRevision          bool                     // Whether the revision / page history feature is enabled

--- a/internal/wiki/auth/routes.go
+++ b/internal/wiki/auth/routes.go
@@ -170,6 +170,7 @@ func (r *Routes) handleConfig(ctx httpinternal.RouterContext) gin.HandlerFunc {
 			"publicAccess":            opts.PublicAccess,
 			"hideLinkMetadataSection": opts.HideLinkMetadataSection,
 			"authDisabled":            opts.AuthDisabled,
+			"allowWeakPasswords":      opts.AllowWeakPasswords,
 			"basePath":                opts.BasePath,
 			"maxAssetUploadSizeBytes": opts.MaxAssetUploadSizeBytes,
 			"enableRevision":          opts.EnableRevision,

--- a/internal/wiki/auth/use_cases.go
+++ b/internal/wiki/auth/use_cases.go
@@ -302,13 +302,14 @@ type CreateUserUseCase struct {
 	// this use case automatically tracks a live restore's
 	// AuthService.ReplaceUserStore swap instead of going stale — see
 	// Wiki.UserService().
-	user     func() *coreauth.UserService
-	resolver *coreauth.UserResolver
-	log      *slog.Logger
+	user               func() *coreauth.UserService
+	resolver           *coreauth.UserResolver
+	log                *slog.Logger
+	allowWeakPasswords bool
 }
 
-func NewCreateUserUseCase(u func() *coreauth.UserService, r *coreauth.UserResolver, log *slog.Logger) *CreateUserUseCase {
-	return &CreateUserUseCase{user: u, resolver: r, log: log}
+func NewCreateUserUseCase(u func() *coreauth.UserService, r *coreauth.UserResolver, log *slog.Logger, allowWeakPasswords bool) *CreateUserUseCase {
+	return &CreateUserUseCase{user: u, resolver: r, log: log, allowWeakPasswords: allowWeakPasswords}
 }
 
 func (uc *CreateUserUseCase) Execute(_ context.Context, in CreateUserInput) (*CreateUserOutput, error) {
@@ -323,7 +324,7 @@ func (uc *CreateUserUseCase) Execute(_ context.Context, in CreateUserInput) (*Cr
 	}
 	if in.Password == "" {
 		ve.Add("password", "Password must not be empty")
-	} else if len(in.Password) < 8 {
+	} else if !uc.allowWeakPasswords && len(in.Password) < 8 {
 		ve.Add("password", "Password must be at least 8 characters long")
 	}
 	if !coreauth.IsValidRole(in.Role) {
@@ -359,13 +360,14 @@ type UpdateUserOutput struct {
 }
 
 type UpdateUserUseCase struct {
-	user     func() *coreauth.UserService
-	resolver *coreauth.UserResolver
-	log      *slog.Logger
+	user               func() *coreauth.UserService
+	resolver           *coreauth.UserResolver
+	log                *slog.Logger
+	allowWeakPasswords bool
 }
 
-func NewUpdateUserUseCase(u func() *coreauth.UserService, r *coreauth.UserResolver, log *slog.Logger) *UpdateUserUseCase {
-	return &UpdateUserUseCase{user: u, resolver: r, log: log}
+func NewUpdateUserUseCase(u func() *coreauth.UserService, r *coreauth.UserResolver, log *slog.Logger, allowWeakPasswords bool) *UpdateUserUseCase {
+	return &UpdateUserUseCase{user: u, resolver: r, log: log, allowWeakPasswords: allowWeakPasswords}
 }
 
 func (uc *UpdateUserUseCase) Execute(_ context.Context, in UpdateUserInput) (*UpdateUserOutput, error) {
@@ -377,6 +379,9 @@ func (uc *UpdateUserUseCase) Execute(_ context.Context, in UpdateUserInput) (*Up
 		ve.Add("email", "Email must not be empty")
 	} else if !emailRegex.MatchString(in.Email) {
 		ve.Add("email", "Email is not valid")
+	}
+	if in.Password != "" && !uc.allowWeakPasswords && len(in.Password) < 8 {
+		ve.Add("password", "Password must be at least 8 characters long")
 	}
 	role := in.Role
 	roleProvided := strings.TrimSpace(in.Role) != ""
@@ -414,18 +419,19 @@ type ChangeOwnPasswordInput struct {
 }
 
 type ChangeOwnPasswordUseCase struct {
-	user func() *coreauth.UserService
+	user               func() *coreauth.UserService
+	allowWeakPasswords bool
 }
 
-func NewChangeOwnPasswordUseCase(u func() *coreauth.UserService) *ChangeOwnPasswordUseCase {
-	return &ChangeOwnPasswordUseCase{user: u}
+func NewChangeOwnPasswordUseCase(u func() *coreauth.UserService, allowWeakPasswords bool) *ChangeOwnPasswordUseCase {
+	return &ChangeOwnPasswordUseCase{user: u, allowWeakPasswords: allowWeakPasswords}
 }
 
 func (uc *ChangeOwnPasswordUseCase) Execute(_ context.Context, in ChangeOwnPasswordInput) error {
 	ve := sharederrors.NewValidationErrors()
 	if in.NewPassword == "" {
 		ve.Add("newPassword", "New password must not be empty")
-	} else if len(in.NewPassword) < 8 {
+	} else if !uc.allowWeakPasswords && len(in.NewPassword) < 8 {
 		ve.Add("newPassword", "New password must be at least 8 characters long")
 	}
 	if _, err := uc.user().DoesIDAndPasswordMatch(in.UserID, in.OldPassword); err != nil {

--- a/internal/wiki/auth/use_cases_test.go
+++ b/internal/wiki/auth/use_cases_test.go
@@ -93,7 +93,7 @@ func setupUpdateUserUseCase(t *testing.T) (*UpdateUserUseCase, *coreauth.UserSer
 	if err != nil {
 		t.Fatalf("NewUserResolver: %v", err)
 	}
-	return NewUpdateUserUseCase(userSvcFn, resolver, slog.Default()), userSvc
+	return NewUpdateUserUseCase(userSvcFn, resolver, slog.Default(), false), userSvc
 }
 
 // TestUpdateUser_AdminCanChangeRole verifies that an admin requester can promote

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -53,7 +53,8 @@ type Wiki struct {
 	branding     *branding.BrandingService
 	searchIndex  *search.SQLiteIndex
 	status       *search.IndexingStatus
-	storageDir   string
+	storageDir         string
+	allowWeakPasswords bool
 
 	// Domain route registrars (populated by NewWiki).
 	pagesRoutes      *wikipages.Routes
@@ -104,18 +105,20 @@ type WikiOptions struct {
 	MaxAssetUploadSizeBytes int64         // Maximum allowed size in bytes for asset/import uploads; 0 = default
 	RevisionCoalesceWindow  time.Duration // Window for coalescing rapid successive saves; 0 = disabled
 	TOTPEncryptionKey       string        // Key used to encrypt per-user TOTP secrets at rest; empty disables TOTP self-service
+	AllowWeakPasswords      bool          // When true, skip the minimum 8-character password length check
 	Metrics                 *httpmetrics.HTTPMetrics
 }
 
 func NewWiki(options *WikiOptions) (*Wiki, error) {
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 	w := &Wiki{
-		storageDir:     options.StorageDir,
-		log:            slog.Default().With("component", "Wiki"),
-		resyncJob:      wikiresync.NewResyncJob(),
-		shutdownCtx:    shutdownCtx,
-		shutdownCancel: shutdownCancel,
-		metrics:        options.Metrics,
+		storageDir:         options.StorageDir,
+		allowWeakPasswords: options.AllowWeakPasswords,
+		log:                slog.Default().With("component", "Wiki"),
+		resyncJob:          wikiresync.NewResyncJob(),
+		shutdownCtx:        shutdownCtx,
+		shutdownCancel:     shutdownCancel,
+		metrics:            options.Metrics,
 	}
 	if err := w.initAuth(options); err != nil {
 		return nil, err
@@ -445,9 +448,9 @@ func (w *Wiki) buildAuthRoutes() *wikiauth.Routes {
 		CompleteTOTPLogin: wikiauth.NewCompleteTOTPLoginUseCase(w.auth, w.metrics),
 		Logout:            wikiauth.NewLogoutUseCase(w.auth, w.metrics),
 		RefreshToken:      wikiauth.NewRefreshTokenUseCase(w.auth, w.metrics),
-		CreateUser:        wikiauth.NewCreateUserUseCase(w.UserService, w.userResolver, w.log),
-		UpdateUser:        wikiauth.NewUpdateUserUseCase(w.UserService, w.userResolver, w.log),
-		ChangeOwnPassword: wikiauth.NewChangeOwnPasswordUseCase(w.UserService),
+		CreateUser:        wikiauth.NewCreateUserUseCase(w.UserService, w.userResolver, w.log, w.allowWeakPasswords),
+		UpdateUser:        wikiauth.NewUpdateUserUseCase(w.UserService, w.userResolver, w.log, w.allowWeakPasswords),
+		ChangeOwnPassword: wikiauth.NewChangeOwnPasswordUseCase(w.UserService, w.allowWeakPasswords),
 		DeleteUser:        wikiauth.NewDeleteUserUseCase(w.UserService, w.userResolver, w.favorites, w.log),
 		GetUsers:          wikiauth.NewGetUsersUseCase(w.UserService),
 		GetUserByID:       wikiauth.NewGetUserByIDUseCase(w.UserService),

--- a/ui/leafwiki-ui/src/features/users/ChangeOwnPasswordDialog.tsx
+++ b/ui/leafwiki-ui/src/features/users/ChangeOwnPasswordDialog.tsx
@@ -2,6 +2,7 @@ import BaseDialog from '@/components/BaseDialog'
 import { FormInput } from '@/components/FormInput'
 import { handleFieldErrors } from '@/lib/handleFieldErrors'
 import { DIALOG_CHANGE_OWN_PASSWORD } from '@/lib/registries'
+import { useConfigStore } from '@/stores/config'
 import { useSessionStore } from '@/stores/session'
 import { useUserStore } from '@/stores/users'
 import { useCallback, useState } from 'react'
@@ -17,6 +18,7 @@ export function ChangeOwnPasswordDialog() {
   const [confirm, setConfirm] = useState('')
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
   const [loading, setLoading] = useState(false)
+  const allowWeakPasswords = useConfigStore((s) => s.allowWeakPasswords)
 
   const { user } = useSessionStore()
   const { changeOwnPassword } = useUserStore()
@@ -38,7 +40,7 @@ export function ChangeOwnPasswordDialog() {
 
   const handleNewPasswordChange = (val: string) => {
     setNewPassword(val)
-    if (val.length < 8) {
+    if (!allowWeakPasswords && val.length < 8) {
       setFieldErrors((prev) => ({
         ...prev,
         newPassword: t('validation.passwordTooShort'),

--- a/ui/leafwiki-ui/src/features/users/ChangePasswordDialog.tsx
+++ b/ui/leafwiki-ui/src/features/users/ChangePasswordDialog.tsx
@@ -2,6 +2,7 @@ import BaseDialog from '@/components/BaseDialog'
 import { FormInput } from '@/components/FormInput'
 import { handleFieldErrors } from '@/lib/handleFieldErrors'
 import { DIALOG_CHANGE_USER_PASSWORD } from '@/lib/registries'
+import { useConfigStore } from '@/stores/config'
 import { useUserStore } from '@/stores/users'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -23,6 +24,7 @@ export function ChangePasswordDialog({
   const [confirm, setConfirm] = useState('')
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
   const [loading, setLoading] = useState(false)
+  const allowWeakPasswords = useConfigStore((s) => s.allowWeakPasswords)
 
   const { users, updateUser } = useUserStore()
 
@@ -37,16 +39,18 @@ export function ChangePasswordDialog({
 
   if (!user) return null
 
+  const passwordTooShort = !allowWeakPasswords && password.length < 8
+
   const submitDisabled =
     loading ||
-    password.length < 8 ||
+    passwordTooShort ||
     password !== confirm ||
     fieldErrors.password !== '' ||
     fieldErrors.confirm !== ''
 
   const handlePasswordChange = (val: string) => {
     setPassword(val)
-    if (val.length < 8) {
+    if (!allowWeakPasswords && val.length < 8) {
       setFieldErrors((prev) => ({
         ...prev,
         password: t('validation.passwordTooShort'),

--- a/ui/leafwiki-ui/src/lib/api/config.ts
+++ b/ui/leafwiki-ui/src/lib/api/config.ts
@@ -16,6 +16,7 @@ export type Config = {
   publicAccess: boolean
   hideLinkMetadataSection: boolean
   authDisabled: boolean
+  allowWeakPasswords: boolean
   maxAssetUploadSizeBytes: number
   enableRevision: boolean
   enableLinkRefactor: boolean

--- a/ui/leafwiki-ui/src/stores/config.test.ts
+++ b/ui/leafwiki-ui/src/stores/config.test.ts
@@ -18,6 +18,7 @@ const baseConfig = {
   publicAccess: false,
   hideLinkMetadataSection: false,
   authDisabled: false,
+  allowWeakPasswords: false,
   maxAssetUploadSizeBytes: 1000,
   enableRevision: false,
   enableLinkRefactor: false,

--- a/ui/leafwiki-ui/src/stores/config.ts
+++ b/ui/leafwiki-ui/src/stores/config.ts
@@ -8,6 +8,7 @@ type ConfigStore = {
   publicAccess: boolean
   hideLinkMetadataSection: boolean
   authDisabled: boolean
+  allowWeakPasswords: boolean
   maxAssetUploadSizeBytes: number
   enableRevision: boolean
   enableLinkRefactor: boolean
@@ -46,6 +47,7 @@ export const useConfigStore = create<ConfigStore>((set) => ({
   publicAccess: false,
   hideLinkMetadataSection: false,
   authDisabled: false,
+  allowWeakPasswords: false,
   maxAssetUploadSizeBytes: DEFAULT_MAX_ASSET_UPLOAD_SIZE_BYTES,
   enableRevision: false,
   enableLinkRefactor: false,
@@ -78,6 +80,7 @@ export const useConfigStore = create<ConfigStore>((set) => ({
           publicAccess: config.publicAccess,
           hideLinkMetadataSection: config.hideLinkMetadataSection,
           authDisabled: config.authDisabled,
+          allowWeakPasswords: config.allowWeakPasswords ?? false,
           maxAssetUploadSizeBytes,
           enableRevision: config.enableRevision ?? false,
           enableLinkRefactor: config.enableLinkRefactor ?? false,


### PR DESCRIPTION
Fixes #1405

Adds `--allow-weak-passwords` / `LEAFWIKI_ALLOW_WEAK_PASSWORDS` to skip the 8-character password check when creating or changing passwords. The setting is exposed via `/api/config` so the UI stays in sync.

## Checklist

- [x] I discussed the approach on the linked issue before starting (or this is a trivial fix: typo, docs, obvious one-liner)
- [x] This PR is focused on a single change
- [x] I ran `npm run format` in `ui/leafwiki-ui` (and in `e2e` if e2e tests changed)
- [x] I updated documentation if needed
