### PR TITLE
fix(build): embed frontend in make build for source binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ CMD_DIR=./cmd/leafwiki
 VERSION ?= $(shell ./scripts/resolve-version.sh)
 RELEASE_DIR := releases
 DOCKER_BUILDER := Dockerfile.builder
+UI_DIR := ui/leafwiki-ui
+HTTP_DIST := internal/http/dist
+EMBED_LDFLAGS := -X github.com/perber/wiki/internal/http.EmbedFrontend=true -X github.com/perber/wiki/internal/http.Environment=production
+LDFLAGS := -X main.Version=$(VERSION) $(EMBED_LDFLAGS)
 
 PLATFORMS := \
   linux/amd64 \
@@ -13,7 +17,22 @@ PLATFORMS := \
 
 all: build
 
-build:
+# Build the Vite SPA into internal/http/dist for go:embed.
+ui:
+	@echo "Building frontend..."
+	cd $(UI_DIR) && npm ci --ignore-scripts && VITE_API_URL=/ APP_VERSION=$(VERSION) npm run build
+	rm -rf $(HTTP_DIST)
+	mkdir -p $(HTTP_DIST)
+	cp -R $(UI_DIR)/dist/. $(HTTP_DIST)/
+	touch $(HTTP_DIST)/.gitkeep
+	@test -f $(HTTP_DIST)/index.html || (echo "Frontend build missing $(HTTP_DIST)/index.html" && exit 1)
+
+# Self-contained binary with embedded UI (matches release/Docker builds).
+build: ui
+	go build -ldflags "$(LDFLAGS)" -o $(BINARY_NAME) $(CMD_DIR)
+
+# API-only binary for local Vite-proxied development (no embedded SPA).
+build-api:
 	go build -ldflags "-X main.Version=$(VERSION)" -o $(BINARY_NAME) $(CMD_DIR)
 
 run:
@@ -103,7 +122,9 @@ run-e2e-local-fast:
 
 help:
 	@echo "Available commands:"
-	@echo "  make build                – Build binary for current system"
+	@echo "  make build                – Build self-contained binary with embedded UI (needs Node.js)"
+	@echo "  make build-api            – Build API-only binary (use with Vite in Dev Setup)"
+	@echo "  make ui                   – Build frontend into internal/http/dist for embedding"
 	@echo "  make release              – Cross-compile binaries for all platforms (via Docker)"
 	@echo "  make clean                – Clean all generated files"
 	@echo "  make test                 – Run all Go tests"
@@ -113,8 +134,8 @@ help:
 	@echo "  make run-e2e-local        – Run end-to-end tests via local fast path"
 	@echo "  make run-e2e-local-fast   – Run E2E tests locally, skip UI build (use when dist/ is current)"
 	@echo "                              Optional: GREP=<pattern> to filter tests"
-	@echo "  make run                  – Run development server"
+	@echo "  make run                  – Run development server (API only; use Vite for UI)"
 	@echo "  make docker-build-publish – Build and push multi-arch Docker image"
 	@echo "  make changelog            – Generate changelog"
 
-.PHONY: all build run clean test bench fmt lint help docker-build-publish changelog run-e2e run-e2e-local run-e2e-local-fast run-proxy-e2e
+.PHONY: all build build-api ui run clean test bench fmt lint help docker-build-publish changelog run-e2e run-e2e-local run-e2e-local-fast run-proxy-e2e

--- a/README.md
+++ b/README.md
@@ -215,6 +215,20 @@ The server binds to `127.0.0.1:8080` by default. To expose it on the network:
 
 Default data directory is `./data`. Change with `--data-dir`.
 
+### Build from source
+
+Requires Go and Node.js. `make build` compiles the UI, embeds it, and produces a self-contained `leafwiki` binary (same as release/Docker builds). Use HTTP (`http://localhost:8080/`), not HTTPS, unless you terminate TLS in front of LeafWiki.
+
+```bash
+git clone https://github.com/perber/leafwiki.git
+cd leafwiki
+git switch --detach v0.12.1   # or any tag / main
+make build
+./leafwiki --disable-auth --host=127.0.0.1 --data-dir ./data --allow-insecure=true
+```
+
+For API-only local development with Vite, use `make build-api` (or `make run`) instead — see [Dev Setup](#dev-setup).
+
 ### Reset admin password
 
 ```bash

--- a/cmd/leafwiki/main_test.go
+++ b/cmd/leafwiki/main_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync/atomic"
@@ -994,27 +995,55 @@ func TestResolveVersionScript_AppVersionEnvOverride_ReturnsEnvValue(t *testing.T
 // release/Docker targets do, instead of leaving local builds on the "dev"
 // default silently.
 func TestMakefile_BuildAndRunTargets_InjectVersionLdflags(t *testing.T) {
-	content, err := os.ReadFile(filepath.Join("..", "..", "Makefile"))
+	raw, err := os.ReadFile(filepath.Join("..", "..", "Makefile"))
 	if err != nil {
 		t.Fatalf("failed to read Makefile: %v", err)
 	}
+	content := string(raw)
 
 	for _, target := range []string{"build:", "run:"} {
-		idx := strings.Index(string(content), target)
+		idx := strings.Index(content, target)
 		if idx == -1 {
 			t.Fatalf("Makefile target %q not found", target)
 		}
 
-		recipeEnd := strings.Index(string(content)[idx:], "\n\n")
+		recipeEnd := strings.Index(content[idx:], "\n\n")
 		if recipeEnd == -1 {
 			recipeEnd = len(content) - idx
 		}
-		recipe := string(content)[idx : idx+recipeEnd]
+		recipe := content[idx : idx+recipeEnd]
 
-		if !strings.Contains(recipe, "-X main.Version=$(VERSION)") {
+		if !strings.Contains(resolveMakeVars(content, recipe), "-X main.Version=$(VERSION)") {
 			t.Fatalf("expected Makefile %q recipe to inject main.Version from $(VERSION), got: %s", target, recipe)
 		}
 	}
+}
+
+var makeVarAssignment = regexp.MustCompile(`(?m)^([A-Za-z_][A-Za-z0-9_]*)\s*(?::=|\?=|=)\s*(.*)$`)
+
+// resolveMakeVars expands $(NAME) references in s using NAME's assignment
+// elsewhere in the Makefile, so the check above still works when a recipe
+// builds its ldflags from a variable (e.g. $(LDFLAGS)) instead of a literal
+// string. $(VERSION) itself is left unresolved since the test asserts on
+// that exact reference.
+func resolveMakeVars(content, s string) string {
+	assignments := map[string]string{}
+	for _, m := range makeVarAssignment.FindAllStringSubmatch(content, -1) {
+		assignments[m[1]] = m[2]
+	}
+	delete(assignments, "VERSION")
+
+	for changed := true; changed; {
+		changed = false
+		for name, value := range assignments {
+			token := "$(" + name + ")"
+			if strings.Contains(s, token) {
+				s = strings.ReplaceAll(s, token, value)
+				changed = true
+			}
+		}
+	}
+	return s
 }
 
 // TestViteConfig_ResolvesVersionViaSharedScript pins that the frontend


### PR DESCRIPTION
`make build` now builds the UI, embeds it, and sets `EmbedFrontend` so `GET /` works from a source binary.

Fixes #1435