### PR TITLE
Remove Unecessary Table Whitespace

### DIFF
--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -2302,7 +2302,7 @@
   }
 
   .table-wrapper table {
-    @apply w-full border-collapse;
+    @apply w-fit max-w-full border-collapse;
   }
 
   .table-wrapper tbody tr:nth-child(odd) {


### PR DESCRIPTION
## Related issue

Fixes #1462

## What changed

Table layout altered to remove unnecessary whitespace, so the content naturally anchors to page left.  See example:

<img width="1021" height="250" alt="image" src="https://github.com/user-attachments/assets/a7ced910-11ee-4b15-9a9f-d256ee7b8916" />


## Checklist

- [x] I discussed the approach on the linked issue before starting (or this is a trivial fix: typo, docs, obvious one-liner)
- [x] This PR is focused on a single change
- [x] I ran `npm run format` in `ui/leafwiki-ui` (and in `e2e` if e2e tests changed)
- [ ] I updated documentation if needed
