### PR TITLE
fix(settings): align settings nav styling with tree/tabs

### DIFF
--- a/ui/leafwiki-ui/src/features/settings/SettingsNav.tsx
+++ b/ui/leafwiki-ui/src/features/settings/SettingsNav.tsx
@@ -9,6 +9,7 @@ import {
   settingsSections,
   useSettingsSectionContext,
 } from '@/lib/registries/settingsSectionRegistry'
+import { Settings } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router'
 
@@ -24,7 +25,13 @@ export default function SettingsNav() {
 
   return (
     <ListView
-      header={<ListViewHeader>{t('nav.title')}</ListViewHeader>}
+      header={
+        <ListViewHeader>
+          <Settings size={16} />
+          {t('nav.title')}
+        </ListViewHeader>
+      }
+      className="settings-nav"
       testId="settings-nav"
     >
       <ListViewList>

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -2871,16 +2871,25 @@
     @apply mx-auto w-full max-w-4xl px-4 pt-4 pb-4 sm:px-8 sm:pt-8;
   }
 
-  .settings-nav {
-    @apply border-surface-border mb-6 flex flex-wrap gap-1 border-b pb-3;
+  .settings-nav .list-view__header {
+    @apply border-b-surface-border bg-surface h-12 min-h-0 border-b px-2;
   }
 
-  .settings-nav__link {
-    @apply text-muted-foreground hover:text-foreground rounded-md px-3 py-1.5 text-sm no-underline transition-colors;
+  .settings-nav .list-view__title {
+    @apply text-brand inline-flex items-center gap-1 px-3 py-1.5 text-sm font-normal;
   }
 
-  .settings-nav__link--active {
-    @apply bg-accent text-foreground font-medium;
+  .settings-nav .list-view__content {
+    @apply p-2 pt-0;
+  }
+
+  .settings-nav .list-view__item {
+    @apply flex items-center gap-2.5 rounded-none text-sm;
+  }
+
+  .settings-nav .list-view__item--active {
+    @apply border-surface-border/0 bg-surface-alt text-brand;
+    box-shadow: inset 3px 0 0 hsl(var(--brand));
   }
 
   .settings__title {


### PR DESCRIPTION
Icon/text alignment, item spacing, and active-state color in the settings sidebar didn't match the tree and sidebar tab conventions. The nav header now mirrors the sidebar tab bar (icon, brand color, normal weight) instead of the old boxed/accordion look, and items lose their rounded corners and pale active border in favor of the solid brand accent bar used elsewhere.

