### PR TITLE
docs: add storage and backup-restore guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ sudo ./install.sh --non-interactive --env-file ./.env
 **Deployment examples:**
 - [Install with nginx on Ubuntu](docs/install/nginx.md)
 - [Install on a Raspberry Pi](docs/install/raspberry.md)
+- [How LeafWiki stores data](docs/storage.md)
+- [Backup and restore](docs/backup-restore.md)
 
 ### Binary
 

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -1,0 +1,69 @@
+# Backup and restore
+
+LeafWiki offers three backup strategies, from simplest to most integrated.
+
+## 1. Copy the data directory (full backup)
+
+The most complete offline backup is a copy of the entire data directory **while LeafWiki is stopped**:
+
+```bash
+systemctl stop leafwiki   # or stop your container/process
+cp -a /path/to/data /path/to/data-backup-$(date +%F)
+systemctl start leafwiki
+```
+
+This includes Markdown pages, assets, the SQLite database, and any snapshot ZIPs already on disk.
+
+## 2. Snapshot backups (built-in, recommended)
+
+Since v0.12.0, LeafWiki can create **full snapshot ZIPs** that bundle `root/`, `assets/`, and the SQLite database. Snapshots are enabled by default.
+
+### Configuration
+
+| Flag / env | Default | Description |
+|------------|---------|-------------|
+| `--snapshot` / `LEAFWIKI_SNAPSHOT` | `true` | Enable snapshot backups |
+| `--snapshot-interval` / `LEAFWIKI_SNAPSHOT_INTERVAL` | `24h` | Auto snapshot interval; `0` = manual only |
+| `--snapshot-retention` / `LEAFWIKI_SNAPSHOT_RETENTION` | `10` | Keep the N most recent snapshots; `<= 0` = keep all |
+| `--snapshot-dir` / `LEAFWIKI_SNAPSHOT_DIR` | `<data-dir>/snapshots` | Where ZIP files are stored |
+
+### From the admin UI
+
+Admins can open **Snapshot** settings to:
+
+- Trigger a snapshot immediately
+- Download existing snapshot ZIPs
+- Upload a snapshot ZIP to restore (replaces the live data directory)
+- Delete old snapshots
+
+Restoring from the UI takes the wiki briefly offline while data is swapped.
+
+### From the CLI (offline restore)
+
+To restore onto a **stopped** instance (e.g. disaster recovery on a fresh machine):
+
+```bash
+./leafwiki --data-dir ./data restore-snapshot /path/to/snapshot.zip
+```
+
+Then start LeafWiki normally. The data directory must exist and LeafWiki must not be running against it during restore.
+
+## 3. Git Backup (content only, experimental)
+
+`--git-backup` pushes `root/` and `assets/` to a remote Git repository over SSH on a schedule. It does **not** include the SQLite database.
+
+Use Git Backup for off-site **content** history; pair it with snapshot backups or data-directory copies for a full restore. See the [Git Backup section in the README](../README.md#git-backup-v0113-experimental) for SSH key and remote setup.
+
+## Which method to use
+
+| Goal | Method |
+|------|--------|
+| Full restore after hardware failure | Snapshot ZIP or `cp -a` of the data dir |
+| Scheduled automated full backups | Snapshots (`--snapshot-interval`) |
+| Version history of page Markdown in Git | Git Backup |
+| Quick manual export before an upgrade | Trigger snapshot in the UI, then download the ZIP |
+
+## Related docs
+
+- [How LeafWiki stores data](storage.md)
+- [Install with nginx](install/nginx.md)

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1,0 +1,38 @@
+# How LeafWiki stores data
+
+LeafWiki keeps wiki **content on disk as Markdown** and uses **SQLite** for metadata, search, users, and other runtime state. Both live under a single **data directory** (default `./data`, or `/app/data` in the Docker image).
+
+## Data directory layout
+
+| Path | Purpose |
+|------|---------|
+| `root/` | Page content as `.md` files, mirroring the wiki tree |
+| `assets/` | Uploaded images and other files referenced from pages |
+| `wiki.db` | SQLite database (users, sessions, tree order, tags, search index, …) |
+| `snapshots/` | Full backup ZIPs when snapshot backups are enabled (default location) |
+| `.git/` | Local git repo used by Git Backup (only when `--git-backup` is enabled) |
+
+Page identity is stored in each file's frontmatter (`leafwiki_id`), not in the filename. That lets pages survive renames and moves without breaking links.
+
+## What lives where
+
+**On disk (`root/`, `assets/`):**
+
+- Human-readable Markdown and uploads
+- Safe to back up with `cp -r` or rsync when LeafWiki is stopped
+- Editable outside the app (trigger a resync from the admin UI or send `SIGUSR1` / `SIGHUP` after external edits)
+
+**In SQLite (`wiki.db`):**
+
+- User accounts, roles, and sessions
+- Page tree structure and manual sort order
+- Tags, backlinks metadata, and the full-text search index
+- Revision history (when `--enable-revision` is on)
+- Other app state that is not duplicated in Markdown files
+
+You cannot fully reconstruct a running wiki from `root/` alone — you need the database too (or a snapshot that includes both).
+
+## Related docs
+
+- [Backup and restore](backup-restore.md)
+- [Install with nginx](install/nginx.md)


### PR DESCRIPTION
Fixes #1282

Adds `docs/storage.md` and `docs/backup-restore.md`, linked from the README deployment examples.

## Checklist

- [x] I discussed the approach on the linked issue before starting (or this is a trivial fix: typo, docs, obvious one-liner)
- [x] This PR is focused on a single change
- [ ] I ran `npm run format` in `ui/leafwiki-ui` (and in `e2e` if e2e tests changed)
- [x] I updated documentation if needed
