### PR TITLE
fix(build): declare ARG APP_VERSION in the Go build stage of both Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN VITE_API_URL=/ APP_VERSION=${APP_VERSION} npm run build
 # Step 2: Backend + Build binary
 FROM golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS backend-build
 WORKDIR /app
+ARG APP_VERSION
 ARG DISABLE_REFRESH_TOKEN_RATE_LIMIT=false
 COPY go.mod go.sum ./
 RUN go mod download

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -14,6 +14,7 @@ RUN VITE_API_URL=/ APP_VERSION=${APP_VERSION} npm run build
 # Stage 2: Go backend build
 FROM golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
 
+ARG APP_VERSION
 ARG GOOS
 ARG GOARCH
 ARG CGO_ENABLED=0

--- a/cmd/leafwiki/main_test.go
+++ b/cmd/leafwiki/main_test.go
@@ -902,6 +902,72 @@ func TestDockerfileBuilder_GoBuildLdflags_InjectsAppVersion(t *testing.T) {
 	}
 }
 
+// dockerBuildStageDeclaresArg checks that the multi-stage Docker build
+// stage containing marker (e.g. the `go build` line) is preceded by its own
+// `ARG argName` declaration *within that stage*. Docker scopes ARG per
+// build stage: an ARG declared in an earlier stage does not carry into a
+// later one, even though `${argName}` still substitutes silently as an
+// empty string there instead of failing the build.
+func dockerBuildStageDeclaresArg(t *testing.T, dockerfilePath, marker, argName string) bool {
+	t.Helper()
+
+	content, err := os.ReadFile(dockerfilePath)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", dockerfilePath, err)
+	}
+
+	lines := strings.Split(string(content), "\n")
+
+	markerIdx := -1
+	for i, line := range lines {
+		if strings.Contains(line, marker) {
+			markerIdx = i
+			break
+		}
+	}
+	if markerIdx == -1 {
+		t.Fatalf("no line containing %q found in %s", marker, dockerfilePath)
+	}
+
+	stageStart := 0
+	for i := markerIdx; i >= 0; i-- {
+		if strings.HasPrefix(strings.TrimSpace(lines[i]), "FROM ") {
+			stageStart = i
+			break
+		}
+	}
+
+	for _, line := range lines[stageStart:markerIdx] {
+		if strings.TrimSpace(line) == "ARG "+argName {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDockerfile_GoBuildStage_DeclaresAppVersionArg pins the bug where
+// Dockerfile's backend-build stage used ${APP_VERSION} in its go build
+// -ldflags without re-declaring `ARG APP_VERSION` in that stage (it was
+// only declared in the earlier frontend-build stage). Docker scopes ARG per
+// stage, so the ldflags line silently baked in an empty version string
+// instead of failing the build — every v0.12.x release image/binary shipped
+// main.Version="" (visible in the leafwiki_build_info metric and in the
+// snapshot/restore version-mismatch check, which silently no-ops when
+// WikiVersion is empty).
+func TestDockerfile_GoBuildStage_DeclaresAppVersionArg(t *testing.T) {
+	if !dockerBuildStageDeclaresArg(t, filepath.Join("..", "..", "Dockerfile"), "go build", "APP_VERSION") {
+		t.Fatal("Dockerfile's go build stage uses ${APP_VERSION} without declaring ARG APP_VERSION in that stage")
+	}
+}
+
+// TestDockerfileBuilder_GoBuildStage_DeclaresAppVersionArg is the same
+// regression check for Dockerfile.builder's builder stage.
+func TestDockerfileBuilder_GoBuildStage_DeclaresAppVersionArg(t *testing.T) {
+	if !dockerBuildStageDeclaresArg(t, filepath.Join("..", "..", "Dockerfile.builder"), "go build", "APP_VERSION") {
+		t.Fatal("Dockerfile.builder's builder stage uses ${APP_VERSION} without declaring ARG APP_VERSION in that stage")
+	}
+}
+
 // TestResolveVersionScript_AppVersionEnvOverride_ReturnsEnvValue exercises
 // the deterministic branch of scripts/resolve-version.sh (the shared
 // algorithm used by both `make build`/`make run` and vite.config.ts). The


### PR DESCRIPTION
## Summary
- `31cdab3b` threaded `-X main.Version=${APP_VERSION}` into the Go build ldflags for both `Dockerfile` and `Dockerfile.builder`, but never re-declared `ARG APP_VERSION` in the backend-build stage that consumes it. Docker scopes `ARG` per build stage, so it silently resolved to an empty string instead of failing the build.
- Confirmed against the published `v0.12.1` image and release binary: both shipped `leafwiki_build_info{version=""}`.
- Strengthens the regression test to check that the `ARG` is actually declared within the stage using it, not just that the ldflags string mentions `${APP_VERSION}` — the existing test passed despite the bug.

## Test plan
- [x] New regression tests (`TestDockerfile_GoBuildStage_DeclaresAppVersionArg`, `TestDockerfileBuilder_GoBuildStage_DeclaresAppVersionArg`) fail against the pre-fix Dockerfiles and pass after the fix
- [x] `go test ./cmd/leafwiki/...` green
- [ ] Local `docker build --target final --build-arg APP_VERSION=...` verification (running)
- [ ] Re-verify against the re-tagged `v0.12.1` release once published