### PR TITLE
fix(settings): restore top padding in settings nav list

### DIFF
--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -2880,7 +2880,7 @@
   }
 
   .settings-nav .list-view__content {
-    @apply p-2 pt-0;
+    @apply p-2;
   }
 
   .settings-nav .list-view__item {


### PR DESCRIPTION
The active-item accent bar fix dropped top padding on the item list entirely, leaving Account flush against the header's bottom border.
