### PR TITLE
fix(preview): hide inline-code copy button on mobile

### DIFF
--- a/ui/leafwiki-ui/src/features/preview/MarkdownInlineCode.test.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownInlineCode.test.tsx
@@ -5,7 +5,12 @@ import MarkdownInlineCode from './MarkdownInlineCode'
 
 const { copyMock } = vi.hoisted(() => ({ copyMock: vi.fn() }))
 
+let mockIsMobile = false
+
 vi.mock('copy-to-clipboard', () => ({ default: copyMock }))
+vi.mock('@/lib/useIsMobile', () => ({
+  useIsMobile: () => mockIsMobile,
+}))
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) =>
@@ -47,6 +52,7 @@ vi.mock('@/components/TooltipWrapper', () => ({
 
 describe('MarkdownInlineCode', () => {
   beforeEach(() => {
+    mockIsMobile = false
     copyMock.mockReset()
     copyMock.mockReturnValue(true)
     vi.mocked(toast.error).mockReset()
@@ -107,5 +113,14 @@ describe('MarkdownInlineCode', () => {
     expect(fireEvent.click(button)).toBe(false)
     expect(onParentClick).not.toHaveBeenCalled()
     expect(copyMock).toHaveBeenCalledWith('npm test')
+  })
+
+  it('does not render the copy button on mobile viewports', () => {
+    mockIsMobile = true
+    render(<MarkdownInlineCode>npm test</MarkdownInlineCode>)
+
+    expect(
+      screen.queryByTestId('markdown-inline-code-copy-button'),
+    ).not.toBeInTheDocument()
   })
 })

--- a/ui/leafwiki-ui/src/features/preview/MarkdownInlineCode.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownInlineCode.tsx
@@ -1,5 +1,6 @@
 import { TooltipWrapper } from '@/components/TooltipWrapper'
 import { Button } from '@/components/ui/button'
+import { useIsMobile } from '@/lib/useIsMobile'
 import { Check, Copy } from 'lucide-react'
 import { ClassAttributes, HTMLAttributes, MouseEvent, ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -14,6 +15,7 @@ export default function MarkdownInlineCode({
   ...codeProps
 }: Props) {
   const { t } = useTranslation('viewer')
+  const isMobile = useIsMobile()
   const code = readTextContent(children)
   const { copied, copyCode } = useCodeCopy(code)
 
@@ -28,28 +30,30 @@ export default function MarkdownInlineCode({
       <code {...codeProps} className={`inline-code ${className ?? ''}`.trim()}>
         {children}
       </code>
-      <TooltipWrapper
-        label={
-          copied ? t('codeBlock.copiedTooltip') : t('codeBlock.copyTooltip')
-        }
-        asChild
-      >
-        <Button
-          type="button"
-          variant="outline"
-          size="icon"
-          className="markdown-inline-code__copy-button"
-          onClick={handleCopy}
-          aria-label={
-            copied
-              ? t('codeBlock.copiedAriaLabel')
-              : t('codeBlock.copyAriaLabel')
+      {!isMobile && (
+        <TooltipWrapper
+          label={
+            copied ? t('codeBlock.copiedTooltip') : t('codeBlock.copyTooltip')
           }
-          data-testid="markdown-inline-code-copy-button"
+          asChild
         >
-          {copied ? <Check /> : <Copy />}
-        </Button>
-      </TooltipWrapper>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="markdown-inline-code__copy-button"
+            onClick={handleCopy}
+            aria-label={
+              copied
+                ? t('codeBlock.copiedAriaLabel')
+                : t('codeBlock.copyAriaLabel')
+            }
+            data-testid="markdown-inline-code-copy-button"
+          >
+            {copied ? <Check /> : <Copy />}
+          </Button>
+        </TooltipWrapper>
+      )}
     </span>
   )
 }

--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.test.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.test.tsx
@@ -3,13 +3,21 @@ import { TooltipProvider } from '@/components/ui/tooltip'
 import { useDesignModeStore } from '@/features/designtoggle/designmode'
 import MarkdownPreview from './MarkdownPreview'
 
+function renderPreview(content: string) {
+  return render(
+    <TooltipProvider>
+      <MarkdownPreview content={content} />
+    </TooltipProvider>,
+  )
+}
+
 describe('MarkdownPreview syntax highlighting', () => {
   beforeEach(() => {
     localStorage.setItem('design-mode', 'light')
     useDesignModeStore.setState({ mode: 'light' })
-    window.matchMedia = vi.fn().mockImplementation(() => ({
-      matches: true,
-      media: '(prefers-color-scheme: light)',
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(prefers-color-scheme: light)',
+      media: query,
       onchange: null,
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
@@ -35,7 +43,7 @@ if (Test-Path $path) {
 }
 \`\`\``
 
-    const { container } = render(<MarkdownPreview content={content} />)
+    const { container } = renderPreview(content)
 
     const bashCodeBlock = container.querySelector('code.language-bash.hljs')
     expect(bashCodeBlock).not.toBeNull()
@@ -62,7 +70,7 @@ if WinExist("Untitled - Notepad") {
 }
 \`\`\``
 
-    const { container } = render(<MarkdownPreview content={content} />)
+    const { container } = renderPreview(content)
 
     const autohotkeyCodeBlock = container.querySelector(
       'code.language-autohotkey.hljs',
@@ -79,7 +87,7 @@ echo two
 echo three
 \`\`\``
 
-    const { container } = render(<MarkdownPreview content={content} />)
+    const { container } = renderPreview(content)
 
     const block = container.querySelector('.markdown-code-block--line-numbers')
     expect(block).not.toBeNull()
@@ -102,7 +110,7 @@ echo one
 echo two
 \`\`\``
 
-    const { container } = render(<MarkdownPreview content={content} />)
+    const { container } = renderPreview(content)
 
     expect(
       container.querySelector('.markdown-code-block--line-numbers'),
@@ -113,8 +121,8 @@ echo two
   })
 
   it('renders external images from markdown image syntax', () => {
-    const { container } = render(
-      <MarkdownPreview content="![Remote diagram](https://example.com/diagram.png)" />,
+    const { container } = renderPreview(
+      '![Remote diagram](https://example.com/diagram.png)',
     )
 
     const image = container.querySelector('img')
@@ -124,8 +132,8 @@ echo two
   })
 
   it('renders external images from sanitized inline html', () => {
-    const { container } = render(
-      <MarkdownPreview content='<img src="https://example.com/banner.png" alt="Remote banner" />' />,
+    const { container } = renderPreview(
+      '<img src="https://example.com/banner.png" alt="Remote banner" />',
     )
 
     const image = container.querySelector('img')
@@ -135,11 +143,7 @@ echo two
   })
 
   it('renders inline code with its copy action', () => {
-    const { container } = render(
-      <TooltipProvider>
-        <MarkdownPreview content="Use `npm run build` here." />
-      </TooltipProvider>,
-    )
+    const { container } = renderPreview('Use `npm run build` here.')
 
     const inlineCode = container.querySelector('.markdown-inline-code')
     expect(inlineCode?.textContent).toContain('npm run build')
@@ -151,9 +155,7 @@ echo two
   })
 
   it('renders ==text== as a mark element', () => {
-    const { container } = render(
-      <MarkdownPreview content="Some ==highlighted== text." />,
-    )
+    const { container } = renderPreview('Some ==highlighted== text.')
 
     const mark = container.querySelector('mark')
     expect(mark).not.toBeNull()
@@ -161,9 +163,7 @@ echo two
   })
 
   it('supports nested formatting inside a highlighted span', () => {
-    const { container } = render(
-      <MarkdownPreview content="==**bold highlight**==" />,
-    )
+    const { container } = renderPreview('==**bold highlight**==')
 
     const mark = container.querySelector('mark')
     expect(mark).not.toBeNull()
@@ -179,7 +179,7 @@ echo two
       '```',
     ].join('\n')
 
-    const { container } = render(<MarkdownPreview content={content} />)
+    const { container } = renderPreview(content)
 
     expect(container.querySelector('mark')).toBeNull()
     expect(container.querySelector('code')?.textContent).toContain('==')

--- a/ui/leafwiki-ui/src/features/preview/markdownPreviewCodeTheme.css
+++ b/ui/leafwiki-ui/src/features/preview/markdownPreviewCodeTheme.css
@@ -10,6 +10,16 @@
   font-weight: 500;
 }
 
+/* Tailwind Typography's `prose` class wraps inline `code` in backticks via
+   ::before/::after; the pill styling above already sets code apart visually,
+   so drop the redundant backticks here. */
+.page-viewer__content .inline-code::before,
+.page-viewer__content .inline-code::after,
+.markdown-editor__preview .inline-code::before,
+.markdown-editor__preview .inline-code::after {
+  content: none;
+}
+
 .markdown-inline-code {
   position: relative;
   display: inline-block;


### PR DESCRIPTION
The copy button on inline `code` spans was always semi-visible on touch devices; it now follows the same useIsMobile() convention as other actionable UI (e.g. TreeNode) and doesn't render below the 768px breakpoint.

Also fixes a latent bug in MarkdownPreview.test.tsx: the matchMedia mock returned matches: true for every query, so useIsMobile() was always true across the whole file and the real desktop Tooltip path (which needs TooltipProvider) never ran under test.
