### PR TITLE
feat(settings): integrate per-user UserSettings into the Settings page

### DIFF
--- a/e2e/pages/AccountSettingsPage.ts
+++ b/e2e/pages/AccountSettingsPage.ts
@@ -1,0 +1,19 @@
+import { Page } from '@playwright/test';
+import { toAppPath } from './appPath';
+
+export default class AccountSettingsPage {
+  constructor(private page: Page) {}
+
+  async goto() {
+    await this.page.goto(toAppPath('/settings/account'));
+    await this.autoSaveCheckbox().waitFor({ state: 'visible' });
+  }
+
+  autoSaveCheckbox() {
+    return this.page.locator('button[data-testid="preferences-autosave-checkbox"]');
+  }
+
+  async toggleAutoSave() {
+    await this.autoSaveCheckbox().click();
+  }
+}

--- a/e2e/tests/settings-preferences.spec.ts
+++ b/e2e/tests/settings-preferences.spec.ts
@@ -1,0 +1,72 @@
+import test, { expect } from '@playwright/test';
+import { createPage, getCsrfScript } from '../helpers/api';
+import AccountSettingsPage from '../pages/AccountSettingsPage';
+import LoginPage from '../pages/LoginPage';
+import ViewPage from '../pages/ViewPage';
+
+const user = process.env.E2E_ADMIN_USER || 'admin';
+const password = process.env.E2E_ADMIN_PASSWORD || 'admin';
+
+// autoSave is now a per-user server setting (GET/PUT /api/user-settings), not
+// per-browser localStorage — it persists across reloads AND leaks into every
+// other spec file sharing this admin account. Always restore the default
+// afterward, the same way totp.spec.ts resets TOTP in its afterEach.
+test.afterEach(async ({ page }) => {
+  await page
+    .evaluate(async (csrfScript) => {
+      const csrfToken = new Function(csrfScript)() as string;
+      await fetch('/api/user-settings', {
+        method: 'PUT',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
+        body: JSON.stringify({ autoSave: true }),
+      });
+    }, getCsrfScript())
+    .catch(() => {});
+});
+
+test.describe('Account settings — preferences', () => {
+  test('toggling auto-save persists across reloads and matches the editor toolbar', async ({
+    page,
+  }) => {
+    const loginPage = new LoginPage(page);
+    const viewPage = new ViewPage(page);
+    const settingsPage = new AccountSettingsPage(page);
+
+    await loginPage.goto();
+    await loginPage.login(user, password);
+    await viewPage.expectUserLoggedIn();
+
+    await settingsPage.goto();
+    await expect(settingsPage.autoSaveCheckbox()).toBeChecked();
+
+    await settingsPage.toggleAutoSave();
+    await expect(settingsPage.autoSaveCheckbox()).not.toBeChecked();
+
+    // Reload to prove this is backend-persisted, not just local UI state.
+    await page.reload();
+    await settingsPage.autoSaveCheckbox().waitFor({ state: 'visible' });
+    await expect(settingsPage.autoSaveCheckbox()).not.toBeChecked();
+
+    // Open a page in the editor and toggle auto-save back on from its toolbar
+    // — Auto Save is the 3rd toolbar button (useToolbarActions.tsx), and
+    // Toolbar.tsx only renders the first 2 directly (VISIBLE_BUTTONS = 2), so
+    // it lives in the "More actions" overflow menu.
+    await createPage(page, {
+      title: 'Auto Save E2E Page',
+      slug: 'auto-save-e2e-page',
+      content: 'hello',
+    });
+    await viewPage.goto('/auto-save-e2e-page');
+    await viewPage.clickEditPageButton();
+
+    await page.getByTestId('toolbar-overflow-button').click();
+    const autoSaveMenuItem = page.getByTestId('toggle-auto-save-menu-item');
+    await autoSaveMenuItem.waitFor({ state: 'visible' });
+    await autoSaveMenuItem.click();
+
+    // Confirm Settings reflects the change made from the editor toolbar.
+    await settingsPage.goto();
+    await expect(settingsPage.autoSaveCheckbox()).toBeChecked();
+  });
+});

--- a/ui/leafwiki-ui/src/App.tsx
+++ b/ui/leafwiki-ui/src/App.tsx
@@ -5,6 +5,7 @@ import { BASE_PATH } from '@/lib/config'
 import { useIsReadOnly } from '@/lib/useIsReadOnly'
 import { useFavoritesStore } from '@/stores/favorites'
 import { useSessionStore } from '@/stores/session'
+import { useUserSettingsStore } from '@/stores/userSettings'
 import useApplyDesignMode from '@/useApplyDesignMode'
 import { Loader2 } from 'lucide-react'
 import { Suspense, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
@@ -35,6 +36,8 @@ function App() {
   const isReadOnlyViewer = isReadOnly && !isLoggedIn
   const loadFavorites = useFavoritesStore((s) => s.loadFavorites)
   const clearFavorites = useFavoritesStore((s) => s.clearFavorites)
+  const loadUserSettings = useUserSettingsStore((s) => s.loadUserSettings)
+  const clearUserSettings = useUserSettingsStore((s) => s.clearUserSettings)
 
   useApplyDesignMode()
   useEffect(() => {
@@ -51,6 +54,16 @@ function App() {
       clearFavorites()
     }
   }, [userId, loadFavorites, clearFavorites])
+
+  // User settings (e.g. autoSave) are per-user server truth, just like
+  // favorites above — (re)load on login, reset on logout.
+  useEffect(() => {
+    if (userId) {
+      loadUserSettings()
+    } else {
+      clearUserSettings()
+    }
+  }, [userId, loadUserSettings, clearUserSettings])
 
   useLayoutEffect(() => {
     // Load branding configuration

--- a/ui/leafwiki-ui/src/features/editor/MarkdownToolbar.test.tsx
+++ b/ui/leafwiki-ui/src/features/editor/MarkdownToolbar.test.tsx
@@ -35,17 +35,26 @@ vi.mock('@/stores/editor', () => ({
     selector: (state: {
       lineWrap: boolean
       toggleLineWrap: ReturnType<typeof vi.fn>
-      autoSave: boolean
-      toggleAutoSave: ReturnType<typeof vi.fn>
       autoSaveStatus: 'idle'
     }) => unknown,
   ) =>
     selector({
       lineWrap: true,
       toggleLineWrap: vi.fn(),
+      autoSaveStatus: 'idle',
+    }),
+}))
+
+vi.mock('@/stores/userSettings', () => ({
+  useUserSettingsStore: (
+    selector: (state: {
+      autoSave: boolean
+      toggleAutoSave: ReturnType<typeof vi.fn>
+    }) => unknown,
+  ) =>
+    selector({
       autoSave: true,
       toggleAutoSave: vi.fn(),
-      autoSaveStatus: 'idle',
     }),
 }))
 

--- a/ui/leafwiki-ui/src/features/editor/MarkdownToolbar.tsx
+++ b/ui/leafwiki-ui/src/features/editor/MarkdownToolbar.tsx
@@ -35,6 +35,7 @@ import {
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useEditorStore } from '@/stores/editor'
+import { useUserSettingsStore } from '@/stores/userSettings'
 import { MarkdownEditorRef } from './MarkdownEditor'
 
 type Props = {
@@ -60,8 +61,8 @@ export default function MarkdownToolbar({
   const openDialog = useDialogsStore((state) => state.openDialog)
   const lineWrap = useEditorStore((s) => s.lineWrap)
   const toggleLineWrap = useEditorStore((s) => s.toggleLineWrap)
-  const autoSave = useEditorStore((s) => s.autoSave)
-  const toggleAutoSave = useEditorStore((s) => s.toggleAutoSave)
+  const autoSave = useUserSettingsStore((s) => s.autoSave)
+  const toggleAutoSave = useUserSettingsStore((s) => s.toggleAutoSave)
   const autoSaveStatus = useEditorStore((s) => s.autoSaveStatus)
   const [canUndo, setCanUndo] = useState(false)
   const [canRedo, setCanRedo] = useState(false)

--- a/ui/leafwiki-ui/src/features/editor/useAutoSave.ts
+++ b/ui/leafwiki-ui/src/features/editor/useAutoSave.ts
@@ -271,14 +271,13 @@ export function useAutoSave(): { status: AutoSaveStatus } {
         !wasAlreadySaving &&
         statusRef.current !== 'paused'
       ) {
-        const editorState = useEditorStore.getState()
         const pageEditorState = usePageEditorStore.getState()
         const validationErrors = validateEditorFrontmatterMetadata(
           pageEditorState.tags,
           pageEditorState.frontmatterFields,
         )
         if (
-          editorState.autoSave &&
+          useUserSettingsStore.getState().autoSave &&
           isDirtyState(pageEditorState) &&
           pageEditorState.page?.slug === pageEditorState.slug &&
           Object.keys(validationErrors).length === 0

--- a/ui/leafwiki-ui/src/features/editor/useAutoSave.ts
+++ b/ui/leafwiki-ui/src/features/editor/useAutoSave.ts
@@ -1,6 +1,7 @@
 import { asApiLocalizedError, mapApiError } from '@/lib/api/errors'
 import { useDialogsStore } from '@/stores/dialogs'
 import { useEditorStore, type AutoSaveStatus } from '@/stores/editor'
+import { useUserSettingsStore } from '@/stores/userSettings'
 import { useEffect, useReducer, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -22,7 +23,7 @@ export function useAutoSave(): { status: AutoSaveStatus } {
     0,
   )
 
-  const autoSave = useEditorStore((s) => s.autoSave)
+  const autoSave = useUserSettingsStore((s) => s.autoSave)
   const content = usePageEditorStore((s) => s.content)
   const tags = usePageEditorStore((s) => s.tags)
   const frontmatterFields = usePageEditorStore((s) => s.frontmatterFields)

--- a/ui/leafwiki-ui/src/features/editor/useToolbarActions.tsx
+++ b/ui/leafwiki-ui/src/features/editor/useToolbarActions.tsx
@@ -14,7 +14,7 @@ import { completionStatus } from '@codemirror/autocomplete'
 import { Save, X, Cloud } from 'lucide-react'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useEditorStore } from '@/stores/editor'
+import { useUserSettingsStore } from '@/stores/userSettings'
 import { useIsMobile } from '@/lib/useIsMobile'
 import { type ToolbarButton, useToolbarStore } from '../toolbar/toolbarStore'
 import { usePageEditorStore } from './pageEditorStore'
@@ -51,8 +51,8 @@ export function useToolbarActions({
   const unregisterHotkey = useHotKeysStore((s) => s.unregisterHotkey)
 
   const dirty = usePageEditorStore(isDirtyState)
-  const autoSave = useEditorStore((s) => s.autoSave)
-  const toggleAutoSave = useEditorStore((s) => s.toggleAutoSave)
+  const autoSave = useUserSettingsStore((s) => s.autoSave)
+  const toggleAutoSave = useUserSettingsStore((s) => s.toggleAutoSave)
   const isMacOS =
     typeof navigator !== 'undefined' &&
     /Mac|iPhone|iPad|iPod/.test(navigator.platform)

--- a/ui/leafwiki-ui/src/features/settings/account/AccountSettings.tsx
+++ b/ui/leafwiki-ui/src/features/settings/account/AccountSettings.tsx
@@ -3,6 +3,7 @@ import { useSessionStore } from '@/stores/session'
 import { useTranslation } from 'react-i18next'
 import { useSetTitle } from '../../viewer/setTitle'
 import { ChangeOwnPasswordPanel } from './ChangeOwnPasswordPanel'
+import { PreferencesPanel } from './PreferencesPanel'
 import { TotpPanel } from './TotpPanel'
 
 export default function AccountSettings() {
@@ -36,6 +37,16 @@ export default function AccountSettings() {
           <TotpPanel />
         </div>
       )}
+
+      <div className="settings__section">
+        <h2 className="settings__section-title">
+          {t('account.preferences.sectionTitle')}
+        </h2>
+        <p className="settings__section-description">
+          {t('account.preferences.sectionDescription')}
+        </p>
+        <PreferencesPanel />
+      </div>
     </div>
   )
 }

--- a/ui/leafwiki-ui/src/features/settings/account/PreferencesPanel.tsx
+++ b/ui/leafwiki-ui/src/features/settings/account/PreferencesPanel.tsx
@@ -1,0 +1,27 @@
+import { Checkbox } from '@/components/ui/checkbox'
+import { useUserSettingsStore } from '@/stores/userSettings'
+import { useTranslation } from 'react-i18next'
+
+export function PreferencesPanel() {
+  const { t } = useTranslation('settings')
+  const autoSave = useUserSettingsStore((s) => s.autoSave)
+  const toggleAutoSave = useUserSettingsStore((s) => s.toggleAutoSave)
+
+  return (
+    <div className="settings__field" data-testid="preferences-panel">
+      <label className="settings__checkbox-label">
+        <Checkbox
+          data-testid="preferences-autosave-checkbox"
+          checked={autoSave}
+          onCheckedChange={(checked) => {
+            if (!!checked !== autoSave) toggleAutoSave()
+          }}
+        />
+        {t('account.preferences.autoSaveLabel')}
+      </label>
+      <p className="settings__section-description">
+        {t('account.preferences.autoSaveDescription')}
+      </p>
+    </div>
+  )
+}

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -2912,6 +2912,10 @@
     @apply mb-4;
   }
 
+  .settings__checkbox-label {
+    @apply flex items-center gap-2;
+  }
+
   .settings__preview {
     @apply bg-surface-alt mb-4 flex items-center gap-3 rounded-md p-4;
   }

--- a/ui/leafwiki-ui/src/lib/api/userSettings.ts
+++ b/ui/leafwiki-ui/src/lib/api/userSettings.ts
@@ -1,0 +1,25 @@
+import { fetchWithAuth } from './auth'
+
+export type UserSettings = {
+  userId: string
+  language: string
+  autoSave: boolean
+  updatedAt: string
+}
+
+export type UserSettingsPatch = {
+  autoSave?: boolean
+}
+
+export async function getUserSettings(): Promise<UserSettings> {
+  return (await fetchWithAuth('/api/user-settings')) as UserSettings
+}
+
+export async function updateUserSettings(
+  patch: UserSettingsPatch,
+): Promise<UserSettings> {
+  return (await fetchWithAuth('/api/user-settings', {
+    method: 'PUT',
+    body: JSON.stringify(patch),
+  })) as UserSettings
+}

--- a/ui/leafwiki-ui/src/locales/de/settings.json
+++ b/ui/leafwiki-ui/src/locales/de/settings.json
@@ -9,6 +9,13 @@
     "passwordSectionTitle": "Passwort",
     "passwordSectionDescription": "Ändern Sie Ihr Passwort. Merken Sie es sich gut!",
     "twoFactorSectionTitle": "Zwei-Faktor-Authentifizierung",
-    "twoFactorSectionDescription": "Fügen Sie Ihrem Konto eine zusätzliche Sicherheitsebene hinzu."
+    "twoFactorSectionDescription": "Fügen Sie Ihrem Konto eine zusätzliche Sicherheitsebene hinzu.",
+    "preferences": {
+      "sectionTitle": "Voreinstellungen",
+      "sectionDescription": "Bearbeitungseinstellungen, geräteübergreifend synchronisiert.",
+      "autoSaveLabel": "Automatisches Speichern aktivieren",
+      "autoSaveDescription": "Änderungen beim Bearbeiten einer Seite automatisch speichern.",
+      "autoSaveToggleError": "Einstellung für automatisches Speichern konnte nicht aktualisiert werden"
+    }
   }
 }

--- a/ui/leafwiki-ui/src/locales/en/settings.json
+++ b/ui/leafwiki-ui/src/locales/en/settings.json
@@ -9,6 +9,13 @@
     "passwordSectionTitle": "Password",
     "passwordSectionDescription": "Change your password. Make sure to remember it!",
     "twoFactorSectionTitle": "Two-Factor Authentication",
-    "twoFactorSectionDescription": "Add an extra layer of security to your account."
+    "twoFactorSectionDescription": "Add an extra layer of security to your account.",
+    "preferences": {
+      "sectionTitle": "Preferences",
+      "sectionDescription": "Editing preferences, synced across your devices.",
+      "autoSaveLabel": "Enable auto-save",
+      "autoSaveDescription": "Automatically save your changes while editing a page.",
+      "autoSaveToggleError": "Could not update auto-save setting"
+    }
   }
 }

--- a/ui/leafwiki-ui/src/stores/editor.ts
+++ b/ui/leafwiki-ui/src/stores/editor.ts
@@ -11,8 +11,6 @@ type EditorStore = {
   togglePreviewLayout: () => void
   lineWrap: boolean
   toggleLineWrap: () => void
-  autoSave: boolean
-  toggleAutoSave: () => void
   autoSaveStatus: AutoSaveStatus
   setAutoSaveStatus: (status: AutoSaveStatus) => void
 }
@@ -27,8 +25,6 @@ export const useEditorStore = create<EditorStore>()(
       togglePreviewLayout: () => set({ previewStacked: !get().previewStacked }),
       lineWrap: true,
       toggleLineWrap: () => set({ lineWrap: !get().lineWrap }),
-      autoSave: true,
-      toggleAutoSave: () => set({ autoSave: !get().autoSave }),
       autoSaveStatus: 'idle',
       setAutoSaveStatus: (status) => set({ autoSaveStatus: status }),
     }),
@@ -38,7 +34,6 @@ export const useEditorStore = create<EditorStore>()(
         previewVisible: state.previewVisible,
         previewStacked: state.previewStacked,
         lineWrap: state.lineWrap,
-        autoSave: state.autoSave,
       }),
     },
   ),

--- a/ui/leafwiki-ui/src/stores/userSettings.ts
+++ b/ui/leafwiki-ui/src/stores/userSettings.ts
@@ -1,0 +1,50 @@
+// stores/userSettings.ts
+// A logged-in user's private preferences (currently just autoSave; language
+// is stored by the backend but not yet surfaced in the frontend). Per-user
+// server truth fetched once via GET /api/user-settings and never persisted
+// to localStorage — mirrors stores/favorites.ts. App.tsx owns calling
+// loadUserSettings()/clearUserSettings() as the session's logged-in state
+// changes.
+
+import { mapApiError } from '@/lib/api/errors'
+import { getUserSettings, updateUserSettings } from '@/lib/api/userSettings'
+import i18next from '@/lib/i18n'
+import { create } from 'zustand'
+import { toast } from 'sonner'
+
+const t = (key: string) => i18next.t(key, { ns: 'settings' })
+
+type UserSettingsStore = {
+  autoSave: boolean
+  loaded: boolean
+  loadUserSettings: () => Promise<void>
+  toggleAutoSave: () => Promise<void>
+  clearUserSettings: () => void
+}
+
+export const useUserSettingsStore = create<UserSettingsStore>()((set, get) => ({
+  autoSave: true,
+  loaded: false,
+  loadUserSettings: async () => {
+    try {
+      const settings = await getUserSettings()
+      set({ autoSave: settings.autoSave, loaded: true })
+    } catch (err) {
+      console.warn('Failed to load user settings:', err)
+    }
+  },
+  toggleAutoSave: async () => {
+    const previous = get().autoSave
+    const next = !previous
+    set({ autoSave: next })
+    try {
+      await updateUserSettings({ autoSave: next })
+    } catch (err) {
+      set({ autoSave: previous })
+      toast.error(
+        mapApiError(err, t('account.preferences.autoSaveToggleError')).message,
+      )
+    }
+  },
+  clearUserSettings: () => set({ autoSave: true, loaded: false }),
+}))


### PR DESCRIPTION
## Summary
- Wires up `GET/PUT /api/user-settings` (backend from #1454) on the frontend via a new `useUserSettingsStore`, mirroring the favorites store's per-user server-truth pattern.
- Adds a "Preferences" section to Settings → Account with an Auto-Save toggle.
- The editor's existing Auto-Save toggle (toolbar dropdown + toolbar overflow button) now reads/writes this same backend-synced store instead of a per-browser `localStorage` value, so it's consistent across devices.
- No language selector yet — deferred until frontend locale support existed. Note: #1457 (also just merged) adds German, so this is worth revisiting as a fast follow.

## Test plan
- [x] `npm run format` / `tsc -b` (the exact command the Docker build runs) clean
- [x] `MarkdownToolbar.test.tsx` and `features/settings/account/*.test.tsx` pass in isolation
- [x] New Playwright e2e spec (`e2e/tests/settings-preferences.spec.ts`): toggles auto-save in Settings, confirms it survives a reload, then toggles it back on from the editor toolbar and confirms Settings reflects it — passes against a local build (`E2E_RUN_MODE=local ./run.sh`)