### PR TITLE
feat(config): support Docker-style LEAFWIKI_*_FILE env secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,8 @@ LEAFWIKI_DATA_DIR=./data
 
 # Auth (required unless LEAFWIKI_DISABLE_AUTH=true)
 LEAFWIKI_JWT_SECRET=
+# Or Docker-style file secret (wins over the plain variable above):
+# LEAFWIKI_JWT_SECRET_FILE=/run/secrets/jwt_secret
 LEAFWIKI_ADMIN_PASSWORD=
 # LEAFWIKI_ADMIN_USERNAME=admin
 # LEAFWIKI_ADMIN_EMAIL=admin@localhost

--- a/README.md
+++ b/README.md
@@ -363,6 +363,8 @@ For plain HTTP: add `--allow-insecure=true` so login and CSRF cookies work.
 
 ### Environment Variables
 
+Any `LEAFWIKI_*` variable can also be loaded from a file via the Docker secrets pattern `LEAFWIKI_*_FILE` (file contents win over the plain variable). Example: `LEAFWIKI_JWT_SECRET_FILE=/run/secrets/jwt`.
+
 | Variable                                | Description                                          | Default       | Since   |
 |-----------------------------------------|------------------------------------------------------|---------------|---------|
 | `LEAFWIKI_HOST`                         | Host/IP address                                      | `127.0.0.1`   | –       |

--- a/cmd/leafwiki/env.go
+++ b/cmd/leafwiki/env.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"os"
+	"strings"
+)
+
+// lookupEnv resolves a process environment value with Docker-style *_FILE
+// support. Precedence for callers that also check CLI flags is:
+//
+//	CLI > NAME_FILE > NAME > default
+//
+// When NAME_FILE is set, the file contents are used (trailing whitespace trimmed)
+// and NAME is ignored. A missing/unreadable file fails startup.
+func lookupEnv(name string) string {
+	if path := strings.TrimSpace(os.Getenv(name + "_FILE")); path != "" {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			fail("Failed to read environment file", "variable", name+"_FILE", "path", path, "error", err)
+		}
+		return strings.TrimSpace(string(b))
+	}
+	return strings.TrimSpace(os.Getenv(name))
+}

--- a/cmd/leafwiki/main.go
+++ b/cmd/leafwiki/main.go
@@ -128,6 +128,7 @@ func writeUsage(w io.Writer) {
 	                               *before* the subcommand, e.g. "leafwiki --data-dir ./data restore-snapshot file.zip").
 
 	Environment variables:
+	(each LEAFWIKI_* also supports LEAFWIKI_*_FILE — file contents override the plain variable)
 	LEAFWIKI_HOST
 	LEAFWIKI_PORT
 	LEAFWIKI_UNIX_SOCKET
@@ -193,7 +194,7 @@ func printUsage() {
 
 func setupLogger(w io.Writer, format string) {
 	level := slog.LevelInfo
-	switch os.Getenv("LEAFWIKI_LOG_LEVEL") {
+	switch lookupEnv("LEAFWIKI_LOG_LEVEL") {
 	case "debug":
 		level = slog.LevelDebug
 	case "error":
@@ -835,21 +836,21 @@ func removeStaleUnixSocket(socketPath string) error {
 	return err
 }
 
-// CLI > ENV > default(flag)
+// CLI > ENV (_FILE then plain) > default(flag)
 func resolveString(flagName, flagVal string, visited map[string]bool, envVar string, def string) string {
 	// If flag was explicitly set, it takes precedence
 	if visited[flagName] {
 		return strings.TrimSpace(flagVal)
 	}
-	// Next, check environment variable
-	if env := strings.TrimSpace(os.Getenv(envVar)); env != "" {
+	// Next, check environment variable (NAME_FILE wins over NAME)
+	if env := lookupEnv(envVar); env != "" {
 		return env
 	}
 	// Fall back to provided default when flag wasn't set and no env var is present
 	return def
 }
 
-// CLI > ENV > default
+// CLI > ENV (_FILE then plain) > default
 func resolveLogFormat(flagName, flagVal string, visited map[string]bool, envVar string, def string) string {
 	if visited[flagName] {
 		if f, ok := parseLogFormat(flagVal); ok {
@@ -857,7 +858,7 @@ func resolveLogFormat(flagName, flagVal string, visited map[string]bool, envVar 
 		}
 		fail("Invalid flag value", "flag", flagName, "value", flagVal, "expected", "text or json")
 	}
-	if env := strings.TrimSpace(os.Getenv(envVar)); env != "" {
+	if env := lookupEnv(envVar); env != "" {
 		if f, ok := parseLogFormat(env); ok {
 			return f
 		}
@@ -877,12 +878,12 @@ func parseLogFormat(s string) (string, bool) {
 	return "", false
 }
 
-// CLI > ENV > default(flag)
+// CLI > ENV (_FILE then plain) > default(flag)
 func resolveBool(flagName string, flagVal bool, visited map[string]bool, envVar string) bool {
 	if visited[flagName] {
 		return flagVal
 	}
-	if env := strings.TrimSpace(os.Getenv(envVar)); env != "" {
+	if env := lookupEnv(envVar); env != "" {
 		if b, ok := parseBool(env); ok {
 			return b
 		}
@@ -896,7 +897,7 @@ func resolveInt(flagName string, flagVal int, visited map[string]bool, envVar st
 	if visited[flagName] {
 		return flagVal
 	}
-	if env := strings.TrimSpace(os.Getenv(envVar)); env != "" {
+	if env := lookupEnv(envVar); env != "" {
 		var n int
 		if _, err := fmt.Sscanf(env, "%d", &n); err == nil {
 			return n
@@ -910,7 +911,7 @@ func resolveDuration(flagName string, flagVal time.Duration, visited map[string]
 	if visited[flagName] {
 		return flagVal
 	}
-	if env := strings.TrimSpace(os.Getenv(envVar)); env != "" {
+	if env := lookupEnv(envVar); env != "" {
 		if d, ok := parseDuration(env); ok {
 			return d
 		}

--- a/cmd/leafwiki/main_test.go
+++ b/cmd/leafwiki/main_test.go
@@ -259,6 +259,51 @@ func TestResolveString_TrimsCLIFlagValue(t *testing.T) {
 	}
 }
 
+func TestLookupEnv_FileTakesPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "secret")
+	if err := os.WriteFile(filePath, []byte("from-file\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LEAFWIKI_TEST_SECRET", "from-env")
+	t.Setenv("LEAFWIKI_TEST_SECRET_FILE", filePath)
+
+	got := lookupEnv("LEAFWIKI_TEST_SECRET")
+	if got != "from-file" {
+		t.Fatalf("lookupEnv() = %q, want %q", got, "from-file")
+	}
+}
+
+func TestLookupEnv_PlainEnvWhenNoFile(t *testing.T) {
+	t.Setenv("LEAFWIKI_TEST_SECRET", "from-env")
+	t.Setenv("LEAFWIKI_TEST_SECRET_FILE", "")
+
+	got := lookupEnv("LEAFWIKI_TEST_SECRET")
+	if got != "from-env" {
+		t.Fatalf("lookupEnv() = %q, want %q", got, "from-env")
+	}
+}
+
+func TestResolveString_FileOverEnvUnderCLI(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "secret")
+	if err := os.WriteFile(filePath, []byte("file-value"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LEAFWIKI_JWT_SECRET", "env-value")
+	t.Setenv("LEAFWIKI_JWT_SECRET_FILE", filePath)
+
+	got := resolveString("jwt-secret", "", map[string]bool{}, "LEAFWIKI_JWT_SECRET", "")
+	if got != "file-value" {
+		t.Fatalf("resolveString() = %q, want %q", got, "file-value")
+	}
+
+	gotCLI := resolveString("jwt-secret", "cli-value", map[string]bool{"jwt-secret": true}, "LEAFWIKI_JWT_SECRET", "")
+	if gotCLI != "cli-value" {
+		t.Fatalf("resolveString(CLI) = %q, want %q", gotCLI, "cli-value")
+	}
+}
+
 func TestResolveLogFormat_Precedence(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Any `LEAFWIKI_*` can be loaded from `LEAFWIKI_*_FILE` (file wins over plain env) for Docker/sidecar secrets.

Fixes #1353