### PR TITLE
fix(auth): enforce minimum length on initial admin password

### DIFF
--- a/cmd/leafwiki/main.go
+++ b/cmd/leafwiki/main.go
@@ -66,7 +66,7 @@ func writeUsage(w io.Writer) {
 	--port             Port to run the server on (default: 8080)
 	--unix-socket      Path to a unix domain socket to listen on (overrides --host and --port)
 	--data-dir         Path to data directory (default: ./data)
-	--admin-password   Initial admin password (used only if no admin exists)
+	--admin-password   Initial admin password (used only if no admin exists), min 8 characters
 	--admin-username   Initial admin username (used only if no admin exists) (default: admin)
 	--admin-email      Initial admin email (used only if no admin exists) (default: admin@localhost)
 	--jwt-secret       Secret for signing auth tokens (JWT) (required)
@@ -313,7 +313,7 @@ func registerFlags(fs *flag.FlagSet) *cliFlags {
 		dataDir:                        fs.String("data-dir", "", "path to data directory"),
 		adminUsername:                  fs.String("admin-username", "", "initial admin username (used only if no admin exists) (default: admin)"),
 		adminEmail:                     fs.String("admin-email", "", "initial admin email (used only if no admin exists) (default: admin@localhost)"),
-		adminPassword:                  fs.String("admin-password", "", "initial admin password"),
+		adminPassword:                  fs.String("admin-password", "", "initial admin password, min 8 characters"),
 		jwtSecret:                      fs.String("jwt-secret", "", "JWT secret for authentication"),
 		totpEncryptionKey:              fs.String("totp-encryption-key", "", "key to encrypt per-user TOTP secrets at rest, min 32 bytes (leave unset to keep TOTP self-service unavailable)"),
 		publicAccess:                   fs.Bool("public-access", false, "allow public access to the wiki with read access (default: false)"),

--- a/e2e-proxy/docker-compose.yml
+++ b/e2e-proxy/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         DISABLE_REFRESH_TOKEN_RATE_LIMIT: "true"
     command:
       - "--jwt-secret=proxy-e2e-secret"
-      - "--admin-password=admin"
+      - "--admin-password=adminproxypassword"
       - "--allow-insecure=true"
       - "--enable-http-remote-user=true"
       # Trust the entire proxy-net subnet so nginx can forward headers.
@@ -49,7 +49,7 @@ services:
         DISABLE_REFRESH_TOKEN_RATE_LIMIT: "true"
     command:
       - "--jwt-secret=proxy-e2e-secret"
-      - "--admin-password=admin"
+      - "--admin-password=adminproxypassword"
       - "--allow-insecure=true"
       - "--enable-http-remote-user=true"
       - "--trusted-proxy-ips=172.30.0.0/16"

--- a/e2e-proxy/proxy_auth_test.go
+++ b/e2e-proxy/proxy_auth_test.go
@@ -69,7 +69,7 @@ func loginAdmin(t *testing.T) string {
 
 func loginAdminAt(t *testing.T, baseURL string) string {
 	t.Helper()
-	payload := `{"identifier":"admin","password":"admin"}`
+	payload := `{"identifier":"admin","password":"adminproxypassword"}`
 	req, err := http.NewRequest(http.MethodPost, baseURL+"/api/auth/login", strings.NewReader(payload))
 	if err != nil {
 		t.Fatalf("build login request: %v", err)

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -81,7 +81,7 @@ start_docker() {
     --revision-coalesce-window=0 \
     --jwt-secret=e2e-tests-secret \
     --totp-encryption-key=e2e-tests-totp-encryption-key-32 \
-    --admin-password=admin
+    --admin-password=admine2epassword
 
   echo "✅ Container started on $app_url"
 }
@@ -117,7 +117,7 @@ start_local() {
       --revision-coalesce-window=0 \
       --jwt-secret=e2e-tests-secret \
       --totp-encryption-key=e2e-tests-totp-encryption-key-32 \
-      --admin-password=admin
+      --admin-password=admine2epassword
   ) >"$server_log" 2>&1 &
 
   server_pid=$!
@@ -168,13 +168,13 @@ run_playwright_tests() {
     if command -v stdbuf >/dev/null 2>&1; then
       E2E_BASE_URL="$app_url" \
       E2E_ADMIN_USER="${E2E_ADMIN_USER:-admin}" \
-      E2E_ADMIN_PASSWORD="${E2E_ADMIN_PASSWORD:-admin}" \
+      E2E_ADMIN_PASSWORD="${E2E_ADMIN_PASSWORD:-admine2epassword}" \
       PLAYWRIGHT_FORCE_TTY=1 \
       stdbuf -oL -eL npx playwright test --workers="$workers" --reporter="$reporter" "$@"
     else
       E2E_BASE_URL="$app_url" \
       E2E_ADMIN_USER="${E2E_ADMIN_USER:-admin}" \
-      E2E_ADMIN_PASSWORD="${E2E_ADMIN_PASSWORD:-admin}" \
+      E2E_ADMIN_PASSWORD="${E2E_ADMIN_PASSWORD:-admine2epassword}" \
       PLAYWRIGHT_FORCE_TTY=1 \
       npx playwright test --workers="$workers" --reporter="$reporter" "$@"
     fi

--- a/hacks/proxy-auth/run.sh
+++ b/hacks/proxy-auth/run.sh
@@ -22,7 +22,7 @@
 #
 # The "admin" username is forwarded to LeafWiki via the X-Forwarded-User header.
 # LeafWiki resolves it against its own user database — the built-in admin account
-# (created by --admin-password=admin) matches, so login works out of the box.
+# (created by --admin-password=adminproxypassword) matches, so login works out of the box.
 #
 # Access:
 #   http://localhost:4180   ← entry point (oauth2-proxy handles auth, proxies to LeafWiki)

--- a/hacks/proxy-auth/with-logout.yml
+++ b/hacks/proxy-auth/with-logout.yml
@@ -54,7 +54,7 @@ services:
       dockerfile: Dockerfile
     command:
       - "--jwt-secret=hack-secret"
-      - "--admin-password=admin"
+      - "--admin-password=adminproxypassword"
       - "--allow-insecure=true"
       - "--enable-http-remote-user=true"
       - "--http-remote-user-header-name=X-Forwarded-User"

--- a/hacks/proxy-auth/without-logout.yml
+++ b/hacks/proxy-auth/without-logout.yml
@@ -54,7 +54,7 @@ services:
       dockerfile: Dockerfile
     command:
       - "--jwt-secret=hack-secret"
-      - "--admin-password=admin"
+      - "--admin-password=adminproxypassword"
       - "--allow-insecure=true"
       - "--enable-http-remote-user=true"
       - "--http-remote-user-header-name=X-Forwarded-User"

--- a/internal/core/auth/errors.go
+++ b/internal/core/auth/errors.go
@@ -12,6 +12,7 @@ var ErrInvalidToken = errors.New("invalid token")
 var ErrSessionManagerNotWired = errors.New("session manager: resolveUser not configured (NewAuthService wires this; a SessionManager built directly must set it before use)")
 var ErrUserAccountLocked = errors.New("account temporarily locked due to too many failed login attempts")
 var ErrRemoteUserEmailConflict = errors.New("remote user auto-create: asserted email belongs to a different existing user")
+var ErrPasswordTooShort = errors.New("password is too short")
 
 var ErrAPIKeyNotFound = errors.New("api key not found")
 var ErrAPIKeyInvalid = errors.New("invalid api key")

--- a/internal/core/auth/user_service.go
+++ b/internal/core/auth/user_service.go
@@ -14,6 +14,12 @@ import (
 const (
 	defaultAdminUsername = "admin"
 	defaultAdminEmail    = "admin@localhost"
+
+	// MinPasswordLength is the minimum accepted length for user-chosen
+	// passwords, enforced consistently across every password entry point:
+	// user creation, password change/reset, invites, and the initial admin
+	// bootstrap password.
+	MinPasswordLength = 8
 )
 
 type UserService struct {
@@ -34,6 +40,10 @@ func (s *UserService) InitDefaultAdmin(username, email, newPassword string) erro
 	if _, err := s.store.GetAdminUser(); err == nil {
 		// Admin user already exists, no need to create a new one
 		return nil
+	}
+
+	if len(newPassword) < MinPasswordLength {
+		return fmt.Errorf("%w: initial admin password must be at least %d characters long", ErrPasswordTooShort, MinPasswordLength)
 	}
 
 	username = defaultIfEmpty(username, defaultAdminUsername)

--- a/internal/core/auth/user_service_test.go
+++ b/internal/core/auth/user_service_test.go
@@ -155,7 +155,7 @@ func TestUserService_InitDefaultAdmin(t *testing.T) {
 	store, _ := NewUserStore(t.TempDir())
 	service := NewUserService(store)
 
-	err := service.InitDefaultAdmin("", "", "")
+	err := service.InitDefaultAdmin("", "", "password123")
 	if err != nil {
 		t.Errorf("InitDefaultAdmin failed: %v", err)
 	}
@@ -170,7 +170,7 @@ func TestUserService_InitDefaultAdmin_UsesGivenUsernameAndEmail(t *testing.T) {
 	store, _ := NewUserStore(t.TempDir())
 	service := NewUserService(store)
 
-	err := service.InitDefaultAdmin("root", "root@example.com", "")
+	err := service.InitDefaultAdmin("root", "root@example.com", "password123")
 	if err != nil {
 		t.Errorf("InitDefaultAdmin failed: %v", err)
 	}
@@ -178,6 +178,21 @@ func TestUserService_InitDefaultAdmin_UsesGivenUsernameAndEmail(t *testing.T) {
 	users, err := service.GetUsers()
 	if err != nil || len(users) != 1 || users[0].Username != "root" || users[0].Email != "root@example.com" {
 		t.Errorf("Expected admin user with custom username/email, got: %+v", users)
+	}
+}
+
+func TestUserService_InitDefaultAdmin_PasswordTooShort_ReturnsError(t *testing.T) {
+	store, _ := NewUserStore(t.TempDir())
+	service := NewUserService(store)
+
+	err := service.InitDefaultAdmin("root", "root@example.com", "short")
+	if !errors.Is(err, ErrPasswordTooShort) {
+		t.Fatalf("InitDefaultAdmin() error = %v, want ErrPasswordTooShort", err)
+	}
+
+	users, err := service.GetUsers()
+	if err != nil || len(users) != 0 {
+		t.Errorf("Expected no admin user to be created, got: %+v", users)
 	}
 }
 

--- a/internal/http/apikeys_router_test.go
+++ b/internal/http/apikeys_router_test.go
@@ -25,7 +25,7 @@ func newAPIKeyRouterTest(t *testing.T) (*wiki.Wiki, http.Handler) {
 	t.Helper()
 	w, err := wiki.NewWiki(&wiki.WikiOptions{
 		StorageDir:             t.TempDir(),
-		AdminPassword:          "admin",
+		AdminPassword:          "adminpassword",
 		JWTSecret:              "secretkey",
 		AccessTokenTimeout:     15 * time.Minute,
 		RefreshTokenTimeout:    7 * 24 * time.Hour,

--- a/internal/http/middleware/auth/auth_test.go
+++ b/internal/http/middleware/auth/auth_test.go
@@ -31,7 +31,7 @@ func createTestAuthFixture(t *testing.T) *authFixture {
 	}
 
 	userService := coreauth.NewUserService(userStore)
-	if err := userService.InitDefaultAdmin("", "", "admin"); err != nil {
+	if err := userService.InitDefaultAdmin("", "", "adminpassword"); err != nil {
 		_ = sessionStore.Close()
 		_ = userStore.Close()
 		t.Fatalf("Failed to init default admin: %v", err)
@@ -208,7 +208,7 @@ func TestRequireAuth_WithAuthEnabled_ValidToken(t *testing.T) {
 	authCookies := authmw.NewAuthCookies(true, time.Hour, time.Hour*24)
 
 	// Login to get a valid token
-	authToken, err := fixture.auth.Login("admin", "admin")
+	authToken, err := fixture.auth.Login("admin", "adminpassword")
 	if err != nil {
 		t.Fatalf("Failed to login: %v", err)
 	}
@@ -376,7 +376,7 @@ func TestRequireAuth_WithAuthEnabled_UserSetInContext(t *testing.T) {
 	authCookies := authmw.NewAuthCookies(true, time.Hour, time.Hour*24)
 
 	// Login to get a valid token
-	authToken, err := fixture.auth.Login("admin", "admin")
+	authToken, err := fixture.auth.Login("admin", "adminpassword")
 	if err != nil {
 		t.Fatalf("Failed to login: %v", err)
 	}
@@ -551,7 +551,7 @@ func TestRequireAuth_ComprehensiveScenarios(t *testing.T) {
 			if tc.provideToken {
 				var token string
 				if tc.validToken {
-					authToken, err := fixture.auth.Login("admin", "admin")
+					authToken, err := fixture.auth.Login("admin", "adminpassword")
 					if err != nil {
 						t.Fatalf("Failed to login: %v", err)
 					}
@@ -615,7 +615,7 @@ func TestOptionalAuth_ValidToken_SetsUser(t *testing.T) {
 	}()
 
 	authCookies := authmw.NewAuthCookies(true, time.Hour, time.Hour*24)
-	authToken, err := fixture.auth.Login("admin", "admin")
+	authToken, err := fixture.auth.Login("admin", "adminpassword")
 	if err != nil {
 		t.Fatalf("login: %v", err)
 	}

--- a/internal/http/middleware/auth/reverse_proxy_test.go
+++ b/internal/http/middleware/auth/reverse_proxy_test.go
@@ -36,7 +36,7 @@ func createProxyFixture(t *testing.T) *proxyFixture {
 	}
 
 	userService := coreauth.NewUserService(userStore)
-	if err := userService.InitDefaultAdmin("", "", "admin"); err != nil {
+	if err := userService.InitDefaultAdmin("", "", "adminpassword"); err != nil {
 		_ = userStore.Close()
 		t.Fatalf("init default admin: %v", err)
 	}

--- a/internal/http/router_test.go
+++ b/internal/http/router_test.go
@@ -36,7 +36,7 @@ func createWikiTestInstance(t *testing.T) *wiki.Wiki {
 func createWikiTestInstanceWithRevisionFlag(t *testing.T, enableRevision bool) *wiki.Wiki {
 	w, err := wiki.NewWiki(&wiki.WikiOptions{
 		StorageDir:          t.TempDir(),
-		AdminPassword:       "admin",
+		AdminPassword:       "adminpassword",
 		JWTSecret:           "secretkey",
 		AccessTokenTimeout:  15 * time.Minute,
 		RefreshTokenTimeout: 7 * 24 * time.Hour,
@@ -108,7 +108,7 @@ func createRouterTestInstanceWithAllowInsecure(w *wiki.Wiki, allowInsecure bool,
 
 func authenticatedRequest(t *testing.T, router http.Handler, method, url string, body *strings.Reader) *httptest.ResponseRecorder {
 	// Login
-	loginBody := `{"identifier": "admin", "password": "admin"}`
+	loginBody := `{"identifier": "admin", "password": "adminpassword"}`
 	loginReq := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(loginBody))
 	loginReq.Header.Set("Content-Type", "application/json")
 	loginRec := httptest.NewRecorder()
@@ -365,7 +365,7 @@ func uploadAssetViaAPI(t *testing.T, router http.Handler, pageID, filename, cont
 		t.Fatalf("Close(writer) failed: %v", err)
 	}
 
-	loginBody := `{"identifier": "admin", "password": "admin"}`
+	loginBody := `{"identifier": "admin", "password": "adminpassword"}`
 	loginReq := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(loginBody))
 	loginReq.Header.Set("Content-Type", "application/json")
 	loginRec := httptest.NewRecorder()
@@ -477,7 +477,7 @@ func uploadBrandingLogoViaAPI(t *testing.T, router http.Handler, filename string
 		t.Fatalf("Close(writer) failed: %v", err)
 	}
 
-	loginBody := `{"identifier": "admin", "password": "admin"}`
+	loginBody := `{"identifier": "admin", "password": "adminpassword"}`
 	loginReq := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(loginBody))
 	loginReq.Header.Set("Content-Type", "application/json")
 	loginRec := httptest.NewRecorder()
@@ -535,7 +535,7 @@ func uploadBrandingFaviconViaAPI(t *testing.T, router http.Handler, filename str
 		t.Fatalf("Close(writer) failed: %v", err)
 	}
 
-	loginBody := `{"identifier": "admin", "password": "admin"}`
+	loginBody := `{"identifier": "admin", "password": "adminpassword"}`
 	loginReq := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(loginBody))
 	loginReq.Header.Set("Content-Type", "application/json")
 	loginRec := httptest.NewRecorder()
@@ -799,7 +799,7 @@ func TestLoginEndpoint_ExplainsAllowInsecureRequirementOnHTTP(t *testing.T) {
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
 	router := createRouterTestInstanceWithAllowInsecure(w, false, t)
 
-	loginBody := `{"identifier": "admin", "password": "admin"}`
+	loginBody := `{"identifier": "admin", "password": "adminpassword"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(loginBody))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -1434,7 +1434,7 @@ func TestUploadAssetEndpoint_RejectsFilesExceedingConfiguredLimit(t *testing.T) 
 
 	page := createPageViaAPI(t, router, "Asset Limit Test", "asset-limit-test", nil, pageNodeKind())
 
-	loginBody := `{"identifier": "admin", "password": "admin"}`
+	loginBody := `{"identifier": "admin", "password": "adminpassword"}`
 	loginReq := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(loginBody))
 	loginReq.Header.Set("Content-Type", "application/json")
 	loginRec := httptest.NewRecorder()
@@ -1548,7 +1548,7 @@ func TestCancelImportPlanEndpoint(t *testing.T) {
 		t.Fatalf("Close multipart writer failed: %v", err)
 	}
 
-	loginBody := `{"identifier": "admin", "password": "admin"}`
+	loginBody := `{"identifier": "admin", "password": "adminpassword"}`
 	loginReq := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(loginBody))
 	loginReq.Header.Set("Content-Type", "application/json")
 	loginRec := httptest.NewRecorder()
@@ -1635,7 +1635,7 @@ func TestImportExecuteEndpoint_WithZipUpload_ImportsPagesLinksAndAssets(t *testi
 	fixtureDir := importerFixturePathForHTTPTests(t, "link-assets-package")
 	zipBytes := createZipFromDir(t, fixtureDir)
 
-	loginBody := `{"identifier": "admin", "password": "admin"}`
+	loginBody := `{"identifier": "admin", "password": "adminpassword"}`
 	loginReq := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(loginBody))
 	loginReq.Header.Set("Content-Type", "application/json")
 	loginRec := httptest.NewRecorder()
@@ -1816,7 +1816,7 @@ func TestImportExecuteEndpoint_UsesConfiguredAssetUploadLimit(t *testing.T) {
 
 	zipBytes := createZipFromDir(t, fixtureDir)
 
-	loginBody := `{"identifier": "admin", "password": "admin"}`
+	loginBody := `{"identifier": "admin", "password": "adminpassword"}`
 	loginReq := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(loginBody))
 	loginReq.Header.Set("Content-Type", "application/json")
 	loginRec := httptest.NewRecorder()
@@ -3242,7 +3242,7 @@ func TestAuthLoginEndpoint(t *testing.T) {
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
 	router := createRouterTestInstance(w, t)
 
-	body := `{"identifier": "admin", "password": "admin"}`
+	body := `{"identifier": "admin", "password": "adminpassword"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -3290,7 +3290,7 @@ func TestAuthRefreshToken(t *testing.T) {
 	}
 
 	// 1) Login
-	loginBody := `{"identifier": "admin", "password": "admin"}`
+	loginBody := `{"identifier": "admin", "password": "adminpassword"}`
 	loginReq := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(loginBody))
 	loginReq.Header.Set("Content-Type", "application/json")
 	loginRec := httptest.NewRecorder()
@@ -3823,7 +3823,7 @@ func TestAssetEndpoints(t *testing.T) {
 	router := createRouterTestInstance(w, t)
 
 	// Step 0: Login als Admin und Cookies holen
-	loginBody := `{"identifier": "admin", "password": "admin"}`
+	loginBody := `{"identifier": "admin", "password": "adminpassword"}`
 	loginReq := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(loginBody))
 	loginReq.Header.Set("Content-Type", "application/json")
 	loginRec := httptest.NewRecorder()
@@ -3959,7 +3959,7 @@ func TestAssetMutationRevisionsUseAuthenticatedUser(t *testing.T) {
 	router := createRouterTestInstanceWithRevision(w, t)
 	adminUserID := getAdminUserIDViaAPI(t, router)
 
-	loginBody := `{"identifier": "admin", "password": "admin"}`
+	loginBody := `{"identifier": "admin", "password": "adminpassword"}`
 	loginReq := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(loginBody))
 	loginReq.Header.Set("Content-Type", "application/json")
 	loginRec := httptest.NewRecorder()
@@ -4145,7 +4145,7 @@ func uploadTestAsset(t *testing.T, router *gin.Engine, w *wiki.Wiki, content str
 
 	if needsAuth {
 		// Login to get auth cookies
-		loginBody := `{"identifier": "admin", "password": "admin"}`
+		loginBody := `{"identifier": "admin", "password": "adminpassword"}`
 		loginReq := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(loginBody))
 		loginReq.Header.Set("Content-Type", "application/json")
 		loginRec := httptest.NewRecorder()

--- a/internal/importer/importer_integration_test.go
+++ b/internal/importer/importer_integration_test.go
@@ -69,7 +69,7 @@ func newTestWiki(t *testing.T) *wiki.Wiki {
 	t.Helper()
 	w, err := wiki.NewWiki(&wiki.WikiOptions{
 		StorageDir:          t.TempDir(),
-		AdminPassword:       "admin",
+		AdminPassword:       "adminpassword",
 		JWTSecret:           "secretkey",
 		AccessTokenTimeout:  15 * time.Minute,
 		RefreshTokenTimeout: 7 * 24 * time.Hour,

--- a/internal/wiki/auth/use_cases.go
+++ b/internal/wiki/auth/use_cases.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"regexp"
 	"strings"
@@ -323,8 +324,8 @@ func (uc *CreateUserUseCase) Execute(_ context.Context, in CreateUserInput) (*Cr
 	}
 	if in.Password == "" {
 		ve.Add("password", "Password must not be empty")
-	} else if len(in.Password) < 8 {
-		ve.Add("password", "Password must be at least 8 characters long")
+	} else if len(in.Password) < coreauth.MinPasswordLength {
+		ve.Add("password", fmt.Sprintf("Password must be at least %d characters long", coreauth.MinPasswordLength))
 	}
 	if !coreauth.IsValidRole(in.Role) {
 		ve.Add("role", "Invalid role")
@@ -425,8 +426,8 @@ func (uc *ChangeOwnPasswordUseCase) Execute(_ context.Context, in ChangeOwnPassw
 	ve := sharederrors.NewValidationErrors()
 	if in.NewPassword == "" {
 		ve.Add("newPassword", "New password must not be empty")
-	} else if len(in.NewPassword) < 8 {
-		ve.Add("newPassword", "New password must be at least 8 characters long")
+	} else if len(in.NewPassword) < coreauth.MinPasswordLength {
+		ve.Add("newPassword", fmt.Sprintf("New password must be at least %d characters long", coreauth.MinPasswordLength))
 	}
 	if _, err := uc.user().DoesIDAndPasswordMatch(in.UserID, in.OldPassword); err != nil {
 		ve.Add("oldPassword", "Old password is incorrect")
@@ -580,8 +581,8 @@ func (uc *ConfirmPasswordResetUseCase) Execute(_ context.Context, in ConfirmPass
 	ve := sharederrors.NewValidationErrors()
 	if in.NewPassword == "" {
 		ve.Add("newPassword", "New password must not be empty")
-	} else if len(in.NewPassword) < 8 {
-		ve.Add("newPassword", "New password must be at least 8 characters long")
+	} else if len(in.NewPassword) < coreauth.MinPasswordLength {
+		ve.Add("newPassword", fmt.Sprintf("New password must be at least %d characters long", coreauth.MinPasswordLength))
 	}
 	if ve.HasErrors() {
 		return nil, ve
@@ -727,8 +728,8 @@ func (uc *ConfirmInviteUseCase) Execute(_ context.Context, in ConfirmInviteInput
 	ve := sharederrors.NewValidationErrors()
 	if in.NewPassword == "" {
 		ve.Add("newPassword", "New password must not be empty")
-	} else if len(in.NewPassword) < 8 {
-		ve.Add("newPassword", "New password must be at least 8 characters long")
+	} else if len(in.NewPassword) < coreauth.MinPasswordLength {
+		ve.Add("newPassword", fmt.Sprintf("New password must be at least %d characters long", coreauth.MinPasswordLength))
 	}
 	if ve.HasErrors() {
 		return nil, ve

--- a/internal/wiki/wiki_test.go
+++ b/internal/wiki/wiki_test.go
@@ -23,7 +23,7 @@ func createWikiTestInstance(t *testing.T) *Wiki {
 func createWikiTestInstanceWithMetrics(t *testing.T, metrics *httpmetrics.HTTPMetrics) *Wiki {
 	wikiInstance, err := NewWiki(&WikiOptions{
 		StorageDir:          t.TempDir(),
-		AdminPassword:       "admin",
+		AdminPassword:       "adminpassword",
 		JWTSecret:           "secretkey",
 		AccessTokenTimeout:  15 * time.Minute,
 		RefreshTokenTimeout: 7 * 24 * time.Hour,
@@ -191,7 +191,7 @@ func TestWiki_InitDefaultAdmin_UsesGivenPassword(t *testing.T) {
 	w := createWikiTestInstance(t)
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
 
-	_, err := w.user.GetUserByEmailOrUsernameAndPassword("admin", "admin")
+	_, err := w.user.GetUserByEmailOrUsernameAndPassword("admin", "adminpassword")
 	if err != nil {
 		t.Fatalf("Admin user not found: %v", err)
 	}
@@ -202,7 +202,7 @@ func TestWiki_InitDefaultAdmin_UsesGivenUsernameAndEmail(t *testing.T) {
 		StorageDir:          t.TempDir(),
 		AdminUsername:       "root",
 		AdminEmail:          "root@example.com",
-		AdminPassword:       "admin",
+		AdminPassword:       "adminpassword",
 		JWTSecret:           "secretkey",
 		AccessTokenTimeout:  15 * time.Minute,
 		RefreshTokenTimeout: 7 * 24 * time.Hour,
@@ -212,7 +212,7 @@ func TestWiki_InitDefaultAdmin_UsesGivenUsernameAndEmail(t *testing.T) {
 	}
 	defer test_utils.WrapCloseWithErrorCheck(wikiInstance.Close, t)
 
-	user, err := wikiInstance.user.GetUserByEmailOrUsernameAndPassword("root", "admin")
+	user, err := wikiInstance.user.GetUserByEmailOrUsernameAndPassword("root", "adminpassword")
 	if err != nil {
 		t.Fatalf("Admin user with custom username not found: %v", err)
 	}
@@ -230,7 +230,7 @@ func TestWiki_Login_SuccessAndFailure(t *testing.T) {
 		t.Fatal("expected auth service to be initialized")
 	}
 
-	token, err := authSvc.Login("admin", "admin")
+	token, err := authSvc.Login("admin", "adminpassword")
 	if err != nil || token == nil {
 		t.Error("Expected login to succeed with default admin password")
 	}
@@ -293,7 +293,7 @@ func TestWiki_AuthDisabled_APIKeysUnavailable(t *testing.T) {
 func TestWiki_APIKeyManagementDisabled_APIKeysUnavailable(t *testing.T) {
 	wikiInstance, err := NewWiki(&WikiOptions{
 		StorageDir:             t.TempDir(),
-		AdminPassword:          "admin",
+		AdminPassword:          "adminpassword",
 		JWTSecret:              "secretkey",
 		AccessTokenTimeout:     15 * time.Minute,
 		RefreshTokenTimeout:    7 * 24 * time.Hour,
@@ -315,7 +315,7 @@ func TestWiki_APIKeyManagementDisabled_APIKeysUnavailable(t *testing.T) {
 func TestWiki_APIKeyManagementEnabled_APIKeysAvailable(t *testing.T) {
 	wikiInstance, err := NewWiki(&WikiOptions{
 		StorageDir:             t.TempDir(),
-		AdminPassword:          "admin",
+		AdminPassword:          "adminpassword",
 		JWTSecret:              "secretkey",
 		AccessTokenTimeout:     15 * time.Minute,
 		RefreshTokenTimeout:    7 * 24 * time.Hour,
@@ -475,7 +475,7 @@ func TestWiki_ResyncRespectsLeafwikiignore(t *testing.T) {
 
 	w, err := NewWiki(&WikiOptions{
 		StorageDir:          tmp,
-		AdminPassword:       "admin",
+		AdminPassword:       "adminpassword",
 		JWTSecret:           "secretkey",
 		AccessTokenTimeout:  15 * time.Minute,
 		RefreshTokenTimeout: 7 * 24 * time.Hour,


### PR DESCRIPTION
## Summary
- The initial admin password (`--admin-password` / `LEAFWIKI_ADMIN_PASSWORD`) skipped the 8-character minimum enforced everywhere else (create user, change/reset password, invites) — a 1-character bootstrap password was silently accepted.
- The check now lives in `InitDefaultAdmin`, after the "admin already exists" short-circuit, so it only applies on first-boot bootstrap and never blocks startup of an already-provisioned instance that has a stale/short password left in its env.
- Extracted the previously-duplicated `8` literal (4 call sites) into a shared `coreauth.MinPasswordLength` constant.

## Test plan
- [x] `go test ./internal/core/auth/... ./internal/wiki/auth/... ./cmd/leafwiki/...` — all pass
- [x] `go build ./...` clean, `gofmt -l` clean
- [x] Manual: fresh instance + short `LEAFWIKI_ADMIN_PASSWORD` → fails fast with a clear error
- [x] Manual: already-bootstrapped instance restarted with a short `LEAFWIKI_ADMIN_PASSWORD` in env → starts normally (admin already exists, value never checked)