### PR TITLE
fix(build): check APP_VERSION env var before shelling out in resolveAppVersion

### DIFF
--- a/ui/leafwiki-ui/vite.config.test.ts
+++ b/ui/leafwiki-ui/vite.config.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>()
+  return {
+    ...actual,
+    execSync: vi.fn(() => {
+      throw new Error(
+        'scripts/resolve-version.sh not reachable (simulated Docker frontend-build stage)',
+      )
+    }),
+  }
+})
+
+import { resolveAppVersion } from './vite.config'
+
+describe('resolveAppVersion', () => {
+  const originalAppVersion = process.env.APP_VERSION
+
+  afterEach(() => {
+    if (originalAppVersion === undefined) {
+      delete process.env.APP_VERSION
+    } else {
+      process.env.APP_VERSION = originalAppVersion
+    }
+  })
+
+  it('returns APP_VERSION without needing scripts/resolve-version.sh to be reachable', () => {
+    // The Docker frontend-build stage only COPYs ui/leafwiki-ui/, so
+    // scripts/resolve-version.sh (and bash, on node:*-alpine) generally
+    // isn't present there. Every real build sets APP_VERSION via
+    // --build-arg regardless, so this must not depend on the script
+    // succeeding.
+    process.env.APP_VERSION = 'v9.9.9-test'
+
+    expect(resolveAppVersion()).toBe('v9.9.9-test')
+  })
+})

--- a/ui/leafwiki-ui/vite.config.ts
+++ b/ui/leafwiki-ui/vite.config.ts
@@ -3,7 +3,21 @@ import react from '@vitejs/plugin-react'
 import path from 'path'
 import { defineConfig, type ConfigEnv } from 'vite'
 
-function resolveAppVersion(): string {
+// Mirrors scripts/resolve-version.sh's own env-var-override branch before
+// falling back to invoking the script. This isn't just an optimization: the
+// Docker frontend-build stage only COPYs ./ui/leafwiki-ui/, so the repo-root
+// scripts/ directory (and even bash, on node:*-alpine) generally isn't
+// present there. Every real build always sets APP_VERSION via --build-arg,
+// so checking it first keeps that path working without depending on the
+// script being reachable at all; the script invocation remains as the local
+// `npm run build`/`npm run dev` fallback (git describe), where the full repo
+// and a real shell are available.
+export function resolveAppVersion(): string {
+  const envVersion = process.env.APP_VERSION?.trim()
+  if (envVersion) {
+    return envVersion
+  }
+
   try {
     return execSync('./scripts/resolve-version.sh', {
       cwd: path.resolve(__dirname, '../..'),

--- a/ui/leafwiki-ui/vitest.config.ts
+++ b/ui/leafwiki-ui/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/test-setup.ts'],
-    include: ['src/**/*.test.{ts,tsx}'],
+    include: ['src/**/*.test.{ts,tsx}', 'vite.config.test.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],


### PR DESCRIPTION
## Summary
- `4be33374` moved the `APP_VERSION` env-var check out of `vite.config.ts` and into `scripts/resolve-version.sh`, unconditionally shelling out to it via `execSync`. That breaks in the Docker frontend-build stage: it only `COPY`s `ui/leafwiki-ui/`, so `scripts/resolve-version.sh` isn't present there, and `node:*-alpine` doesn't have `bash` installed to run it even if it were.
- `execSync` throws, and the `catch` silently falls back to the hardcoded `'v0.1.0'` string — confirmed in the published `v0.12.1` image's JS bundle (`` version:`v0.1.0` `` instead of the real tag), even though `APP_VERSION` was already being passed to `npm run build` correctly.
- Restores the env-var-first check (mirroring the script's own priority order) so the Docker/release path no longer depends on the script or a shell being reachable at all.
- Sibling fix to #1431 (same root refactor session, different mechanism — that one was the backend Go ldflags, this is the frontend Vite build).

## Test plan
- [x] New `vite.config.test.ts` (mocks `execSync` to always throw, asserts `APP_VERSION` still wins) — confirmed red before the fix, green after
- [x] `npm run format` / `npx eslint` / `npx tsc --noEmit` clean
- [x] Full Vitest suite green (354/355; the 1 failure is a pre-existing, unrelated flake in `HotKeyHandler.test.tsx`, confirmed passing in isolation)
- [x] Local Docker build verification: `docker build --target final --build-arg APP_VERSION=v0.12.2-frontend-test` — pulled JS bundle shows `version:`v0.12.2-frontend-test`` instead of the `v0.1.0` fallback