### PR TITLE
fix(refactor): rewrite links when moving pages via tree drag-and-drop

### DIFF
--- a/internal/wiki/pages/pages_test.go
+++ b/internal/wiki/pages/pages_test.go
@@ -3274,6 +3274,64 @@ func TestApplyPageRefactorUseCase_Move_RewritesLinksInSubPages(t *testing.T) {
 	}
 }
 
+func TestApplyPageRefactorUseCase_Move_HonorsRequestedPosition(t *testing.T) {
+	deps := newTestDeps(t)
+	createUC := pages.NewCreatePageUseCase(deps.tree, deps.slug, deps.orchestrator(), slog.Default(), nil)
+	applyUC := pages.NewApplyPageRefactorUseCase(deps.tree, deps.slug, deps.revision, deps.links, slog.Default(), nil)
+
+	// Structure:
+	//   /target        (destination parent, already has two children)
+	//   /target/alpha
+	//   /target/beta
+	//   /moved         (page to be dropped between alpha and beta)
+	target, _ := createUC.Execute(context.Background(), pages.CreatePageInput{
+		UserID: "system", Title: "Target", Slug: "target", Kind: pageKind(),
+	})
+	_, _ = createUC.Execute(context.Background(), pages.CreatePageInput{
+		UserID: "system", ParentID: &target.Page.ID, Title: "Alpha", Slug: "alpha", Kind: pageKind(),
+	})
+	_, _ = createUC.Execute(context.Background(), pages.CreatePageInput{
+		UserID: "system", ParentID: &target.Page.ID, Title: "Beta", Slug: "beta", Kind: pageKind(),
+	})
+	moved, _ := createUC.Execute(context.Background(), pages.CreatePageInput{
+		UserID: "system", Title: "Moved", Slug: "moved", Kind: pageKind(),
+	})
+
+	// Drop /moved at index 1, i.e. between alpha (0) and beta (1).
+	position := 1
+	_, err := applyUC.Execute(context.Background(), pages.RefactorApplyInput{
+		UserID:  "system",
+		Version: moved.Page.Version(),
+		RefactorPreviewInput: pages.RefactorPreviewInput{
+			PageID:      moved.Page.ID,
+			Kind:        pages.RefactorKindMove,
+			NewParentID: &target.Page.ID,
+		},
+		Position: &position,
+	})
+	if err != nil {
+		t.Fatalf("ApplyPageRefactor(move with position) failed: %v", err)
+	}
+
+	targetNode, err := deps.tree.FindPageByID(target.Page.ID)
+	if err != nil {
+		t.Fatalf("FindPageByID(target) failed: %v", err)
+	}
+	var order []string
+	for _, child := range targetNode.Children {
+		order = append(order, child.Slug)
+	}
+	want := []string{"alpha", "moved", "beta"}
+	if len(order) != len(want) {
+		t.Fatalf("children order = %v, want %v", order, want)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("children order = %v, want %v", order, want)
+		}
+	}
+}
+
 func TestUpdatePageUseCase_EmitsSuccessMetrics(t *testing.T) {
 	deps := newTestDeps(t)
 	metrics := httpmetrics.NewHTTPMetrics("test")

--- a/internal/wiki/pages/refactor.go
+++ b/internal/wiki/pages/refactor.go
@@ -63,6 +63,8 @@ type RefactorApplyInput struct {
 	Version string
 	RefactorPreviewInput
 	RewriteLinks bool
+	// Position is the target sibling index for RefactorKindMove; nil appends at the end.
+	Position *int
 }
 
 // PreviewPageRefactorUseCase computes what would change if a refactor is applied.
@@ -400,7 +402,7 @@ func (uc *ApplyPageRefactorUseCase) Execute(ctx context.Context, in RefactorAppl
 		}
 		moveStepStarted := time.Now()
 		moveUC := NewMovePageUseCase(uc.tree, o, uc.log, uc.metrics)
-		err := moveUC.Execute(ctx, MovePageInput{UserID: in.UserID, ID: in.PageID, Version: in.Version, ParentID: parentID})
+		err := moveUC.Execute(ctx, MovePageInput{UserID: in.UserID, ID: in.PageID, Version: in.Version, ParentID: parentID, Position: in.Position})
 		uc.metrics.ObserveRefactorStep(in.Kind, "move_target_page", moveStepStarted)
 		if err != nil {
 			return nil, err

--- a/internal/wiki/pages/routes.go
+++ b/internal/wiki/pages/routes.go
@@ -564,6 +564,7 @@ func (r *Routes) handleRefactorApply(c *gin.Context) {
 		Content      *string `json:"content"`
 		NewParentID  *string `json:"parentId"`
 		RewriteLinks bool    `json:"rewriteLinks"`
+		Position     *int    `json:"position"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		respondWithPageStatusError(c, http.StatusBadRequest, ErrCodePageInvalidRequest, errInvalidRequestUserMsg, errInvalidRequestLogMsg)
@@ -581,6 +582,7 @@ func (r *Routes) handleRefactorApply(c *gin.Context) {
 			Content: req.Content, NewParentID: req.NewParentID,
 		},
 		RewriteLinks: req.RewriteLinks,
+		Position:     req.Position,
 	})
 	if err != nil {
 		respondWithPageError(c, err)

--- a/ui/leafwiki-ui/src/features/page/MovePageDialog.test.tsx
+++ b/ui/leafwiki-ui/src/features/page/MovePageDialog.test.tsx
@@ -83,7 +83,15 @@ const preview: PageRefactorPreview = {
   pageId: 'page-1',
   oldPath: 'section-a/child',
   newPath: 'section-b/child',
-  affectedPages: [],
+  affectedPages: [
+    {
+      fromPageId: 'linker-1',
+      fromTitle: 'Linker',
+      fromPath: 'linker',
+      matchedPaths: ['/section-a/child'],
+      warnings: [],
+    },
+  ],
   counts: { affectedPages: 1, matchedLinks: 1 },
   warnings: [],
 }

--- a/ui/leafwiki-ui/src/features/page/MovePageDialog.test.tsx
+++ b/ui/leafwiki-ui/src/features/page/MovePageDialog.test.tsx
@@ -1,0 +1,153 @@
+import { DIALOG_MOVE_PAGE } from '@/lib/registries'
+import { useConfigStore } from '@/stores/config'
+import { useDialogsStore } from '@/stores/dialogs'
+import { useTreeStore } from '@/stores/tree'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PageNode, PageRefactorPreview } from '@/lib/api/pages'
+import {
+  applyPageRefactor,
+  movePage,
+  previewPageRefactor,
+} from '@/lib/api/pages'
+import { MovePageDialog } from './MovePageDialog'
+import { confirmPageRefactor } from './pageRefactorDialogState'
+import { refreshAfterPageRefactor } from './pageMutationRefresh'
+
+vi.mock('@/lib/api/pages', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/lib/api/pages')>('@/lib/api/pages')
+  return {
+    ...actual,
+    movePage: vi.fn(),
+    previewPageRefactor: vi.fn(),
+    applyPageRefactor: vi.fn(),
+  }
+})
+
+vi.mock('./pageRefactorDialogState', () => ({
+  confirmPageRefactor: vi.fn(),
+}))
+
+vi.mock('./pageMutationRefresh', () => ({
+  refreshAfterPageRefactor: vi.fn().mockResolvedValue(undefined),
+}))
+
+Element.prototype.scrollIntoView = () => {}
+
+const child: PageNode = {
+  id: 'page-1',
+  title: 'Child',
+  slug: 'child',
+  path: 'section-a/child',
+  version: 'v1',
+  parentId: 'section-a',
+  children: null,
+  kind: 'page',
+}
+const sectionA: PageNode = {
+  id: 'section-a',
+  title: 'Section A',
+  slug: 'section-a',
+  path: 'section-a',
+  version: 'va',
+  parentId: null,
+  children: [child],
+  kind: 'section',
+}
+const sectionB: PageNode = {
+  id: 'section-b',
+  title: 'Section B',
+  slug: 'section-b',
+  path: 'section-b',
+  version: 'vb',
+  parentId: null,
+  children: [],
+  kind: 'section',
+}
+const root: PageNode = {
+  id: 'root',
+  title: 'Root',
+  slug: '',
+  path: '',
+  version: 'vr',
+  parentId: null,
+  children: [sectionA, sectionB],
+  kind: 'section',
+}
+
+const preview: PageRefactorPreview = {
+  kind: 'move',
+  pageId: 'page-1',
+  oldPath: 'section-a/child',
+  newPath: 'section-b/child',
+  affectedPages: [],
+  counts: { affectedPages: 1, matchedLinks: 1 },
+  warnings: [],
+}
+
+describe('MovePageDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useDialogsStore.setState({
+      dialogType: DIALOG_MOVE_PAGE,
+      dialogProps: null,
+    })
+    useTreeStore.setState({
+      tree: root,
+      byId: {
+        'page-1': child,
+        'section-a': sectionA,
+        'section-b': sectionB,
+        root,
+      },
+    })
+  })
+
+  it('allows skipping the link rewrite when confirming a move', async () => {
+    useConfigStore.setState({ enableLinkRefactor: true })
+    vi.mocked(previewPageRefactor).mockResolvedValue(preview)
+    vi.mocked(confirmPageRefactor).mockResolvedValue(false)
+    vi.mocked(applyPageRefactor).mockResolvedValue(null)
+
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter>
+        <MovePageDialog pageId="page-1" />
+      </MemoryRouter>,
+    )
+
+    await user.click(screen.getByText('Section B'))
+    await user.click(screen.getByTestId('move-page-dialog-button-confirm'))
+
+    expect(confirmPageRefactor).toHaveBeenCalledWith(preview, {
+      allowSkipRewrite: true,
+    })
+    expect(applyPageRefactor).toHaveBeenCalledWith(
+      'page-1',
+      expect.objectContaining({ rewriteLinks: false }),
+    )
+    expect(refreshAfterPageRefactor).toHaveBeenCalled()
+  })
+
+  it('falls back to a plain move without the refactor pipeline when link refactor is disabled', async () => {
+    useConfigStore.setState({ enableLinkRefactor: false })
+    vi.mocked(movePage).mockResolvedValue(null)
+
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter>
+        <MovePageDialog pageId="page-1" />
+      </MemoryRouter>,
+    )
+
+    await user.click(screen.getByText('Section B'))
+    await user.click(screen.getByTestId('move-page-dialog-button-confirm'))
+
+    expect(movePage).toHaveBeenCalledWith('page-1', 'v1', 'section-b')
+    expect(previewPageRefactor).not.toHaveBeenCalled()
+    expect(confirmPageRefactor).not.toHaveBeenCalled()
+  })
+})

--- a/ui/leafwiki-ui/src/features/page/MovePageDialog.tsx
+++ b/ui/leafwiki-ui/src/features/page/MovePageDialog.tsx
@@ -93,7 +93,9 @@ export function MovePageDialog({ pageId }: { pageId: string }) {
           kind: 'move',
           parentId: newParentId,
         })
-        const rewriteLinks = await confirmPageRefactor(preview)
+        const rewriteLinks = await confirmPageRefactor(preview, {
+          allowSkipRewrite: true,
+        })
         if (rewriteLinks === null) {
           return false
         }

--- a/ui/leafwiki-ui/src/features/page/pageMutationRefresh.ts
+++ b/ui/leafwiki-ui/src/features/page/pageMutationRefresh.ts
@@ -11,6 +11,10 @@ type RefreshAfterPageRefactorOptions = {
   preview: PageRefactorPreview
   currentPath: string
   navigate: NavigateFunction
+  // Tree reload variant to use (see useTreeStore.reloadTree). Callers that
+  // already show their own optimistic/loading state (e.g. tree drag-and-drop)
+  // pass true to avoid a second, non-silent tree reload flashing a spinner.
+  silentReload?: boolean
 }
 
 function normalizeRoutePath(path: string) {
@@ -47,8 +51,9 @@ export async function refreshAfterPageRefactor({
   preview,
   currentPath,
   navigate,
+  silentReload = false,
 }: RefreshAfterPageRefactorOptions) {
-  await useTreeStore.getState().reloadTree()
+  await useTreeStore.getState().reloadTree({ silent: silentReload })
 
   const currentViewerPage = useViewerStore.getState().page
   const normalizedViewerPath = normalizeWikiRoutePath(

--- a/ui/leafwiki-ui/src/features/tree/TreeDnd.tsx
+++ b/ui/leafwiki-ui/src/features/tree/TreeDnd.tsx
@@ -1,11 +1,11 @@
 import {
   convertPage,
-  movePage,
   NODE_KIND_PAGE,
   NODE_KIND_SECTION,
   PageNode,
   sortPages,
 } from '@/lib/api/pages'
+import { refreshAfterPageRefactor } from '@/features/page/pageMutationRefresh'
 import { useTreeStore } from '@/stores/tree'
 import {
   DndContext,
@@ -24,8 +24,10 @@ import { getEventCoordinates } from '@dnd-kit/utilities'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
+import { useLocation, useNavigate } from 'react-router'
 import { toast } from 'sonner'
 import i18next from '@/lib/i18n'
+import { performTreeCrossParentMove } from './treeDndMove'
 import { useTreeDndStore } from './treeDndStore'
 import {
   buildOrderedIds,
@@ -151,6 +153,8 @@ export function TreeDndProvider({
   children: React.ReactNode
 }) {
   const { t } = useTranslation('viewer')
+  const currentPath = useLocation().pathname
+  const navigate = useNavigate()
   const [activeNode, setActiveNode] = useState<PageNode | null>(null)
   const [saving, setSaving] = useState(false)
   const subtreeIdsRef = useRef<Set<string>>(new Set())
@@ -293,13 +297,21 @@ export function TreeDndProvider({
     }
     setSaving(true)
     try {
-      await movePage(
-        dragged.id,
-        dragged.version,
-        resolution.parentId,
-        resolution.index,
-      )
-      await reloadTree({ silent: true })
+      const result = await performTreeCrossParentMove(dragged, resolution)
+      if (result.status === 'aborted') {
+        await reloadTree({ silent: true })
+        return
+      }
+      if (result.preview) {
+        await refreshAfterPageRefactor({
+          preview: result.preview,
+          currentPath,
+          navigate,
+          silentReload: true,
+        })
+      } else {
+        await reloadTree({ silent: true })
+      }
       if (currentParentId !== ROOT_ID) {
         offerConvertBackToPage(currentParentId)
       }

--- a/ui/leafwiki-ui/src/features/tree/treeDndMove.test.ts
+++ b/ui/leafwiki-ui/src/features/tree/treeDndMove.test.ts
@@ -31,9 +31,22 @@ const preview: PageRefactorPreview = {
   pageId: 'page-1',
   oldPath: 'section-a/page-1',
   newPath: 'section-b/page-1',
-  affectedPages: [],
+  affectedPages: [
+    {
+      fromPageId: 'linker-1',
+      fromTitle: 'Linker',
+      fromPath: 'linker',
+      matchedPaths: ['/section-a/page-1'],
+      warnings: [],
+    },
+  ],
   counts: { affectedPages: 1, matchedLinks: 1 },
   warnings: [],
+}
+const noAffectedPreview: PageRefactorPreview = {
+  ...preview,
+  affectedPages: [],
+  counts: { affectedPages: 0, matchedLinks: 0 },
 }
 
 describe('performTreeCrossParentMove', () => {
@@ -57,7 +70,7 @@ describe('performTreeCrossParentMove', () => {
 
   it('applies with rewriteLinks:false when nothing is affected (no dialog shown)', async () => {
     useConfigStore.setState({ enableLinkRefactor: true })
-    vi.mocked(previewPageRefactor).mockResolvedValue(preview)
+    vi.mocked(previewPageRefactor).mockResolvedValue(noAffectedPreview)
     vi.mocked(confirmPageRefactor).mockResolvedValue(false)
     vi.mocked(applyPageRefactor).mockResolvedValue(null)
 
@@ -70,7 +83,7 @@ describe('performTreeCrossParentMove', () => {
       kind: 'move',
       parentId: 'section-b',
     })
-    expect(confirmPageRefactor).toHaveBeenCalledWith(preview, {
+    expect(confirmPageRefactor).toHaveBeenCalledWith(noAffectedPreview, {
       allowSkipRewrite: true,
     })
     expect(applyPageRefactor).toHaveBeenCalledWith('page-1', {
@@ -81,7 +94,7 @@ describe('performTreeCrossParentMove', () => {
       rewriteLinks: false,
     })
     expect(movePage).not.toHaveBeenCalled()
-    expect(result).toEqual({ status: 'moved', preview })
+    expect(result).toEqual({ status: 'moved', preview: noAffectedPreview })
   })
 
   it('applies with rewriteLinks:true when the user confirms the rewrite', async () => {

--- a/ui/leafwiki-ui/src/features/tree/treeDndMove.test.ts
+++ b/ui/leafwiki-ui/src/features/tree/treeDndMove.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  applyPageRefactor,
+  movePage,
+  previewPageRefactor,
+} from '@/lib/api/pages'
+import type { PageRefactorPreview } from '@/lib/api/pages'
+import { confirmPageRefactor } from '@/features/page/pageRefactorDialogState'
+import { useConfigStore } from '@/stores/config'
+import { performTreeCrossParentMove } from './treeDndMove'
+import { ROOT_ID } from './treeDndUtils'
+
+vi.mock('@/lib/api/pages', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/lib/api/pages')>('@/lib/api/pages')
+  return {
+    ...actual,
+    movePage: vi.fn(),
+    previewPageRefactor: vi.fn(),
+    applyPageRefactor: vi.fn(),
+  }
+})
+
+vi.mock('@/features/page/pageRefactorDialogState', () => ({
+  confirmPageRefactor: vi.fn(),
+}))
+
+const dragged = { id: 'page-1', version: 'v1' }
+const preview: PageRefactorPreview = {
+  kind: 'move',
+  pageId: 'page-1',
+  oldPath: 'section-a/page-1',
+  newPath: 'section-b/page-1',
+  affectedPages: [],
+  counts: { affectedPages: 1, matchedLinks: 1 },
+  warnings: [],
+}
+
+describe('performTreeCrossParentMove', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls plain movePage when link refactor is disabled', async () => {
+    useConfigStore.setState({ enableLinkRefactor: false })
+    vi.mocked(movePage).mockResolvedValue(null)
+
+    const result = await performTreeCrossParentMove(dragged, {
+      parentId: 'section-b',
+      index: 2,
+    })
+
+    expect(movePage).toHaveBeenCalledWith('page-1', 'v1', 'section-b', 2)
+    expect(previewPageRefactor).not.toHaveBeenCalled()
+    expect(result).toEqual({ status: 'moved', preview: null })
+  })
+
+  it('applies with rewriteLinks:false when nothing is affected (no dialog shown)', async () => {
+    useConfigStore.setState({ enableLinkRefactor: true })
+    vi.mocked(previewPageRefactor).mockResolvedValue(preview)
+    vi.mocked(confirmPageRefactor).mockResolvedValue(false)
+    vi.mocked(applyPageRefactor).mockResolvedValue(null)
+
+    const result = await performTreeCrossParentMove(dragged, {
+      parentId: 'section-b',
+      index: 2,
+    })
+
+    expect(previewPageRefactor).toHaveBeenCalledWith('page-1', {
+      kind: 'move',
+      parentId: 'section-b',
+    })
+    expect(confirmPageRefactor).toHaveBeenCalledWith(preview, {
+      allowSkipRewrite: true,
+    })
+    expect(applyPageRefactor).toHaveBeenCalledWith('page-1', {
+      kind: 'move',
+      version: 'v1',
+      parentId: 'section-b',
+      position: 2,
+      rewriteLinks: false,
+    })
+    expect(movePage).not.toHaveBeenCalled()
+    expect(result).toEqual({ status: 'moved', preview })
+  })
+
+  it('applies with rewriteLinks:true when the user confirms the rewrite', async () => {
+    useConfigStore.setState({ enableLinkRefactor: true })
+    vi.mocked(previewPageRefactor).mockResolvedValue(preview)
+    vi.mocked(confirmPageRefactor).mockResolvedValue(true)
+    vi.mocked(applyPageRefactor).mockResolvedValue(null)
+
+    const result = await performTreeCrossParentMove(dragged, {
+      parentId: 'section-b',
+      index: 2,
+    })
+
+    expect(applyPageRefactor).toHaveBeenCalledWith(
+      'page-1',
+      expect.objectContaining({ rewriteLinks: true }),
+    )
+    expect(result).toEqual({ status: 'moved', preview })
+  })
+
+  it('aborts without calling apply or movePage when the user cancels', async () => {
+    useConfigStore.setState({ enableLinkRefactor: true })
+    vi.mocked(previewPageRefactor).mockResolvedValue(preview)
+    vi.mocked(confirmPageRefactor).mockResolvedValue(null)
+
+    const result = await performTreeCrossParentMove(dragged, {
+      parentId: 'section-b',
+      index: 2,
+    })
+
+    expect(applyPageRefactor).not.toHaveBeenCalled()
+    expect(movePage).not.toHaveBeenCalled()
+    expect(result).toEqual({ status: 'aborted' })
+  })
+
+  it('normalizes the root sentinel to null for the refactor endpoints', async () => {
+    useConfigStore.setState({ enableLinkRefactor: true })
+    vi.mocked(previewPageRefactor).mockResolvedValue(preview)
+    vi.mocked(confirmPageRefactor).mockResolvedValue(false)
+    vi.mocked(applyPageRefactor).mockResolvedValue(null)
+
+    await performTreeCrossParentMove(dragged, { parentId: ROOT_ID, index: 0 })
+
+    expect(previewPageRefactor).toHaveBeenCalledWith('page-1', {
+      kind: 'move',
+      parentId: null,
+    })
+    expect(applyPageRefactor).toHaveBeenCalledWith(
+      'page-1',
+      expect.objectContaining({ parentId: null }),
+    )
+  })
+})

--- a/ui/leafwiki-ui/src/features/tree/treeDndMove.ts
+++ b/ui/leafwiki-ui/src/features/tree/treeDndMove.ts
@@ -1,0 +1,57 @@
+import {
+  applyPageRefactor,
+  movePage,
+  PageRefactorPreview,
+  previewPageRefactor,
+} from '@/lib/api/pages'
+import { confirmPageRefactor } from '@/features/page/pageRefactorDialogState'
+import { useConfigStore } from '@/stores/config'
+import { DropResolution, ROOT_ID } from './treeDndUtils'
+
+export type TreeCrossParentMoveResult =
+  | { status: 'moved'; preview: PageRefactorPreview | null }
+  | { status: 'aborted' }
+
+// Cross-parent tree drag-and-drop moves. When link refactor is disabled this
+// is a plain reparent (today's behavior, unchanged). When enabled, it routes
+// through the same preview/confirm/apply pipeline the manual Move dialog
+// uses, so pages that reference the dragged page get their links rewritten
+// too - drag-and-drop otherwise skipped that pipeline entirely and only
+// marked those links "broken" in the index.
+export async function performTreeCrossParentMove(
+  dragged: { id: string; version: string },
+  resolution: DropResolution,
+): Promise<TreeCrossParentMoveResult> {
+  if (!useConfigStore.getState().enableLinkRefactor) {
+    await movePage(
+      dragged.id,
+      dragged.version,
+      resolution.parentId,
+      resolution.index,
+    )
+    return { status: 'moved', preview: null }
+  }
+
+  const parentId = resolution.parentId === ROOT_ID ? null : resolution.parentId
+
+  const preview = await previewPageRefactor(dragged.id, {
+    kind: 'move',
+    parentId,
+  })
+  const rewriteLinks = await confirmPageRefactor(preview, {
+    allowSkipRewrite: true,
+  })
+  if (rewriteLinks === null) {
+    return { status: 'aborted' }
+  }
+
+  await applyPageRefactor(dragged.id, {
+    kind: 'move',
+    version: dragged.version,
+    parentId,
+    position: resolution.index,
+    rewriteLinks,
+  })
+
+  return { status: 'moved', preview }
+}

--- a/ui/leafwiki-ui/src/lib/api/pages.ts
+++ b/ui/leafwiki-ui/src/lib/api/pages.ts
@@ -233,6 +233,7 @@ export async function applyPageRefactor(
         version: string
         parentId: string | null
         rewriteLinks: boolean
+        position?: number
       },
 ): Promise<Page | null> {
   return (await fetchWithAuth(`/api/pages/${id}/refactor/apply`, {


### PR DESCRIPTION
## Summary
- Tree drag-and-drop (`PUT /pages/:id/move`) only marked other pages' links to the moved page as broken instead of rewriting them - unlike the manual Move dialog, which already used the link-refactor pipeline (`previewPageRefactor` → confirm → `applyPageRefactor`). Cross-parent drag-and-drop now routes through that same pipeline when link refactor (`enableLinkRefactor`) is enabled; behavior is unchanged when the flag is off (default).
- The new logic lives in `performTreeCrossParentMove` (`treeDndMove.ts`), extracted out of `TreeDnd.tsx` so it's unit-testable without simulating `@dnd-kit` drag gestures.
- `ApplyPageRefactorUseCase`'s move path never threaded a sibling position into the underlying move, so it always appended - not viable for drag-and-drop placement. Added an optional `Position` on `RefactorApplyInput`/`MovePageInput` (nil-safe, no behavior change for existing rename/no-position callers).
- Also fixes `MovePageDialog`'s refactor confirmation to allow "move without updating links" (`allowSkipRewrite: true`), matching the rename flows (`TreeNodeActionsMenu`, `pageEditorStore`) that already had it.

## Test plan
- [x] `go test ./internal/wiki/pages/...` - new `TestApplyPageRefactorUseCase_Move_HonorsRequestedPosition` (written first, confirmed failing pre-fix) plus full existing suite green
- [x] `go build ./...`, `go vet ./internal/wiki/pages/...`
- [x] New `treeDndMove.test.ts` (5 cases: flag off, no-op confirm, confirmed rewrite, cancel/abort, root-sentinel normalization)
- [x] New `MovePageDialog.test.tsx` (confirmed failing pre-fix, verified by temporarily reverting the one-line fix), plus flag-off fallback case
- [x] `npx vitest run src/features/tree src/features/page src/lib/api` - all 8 touched/related files green (35 tests)
- [x] `npm run lint` clean, `npm run format` applied
- [x] Manual browser smoke test with `LEAFWIKI_ENABLE_LINK_REFACTOR=true`: drag a page with incoming links into a different section, confirm the link-rewrite dialog and correct drop position