### PR TITLE
perf(settings): bundle admin-only settings sections into one lazy chunk

### DIFF
--- a/ui/leafwiki-ui/src/features/router/lazy-routes.tsx
+++ b/ui/leafwiki-ui/src/features/router/lazy-routes.tsx
@@ -3,29 +3,54 @@ import { lazy } from 'react'
 export const AccountSettings = lazy(
   () => import('../settings/account/AccountSettings'),
 )
-export const ApiKeysManagement = lazy(
-  () => import('../apikeys/ApiKeysManagement'),
+
+// The 7 admin-only settings sections share one dynamic-import specifier
+// (../settings/adminSections) so the bundler collapses them into a single
+// chunk, loaded once when an admin opens any one of them — see
+// pleaf/root/AI-Gen-Infos/plans/open/features/
+// settings-admin-sections-shared-chunk.md.
+export const ApiKeysManagement = lazy(() =>
+  import('../settings/adminSections').then((m) => ({
+    default: m.ApiKeysManagement,
+  })),
 )
-export const BackupSettings = lazy(() => import('../backup/BackupSettings'))
+export const BackupSettings = lazy(() =>
+  import('../settings/adminSections').then((m) => ({
+    default: m.BackupSettings,
+  })),
+)
+export const BrandingSettings = lazy(() =>
+  import('../settings/adminSections').then((m) => ({
+    default: m.BrandingSettings,
+  })),
+)
+export const Importer = lazy(() =>
+  import('../settings/adminSections').then((m) => ({ default: m.Importer })),
+)
+export const MaintenanceSettings = lazy(() =>
+  import('../settings/adminSections').then((m) => ({
+    default: m.MaintenanceSettings,
+  })),
+)
+export const SnapshotSettings = lazy(() =>
+  import('../settings/adminSections').then((m) => ({
+    default: m.SnapshotSettings,
+  })),
+)
+export const UserManagement = lazy(() =>
+  import('../settings/adminSections').then((m) => ({
+    default: m.UserManagement,
+  })),
+)
+
 export const LoginForm = lazy(() => import('../auth/LoginForm'))
 export const ForgotPasswordForm = lazy(
   () => import('../auth/ForgotPasswordForm'),
 )
 export const ResetPasswordPage = lazy(() => import('../auth/ResetPasswordPage'))
 export const AcceptInvitePage = lazy(() => import('../auth/AcceptInvitePage'))
-export const BrandingSettings = lazy(
-  () => import('../branding/BrandingSettings'),
-)
 export const PageEditor = lazy(() => import('../editor/PageEditor'))
-export const Importer = lazy(() => import('../importer/Importer'))
-export const MaintenanceSettings = lazy(
-  () => import('../maintenance/MaintenanceSettings'),
-)
 export const PageHistoryPage = lazy(() => import('../page/PageHistoryPage'))
 export const PermalinkRedirect = lazy(() => import('../page/PermalinkRedirect'))
 export const RootRedirect = lazy(() => import('../page/RootRedirect'))
-export const SnapshotSettings = lazy(
-  () => import('../snapshot/SnapshotSettings'),
-)
-export const UserManagement = lazy(() => import('../users/UserManagement'))
 export { default as PageViewer } from '../viewer/PageViewer'

--- a/ui/leafwiki-ui/src/features/settings/account/TotpPanel.tsx
+++ b/ui/leafwiki-ui/src/features/settings/account/TotpPanel.tsx
@@ -190,10 +190,7 @@ function TotpDisableFlow() {
   if (!user) return null
 
   return (
-    <div
-      className="settings__field space-y-3"
-      data-testid="totp-disable-panel"
-    >
+    <div className="settings__field space-y-3" data-testid="totp-disable-panel">
       <FormInput
         label={t('totp.disable.passwordPlaceholder')}
         name="current-password"

--- a/ui/leafwiki-ui/src/features/settings/adminSections.ts
+++ b/ui/leafwiki-ui/src/features/settings/adminSections.ts
@@ -1,0 +1,13 @@
+// Barrel for the admin-only settings sections (roles: ['admin']).
+// Re-exported from one module so their `lazy()` imports in lazy-routes.tsx
+// share a single dynamic-import specifier and land in one chunk instead of
+// seven — see the plan in pleaf/root/AI-Gen-Infos/plans/open/features/
+// settings-admin-sections-shared-chunk.md. Account stays out of this barrel
+// since it's visible to non-admin users too.
+export { default as ApiKeysManagement } from '../apikeys/ApiKeysManagement'
+export { default as BackupSettings } from '../backup/BackupSettings'
+export { default as BrandingSettings } from '../branding/BrandingSettings'
+export { default as Importer } from '../importer/Importer'
+export { default as MaintenanceSettings } from '../maintenance/MaintenanceSettings'
+export { default as SnapshotSettings } from '../snapshot/SnapshotSettings'
+export { default as UserManagement } from '../users/UserManagement'


### PR DESCRIPTION
## Summary
- The 7 admin-only settings sections (Branding, Users, API-Keys, Backup, Snapshots, Importer, Maintenance) now share one dynamic-import barrel (`features/settings/adminSections.ts`) instead of 7 separate `React.lazy()` chunks, so switching tabs inside settings no longer triggers a fresh network request per tab.
- Account stays on its own chunk since it's the only section visible to non-admin users.
- Verified via `npm run build`: single `adminSections-*.js` chunk instead of 7.
- Plan: pleaf `plans/open/features/settings-admin-sections-shared-chunk.md`.

## Test plan
- [x] `tsc -b` clean
- [x] `eslint` clean
- [x] `npm run format` (no changes)
- [x] `vitest run` on `settingsSectionRegistry`, `router`, `SettingsSectionGuard`, `SettingsIndexRedirect`, `SettingsNav` — 30/30 passing
- [x] `npm run build` — confirmed single shared chunk for admin sections, Account chunk unaffected