### PR TITLE
fix(preview): let images wrapped in links follow the link target

### DIFF
--- a/ui/leafwiki-ui/src/features/preview/MarkdownImage.test.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownImage.test.tsx
@@ -1,0 +1,31 @@
+import { DIALOG_IMAGE_PREVIEW } from '@/lib/registries'
+import { useDialogsStore } from '@/stores/dialogs'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { MarkdownImage } from './MarkdownImage'
+
+describe('MarkdownImage', () => {
+  beforeEach(() => {
+    useDialogsStore.setState({ dialogType: null, dialogProps: null })
+  })
+
+  it('opens the image preview dialog when not wrapped in a link', () => {
+    render(<MarkdownImage src="/assets/foo.png" alt="foo" />)
+
+    fireEvent.click(screen.getByAltText('foo'))
+
+    expect(useDialogsStore.getState().dialogType).toBe(DIALOG_IMAGE_PREVIEW)
+  })
+
+  it('lets the surrounding link handle the click instead of opening the preview', () => {
+    render(
+      <a href="https://github.com/perber/leafwiki">
+        <MarkdownImage src="/assets/foo.png" alt="foo" />
+      </a>,
+    )
+
+    fireEvent.click(screen.getByAltText('foo'))
+
+    expect(useDialogsStore.getState().dialogType).toBeNull()
+  })
+})

--- a/ui/leafwiki-ui/src/features/preview/MarkdownImage.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownImage.tsx
@@ -82,6 +82,13 @@ export function MarkdownImage({
       onClick={(e) => {
         rest.onClick?.(e)
 
+        // Images wrapped in a link (Markdown `[![alt](img)](url)` or raw
+        // `<a><img></a>`) should follow the link instead of opening the
+        // preview dialog.
+        if (e.currentTarget.closest('a')) {
+          return
+        }
+
         if (shouldOpenInNewTab(e)) {
           window.open(versionedSrc, '_blank', 'noopener,noreferrer')
           return


### PR DESCRIPTION
Clicking an image nested inside an <a> (e.g. [![alt](img)](url) or raw HTML <a><img></a>) opened the image preview dialog instead of navigating, because MarkdownImage's onClick always called preventDefault. Skip the preview interception when the image has an ancestor <a>.

Fixes #1428
