### PR TITLE
feat(settings): add language picker to Account Settings

### DIFF
--- a/e2e/pages/AccountSettingsPage.ts
+++ b/e2e/pages/AccountSettingsPage.ts
@@ -16,4 +16,21 @@ export default class AccountSettingsPage {
   async toggleAutoSave() {
     await this.autoSaveCheckbox().click();
   }
+
+  pageTitle() {
+    return this.page.locator('h1.settings__title');
+  }
+
+  languageSelect() {
+    return this.page.locator('button[data-testid="preferences-language-select"]');
+  }
+
+  private languageOptions() {
+    return this.page.locator('[role="option"]');
+  }
+
+  async selectLanguage(name: string) {
+    await this.languageSelect().click();
+    await this.languageOptions().filter({ hasText: name }).first().click();
+  }
 }

--- a/e2e/tests/settings-language.spec.ts
+++ b/e2e/tests/settings-language.spec.ts
@@ -1,0 +1,58 @@
+import test, { expect } from '@playwright/test';
+import { getCsrfScript } from '../helpers/api';
+import AccountSettingsPage from '../pages/AccountSettingsPage';
+import LoginPage from '../pages/LoginPage';
+import ViewPage from '../pages/ViewPage';
+
+const user = process.env.E2E_ADMIN_USER || 'admin';
+const password = process.env.E2E_ADMIN_PASSWORD || 'admin';
+
+// language is a per-user server setting (GET/PUT /api/user-settings), not
+// per-browser localStorage — it persists across reloads AND leaks into every
+// other spec file sharing this admin account. Always restore the default
+// afterward, the same way settings-preferences.spec.ts resets autoSave.
+test.afterEach(async ({ page }) => {
+  await page
+    .evaluate(async (csrfScript) => {
+      const csrfToken = new Function(csrfScript)() as string;
+      await fetch('/api/user-settings', {
+        method: 'PUT',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
+        body: JSON.stringify({ language: 'en' }),
+      });
+    }, getCsrfScript())
+    .catch(() => {});
+});
+
+test.describe('Account settings — language', () => {
+  test('switching the language updates the UI immediately and persists across reloads', async ({
+    page,
+  }) => {
+    const loginPage = new LoginPage(page);
+    const viewPage = new ViewPage(page);
+    const settingsPage = new AccountSettingsPage(page);
+
+    await loginPage.goto();
+    await loginPage.login(user, password);
+    await viewPage.expectUserLoggedIn();
+
+    await settingsPage.goto();
+    await expect(settingsPage.pageTitle()).toHaveText('Account');
+    await expect(settingsPage.languageSelect()).toHaveText('English');
+
+    await settingsPage.selectLanguage('Deutsch');
+
+    // Applied immediately, without waiting for the PUT to resolve or a reload.
+    await expect(settingsPage.pageTitle()).toHaveText('Konto');
+
+    // Reload to prove this is backend-persisted, not just local UI state.
+    await page.reload();
+    await settingsPage.pageTitle().waitFor({ state: 'visible' });
+    await expect(settingsPage.pageTitle()).toHaveText('Konto');
+    await expect(settingsPage.languageSelect()).toHaveText('Deutsch');
+
+    await settingsPage.selectLanguage('English');
+    await expect(settingsPage.pageTitle()).toHaveText('Account');
+  });
+});

--- a/internal/usersettings/language.go
+++ b/internal/usersettings/language.go
@@ -3,11 +3,11 @@ package usersettings
 import "sort"
 
 // allowedLanguages is the set of language codes UserSettings will accept.
-// The frontend only ships an "en" locale today (see ui/leafwiki-ui/src/lib/i18n.ts),
-// so this list is deliberately just the default for now — extend it here
-// once more locales are registered.
+// Keep in sync with the locales shipped under ui/leafwiki-ui/src/locales/ —
+// extend here whenever a new one is added.
 var allowedLanguages = map[string]bool{
 	DefaultLanguage: true,
+	"de":            true,
 }
 
 // IsAllowedLanguage reports whether lang is a language UserSettings accepts.

--- a/internal/usersettings/language_test.go
+++ b/internal/usersettings/language_test.go
@@ -1,0 +1,25 @@
+package usersettings
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAllowedLanguages_ReturnsSortedShippedCodes(t *testing.T) {
+	got := AllowedLanguages()
+	want := []string{"de", "en"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}
+
+func TestIsAllowedLanguage_AcceptsShippedCodesAndRejectsUnknownOnes(t *testing.T) {
+	for _, lang := range []string{"en", "de"} {
+		if !IsAllowedLanguage(lang) {
+			t.Errorf("expected %q to be allowed", lang)
+		}
+	}
+	if IsAllowedLanguage("xx-not-a-real-language") {
+		t.Error("expected an unshipped language code to be rejected")
+	}
+}

--- a/ui/leafwiki-ui/src/features/settings/account/PreferencesPanel.test.tsx
+++ b/ui/leafwiki-ui/src/features/settings/account/PreferencesPanel.test.tsx
@@ -1,0 +1,48 @@
+import '@/lib/i18n'
+import { useUserSettingsStore } from '@/stores/userSettings'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { PreferencesPanel } from './PreferencesPanel'
+
+// jsdom has no real layout/pointer-capture engine, which Radix's Select
+// relies on when opening its popover — stub the bits it touches.
+beforeEach(() => {
+  window.HTMLElement.prototype.scrollIntoView = vi.fn()
+  window.HTMLElement.prototype.hasPointerCapture = vi
+    .fn()
+    .mockReturnValue(false)
+  window.HTMLElement.prototype.releasePointerCapture = vi.fn()
+})
+
+describe('PreferencesPanel', () => {
+  const setLanguage = vi.fn()
+  const toggleAutoSave = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useUserSettingsStore.setState({
+      autoSave: true,
+      language: 'en',
+      loaded: true,
+      setLanguage,
+      toggleAutoSave,
+    })
+  })
+
+  it('shows the currently selected language', () => {
+    render(<PreferencesPanel />)
+
+    expect(screen.getByText('English')).toBeInTheDocument()
+  })
+
+  it('lets the user pick a different shipped language', async () => {
+    const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 })
+    render(<PreferencesPanel />)
+
+    await user.click(screen.getByTestId('preferences-language-select'))
+    await user.click(await screen.findByText('Deutsch'))
+
+    expect(setLanguage).toHaveBeenCalledWith('de')
+  })
+})

--- a/ui/leafwiki-ui/src/features/settings/account/PreferencesPanel.tsx
+++ b/ui/leafwiki-ui/src/features/settings/account/PreferencesPanel.tsx
@@ -1,4 +1,12 @@
 import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { getAvailableLanguages } from '@/lib/i18n'
 import { useUserSettingsStore } from '@/stores/userSettings'
 import { useTranslation } from 'react-i18next'
 
@@ -6,22 +14,49 @@ export function PreferencesPanel() {
   const { t } = useTranslation('settings')
   const autoSave = useUserSettingsStore((s) => s.autoSave)
   const toggleAutoSave = useUserSettingsStore((s) => s.toggleAutoSave)
+  const language = useUserSettingsStore((s) => s.language)
+  const setLanguage = useUserSettingsStore((s) => s.setLanguage)
 
   return (
-    <div className="settings__field" data-testid="preferences-panel">
-      <label className="settings__checkbox-label">
-        <Checkbox
-          data-testid="preferences-autosave-checkbox"
-          checked={autoSave}
-          onCheckedChange={(checked) => {
-            if (!!checked !== autoSave) toggleAutoSave()
+    <div data-testid="preferences-panel">
+      <div className="settings__field">
+        <label className="settings__checkbox-label">
+          <Checkbox
+            data-testid="preferences-autosave-checkbox"
+            checked={autoSave}
+            onCheckedChange={(checked) => {
+              if (!!checked !== autoSave) toggleAutoSave()
+            }}
+          />
+          {t('account.preferences.autoSaveLabel')}
+        </label>
+        <p className="settings__section-description">
+          {t('account.preferences.autoSaveDescription')}
+        </p>
+      </div>
+
+      <div className="settings__field">
+        <label className="settings__field-label">
+          {t('account.preferences.languageLabel')}
+        </label>
+        <Select
+          value={language}
+          onValueChange={(value) => {
+            void setLanguage(value)
           }}
-        />
-        {t('account.preferences.autoSaveLabel')}
-      </label>
-      <p className="settings__section-description">
-        {t('account.preferences.autoSaveDescription')}
-      </p>
+        >
+          <SelectTrigger data-testid="preferences-language-select">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {getAvailableLanguages().map((lang) => (
+              <SelectItem key={lang.code} value={lang.code}>
+                {lang.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
     </div>
   )
 }

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -2916,6 +2916,10 @@
     @apply flex items-center gap-2;
   }
 
+  .settings__field-label {
+    @apply text-interface-text mb-2 block text-sm font-medium;
+  }
+
   .settings__preview {
     @apply bg-surface-alt mb-4 flex items-center gap-3 rounded-md p-4;
   }

--- a/ui/leafwiki-ui/src/lib/api/userSettings.ts
+++ b/ui/leafwiki-ui/src/lib/api/userSettings.ts
@@ -8,6 +8,7 @@ export type UserSettings = {
 }
 
 export type UserSettingsPatch = {
+  language?: string
   autoSave?: boolean
 }
 

--- a/ui/leafwiki-ui/src/locales/de/settings.json
+++ b/ui/leafwiki-ui/src/locales/de/settings.json
@@ -15,7 +15,9 @@
       "sectionDescription": "Bearbeitungseinstellungen, geräteübergreifend synchronisiert.",
       "autoSaveLabel": "Automatisches Speichern aktivieren",
       "autoSaveDescription": "Änderungen beim Bearbeiten einer Seite automatisch speichern.",
-      "autoSaveToggleError": "Einstellung für automatisches Speichern konnte nicht aktualisiert werden"
+      "autoSaveToggleError": "Einstellung für automatisches Speichern konnte nicht aktualisiert werden",
+      "languageLabel": "Sprache",
+      "languageChangeError": "Spracheinstellung konnte nicht aktualisiert werden"
     }
   }
 }

--- a/ui/leafwiki-ui/src/locales/en/settings.json
+++ b/ui/leafwiki-ui/src/locales/en/settings.json
@@ -15,7 +15,9 @@
       "sectionDescription": "Editing preferences, synced across your devices.",
       "autoSaveLabel": "Enable auto-save",
       "autoSaveDescription": "Automatically save your changes while editing a page.",
-      "autoSaveToggleError": "Could not update auto-save setting"
+      "autoSaveToggleError": "Could not update auto-save setting",
+      "languageLabel": "Language",
+      "languageChangeError": "Could not update language setting"
     }
   }
 }

--- a/ui/leafwiki-ui/src/stores/userSettings.test.ts
+++ b/ui/leafwiki-ui/src/stores/userSettings.test.ts
@@ -1,0 +1,110 @@
+import type { UserSettings } from '@/lib/api/userSettings'
+import i18next from '@/lib/i18n'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from 'vitest'
+
+vi.mock('@/lib/api/userSettings', () => ({
+  getUserSettings: vi.fn(),
+  updateUserSettings: vi.fn(),
+}))
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+import * as userSettingsApi from '@/lib/api/userSettings'
+import { toast } from 'sonner'
+import { useUserSettingsStore } from './userSettings'
+
+function makeSettings(overrides: Partial<UserSettings> = {}): UserSettings {
+  return {
+    userId: 'user-1',
+    language: 'en',
+    autoSave: true,
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('useUserSettingsStore', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    useUserSettingsStore.setState({
+      autoSave: true,
+      language: 'en',
+      loaded: false,
+    })
+  })
+
+  afterEach(async () => {
+    await i18next.changeLanguage('en')
+  })
+
+  it('loadUserSettings applies the fetched language via i18next', async () => {
+    ;(userSettingsApi.getUserSettings as Mock).mockResolvedValue(
+      makeSettings({ language: 'de' }),
+    )
+
+    await useUserSettingsStore.getState().loadUserSettings()
+
+    expect(useUserSettingsStore.getState().language).toBe('de')
+    expect(useUserSettingsStore.getState().loaded).toBe(true)
+    expect(i18next.language).toBe('de')
+  })
+
+  it('loadUserSettings ignores an unshipped language code', async () => {
+    ;(userSettingsApi.getUserSettings as Mock).mockResolvedValue(
+      makeSettings({ language: 'xx-not-a-real-language' }),
+    )
+
+    await useUserSettingsStore.getState().loadUserSettings()
+
+    expect(i18next.language).toBe('en')
+  })
+
+  it('setLanguage optimistically switches the language before the API resolves', async () => {
+    let resolveUpdate: (settings: UserSettings) => void = () => {}
+    ;(userSettingsApi.updateUserSettings as Mock).mockReturnValue(
+      new Promise((resolve) => {
+        resolveUpdate = resolve
+      }),
+    )
+
+    const promise = useUserSettingsStore.getState().setLanguage('de')
+    expect(useUserSettingsStore.getState().language).toBe('de')
+    expect(i18next.language).toBe('de')
+
+    resolveUpdate(makeSettings({ language: 'de' }))
+    await promise
+    expect(userSettingsApi.updateUserSettings).toHaveBeenCalledWith({
+      language: 'de',
+    })
+  })
+
+  it('setLanguage rolls back the language and toasts on a failed update', async () => {
+    ;(userSettingsApi.updateUserSettings as Mock).mockRejectedValue(
+      new Error('boom'),
+    )
+
+    await useUserSettingsStore.getState().setLanguage('de')
+
+    expect(useUserSettingsStore.getState().language).toBe('en')
+    expect(i18next.language).toBe('en')
+    expect(toast.error).toHaveBeenCalled()
+  })
+
+  it('clearUserSettings resets language back to the default', () => {
+    useUserSettingsStore.setState({ language: 'de', loaded: true })
+
+    useUserSettingsStore.getState().clearUserSettings()
+
+    expect(useUserSettingsStore.getState().language).toBe('en')
+    expect(useUserSettingsStore.getState().loaded).toBe(false)
+  })
+})

--- a/ui/leafwiki-ui/src/stores/userSettings.ts
+++ b/ui/leafwiki-ui/src/stores/userSettings.ts
@@ -1,34 +1,53 @@
 // stores/userSettings.ts
-// A logged-in user's private preferences (currently just autoSave; language
-// is stored by the backend but not yet surfaced in the frontend). Per-user
+// A logged-in user's private preferences (autoSave, language). Per-user
 // server truth fetched once via GET /api/user-settings and never persisted
 // to localStorage — mirrors stores/favorites.ts. App.tsx owns calling
 // loadUserSettings()/clearUserSettings() as the session's logged-in state
 // changes.
+//
+// The user's saved language is applied on top of the site-wide
+// defaultLanguage (stores/config.ts) once user settings load, so it wins
+// over the instance default for that user's session.
 
 import { mapApiError } from '@/lib/api/errors'
 import { getUserSettings, updateUserSettings } from '@/lib/api/userSettings'
-import i18next from '@/lib/i18n'
+import i18next, { getAvailableLanguages } from '@/lib/i18n'
 import { create } from 'zustand'
 import { toast } from 'sonner'
 
 const t = (key: string) => i18next.t(key, { ns: 'settings' })
 
+const DEFAULT_LANGUAGE = 'en'
+
+function applyLanguageIfShipped(lang: string): void {
+  if (getAvailableLanguages().some((language) => language.code === lang)) {
+    void i18next.changeLanguage(lang)
+  }
+}
+
 type UserSettingsStore = {
   autoSave: boolean
+  language: string
   loaded: boolean
   loadUserSettings: () => Promise<void>
   toggleAutoSave: () => Promise<void>
+  setLanguage: (language: string) => Promise<void>
   clearUserSettings: () => void
 }
 
 export const useUserSettingsStore = create<UserSettingsStore>()((set, get) => ({
   autoSave: true,
+  language: DEFAULT_LANGUAGE,
   loaded: false,
   loadUserSettings: async () => {
     try {
       const settings = await getUserSettings()
-      set({ autoSave: settings.autoSave, loaded: true })
+      set({
+        autoSave: settings.autoSave,
+        language: settings.language,
+        loaded: true,
+      })
+      applyLanguageIfShipped(settings.language)
     } catch (err) {
       console.warn('Failed to load user settings:', err)
     }
@@ -46,5 +65,21 @@ export const useUserSettingsStore = create<UserSettingsStore>()((set, get) => ({
       )
     }
   },
-  clearUserSettings: () => set({ autoSave: true, loaded: false }),
+  setLanguage: async (language) => {
+    const previous = get().language
+    if (language === previous) return
+    set({ language })
+    applyLanguageIfShipped(language)
+    try {
+      await updateUserSettings({ language })
+    } catch (err) {
+      set({ language: previous })
+      applyLanguageIfShipped(previous)
+      toast.error(
+        mapApiError(err, t('account.preferences.languageChangeError')).message,
+      )
+    }
+  },
+  clearUserSettings: () =>
+    set({ autoSave: true, language: DEFAULT_LANGUAGE, loaded: false }),
 }))


### PR DESCRIPTION
## Summary
- Surfaces the per-user `language` preference (already stored by the UserSettings backend since #1454) in Account Settings via a new language `Select`, wired through `stores/userSettings.ts` with the same optimistic-update/rollback pattern as the existing `autoSave` toggle.
- Extends the backend's language allow-list (`internal/usersettings/language.go`) to include `"de"` — it only accepted `"en"` despite German shipping since #1457, which would have made picking German in the new UI fail with a validation error.
- The user's saved language is applied on top of the site-wide `defaultLanguage` once user settings load, so it wins for that user's session.
- Scope note: no language switcher for anonymous/public-access viewers — they have no account to persist a preference against, and the existing instance-wide `defaultLanguage` config already covers that case.

## Test plan
- [x] `go test ./internal/usersettings/... ./internal/wiki/usersettings/...`
- [x] `go build ./...` / `go vet ./...`
- [x] `tsc --noEmit`
- [x] New/changed frontend tests (`stores/userSettings.test.ts`, `features/settings/account/PreferencesPanel.test.tsx`) pass, including a real Select-open interaction
- [x] Full `npm run test` suite green when run without file-parallelism (447/449); the 2 failures were in `ApiKeyFormDialog.test.tsx` (untouched by this change) and passed cleanly when run in isolation — timing timeouts under the sandbox's parallel load, not a regression from this change (not independently verified against a clean checkout)
- [x] Manual browser check: switch language in Account Settings, confirm immediate UI switch + persistence across reload
