### PR TITLE
fix(settings): restore field spacing in account password/TOTP panels

### DIFF
--- a/ui/leafwiki-ui/src/features/settings/account/ChangeOwnPasswordPanel.tsx
+++ b/ui/leafwiki-ui/src/features/settings/account/ChangeOwnPasswordPanel.tsx
@@ -83,7 +83,10 @@ export function ChangeOwnPasswordPanel() {
     fieldErrors.confirm !== ''
 
   return (
-    <div className="settings__field" data-testid="change-own-password-panel">
+    <div
+      className="settings__field space-y-3"
+      data-testid="change-own-password-panel"
+    >
       <input
         aria-hidden="true"
         autoComplete="username"

--- a/ui/leafwiki-ui/src/features/settings/account/TotpPanel.tsx
+++ b/ui/leafwiki-ui/src/features/settings/account/TotpPanel.tsx
@@ -72,7 +72,7 @@ function TotpSetupFlow() {
   if (!user) return null
 
   return (
-    <div className="settings__field" data-testid="totp-setup-panel">
+    <div className="settings__field space-y-3" data-testid="totp-setup-panel">
       {step === 'password' && (
         <>
           <FormInput
@@ -190,7 +190,10 @@ function TotpDisableFlow() {
   if (!user) return null
 
   return (
-    <div className="settings__field" data-testid="totp-disable-panel">
+    <div
+      className="settings__field space-y-3"
+      data-testid="totp-disable-panel"
+    >
       <FormInput
         label={t('totp.disable.passwordPlaceholder')}
         name="current-password"


### PR DESCRIPTION
ChangeOwnPasswordPanel and TotpPanel carried over their outer .settings__field wrapper from the dialogs they replaced, but lost the space-y-3 those dialogs used between stacked FormInputs, leaving the fields packed tightly together.
