### PR TITLE
fix(tree): toggle active section titles

### DIFF
--- a/e2e/pages/TreeView.ts
+++ b/e2e/pages/TreeView.ts
@@ -1,4 +1,4 @@
-import { expect, Page } from '@playwright/test';
+import { expect, Locator, Page } from '@playwright/test';
 import AddPageDialog from './AddPageDialog';
 import MovePageDialog from './MovePageDialog';
 import SortPageDialog from './SortPageDialog';
@@ -118,7 +118,7 @@ export default class TreeView {
   }
 
   async isSidebarVisible(): Promise<boolean> {
-    return this.page.getByTestId('sidebar').isVisible();
+    return this.treeView().isVisible();
   }
 
   async getNumberOfTreeNodes() {
@@ -153,6 +153,60 @@ export default class TreeView {
       await expect.poll(() => new URL(this.page.url()).pathname).toBe(expectedPath);
     }
     await this.page.locator('article').waitFor({ state: 'visible' });
+  }
+
+  async clickNodeTitle(title: string, options?: Parameters<Locator['click']>[0]) {
+    await this.ensureSidebarVisible();
+    await this.closeBlockingOverlayIfPresent();
+    const nodeLink = await this.findPageByTitle(title);
+    await nodeLink.waitFor({ state: 'visible' });
+    await nodeLink.scrollIntoViewIfNeeded();
+    if (options?.button === 'middle' || options?.modifiers?.length) {
+      const modifiers = new Set(options.modifiers ?? []);
+      await nodeLink.dispatchEvent(options.button === 'middle' ? 'auxclick' : 'click', {
+        button: options.button === 'middle' ? 1 : 0,
+        ctrlKey: modifiers.has('Control'),
+        metaKey: modifiers.has('Meta'),
+        shiftKey: modifiers.has('Shift'),
+        altKey: modifiers.has('Alt'),
+      });
+      return;
+    }
+
+    await nodeLink.evaluate((element) => {
+      if (!(element instanceof HTMLElement)) {
+        throw new Error('Expected HTMLElement');
+      }
+
+      element.click();
+    });
+  }
+
+  async expectNodeExpanded(title: string, expanded: boolean) {
+    await this.ensureSidebarVisible();
+    const nodeRow = this.getNodeRowByTitle(title);
+    const childContainer = nodeRow.locator(
+      'xpath=following-sibling::div[contains(@class,"tree-node__children")][1]',
+    );
+
+    if (expanded) {
+      await expect(childContainer).not.toHaveClass(/tree-node__children--closed/);
+    } else {
+      await expect(childContainer).toHaveClass(/tree-node__children--closed/);
+    }
+  }
+
+  async clickNodeChevron(title: string) {
+    await this.ensureSidebarVisible();
+    const nodeRow = this.getNodeRowByTitle(title);
+    await nodeRow.waitFor({ state: 'visible' });
+    await nodeRow.locator('svg[data-testid^="tree-node-toggle-icon-"]').evaluate((element) => {
+      if (!(element instanceof SVGElement)) {
+        throw new Error('Expected SVGElement');
+      }
+
+      element.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
   }
 
   async expandNodeByTitle(title: string) {

--- a/e2e/tests/page.spec.ts
+++ b/e2e/tests/page.spec.ts
@@ -1250,6 +1250,50 @@ test.describe('Authenticated', () => {
       .toEqual(desiredOrder);
   });
 
+  test('section-title-toggles-only-on-an-active-unmodified-click', async ({ page }) => {
+    const stamp = Date.now();
+    const sectionTitle = `Section Title Toggle ${stamp}`;
+    const sectionSlug = `section-title-toggle-${stamp}`;
+
+    await createTopLevelNode(page, {
+      title: sectionTitle,
+      slug: sectionSlug,
+      kind: 'section',
+    });
+    await page.reload();
+    await createChildPagesByPath(page, {
+      parentPath: sectionSlug,
+      titles: [`Section Child ${stamp}`],
+    });
+    await page.reload();
+
+    const treeView = new TreeView(page);
+    await treeView.expectNodeExpanded(sectionTitle, false);
+
+    // Navigation to an inactive section still uses PageViewer's automatic openNode.
+    await treeView.clickNodeTitle(sectionTitle);
+    await expect(page).toHaveURL(new RegExp(`/${sectionSlug}$`));
+    await treeView.expectNodeExpanded(sectionTitle, true);
+
+    await treeView.clickNodeTitle(sectionTitle);
+    await treeView.expectNodeExpanded(sectionTitle, false);
+
+    await treeView.clickNodeChevron(sectionTitle);
+    await treeView.expectNodeExpanded(sectionTitle, true);
+    await treeView.clickNodeChevron(sectionTitle);
+    await treeView.expectNodeExpanded(sectionTitle, false);
+    await treeView.clickNodeTitle(sectionTitle);
+    await treeView.expectNodeExpanded(sectionTitle, true);
+
+    for (const modifier of ['Control', 'Meta', 'Shift', 'Alt'] as const) {
+      await treeView.clickNodeTitle(sectionTitle, { modifiers: [modifier] });
+      await treeView.expectNodeExpanded(sectionTitle, true);
+    }
+
+    await treeView.clickNodeTitle(sectionTitle, { button: 'middle' });
+    await treeView.expectNodeExpanded(sectionTitle, true);
+  });
+
   test('copy-markdown-code-block', async ({ page }) => {
     const title = `Copy Code Block ${Date.now()}`;
     const viewPage = await createPageAndOpenViewer(page, title);

--- a/ui/leafwiki-ui/src/features/tree/TreeNode.tsx
+++ b/ui/leafwiki-ui/src/features/tree/TreeNode.tsx
@@ -37,6 +37,22 @@ export const TreeNode = React.memo(function TreeNode({ node }: Props) {
   const isLoggedIn = useSessionStore((s) => s.user !== null)
   const isActive = isStoreActive
 
+  const handleLinkClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    if (
+      node.kind !== NODE_KIND_SECTION ||
+      !isActive ||
+      event.button !== 0 ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return
+    }
+
+    toggleNode(node.id)
+  }
+
   const dndEnabled = useTreeDndStore((s) => s.enabled)
   const isDragActive = useTreeDndStore((s) => s.activeId === node.id)
   const dropZone = useTreeDndStore((s) =>
@@ -73,6 +89,7 @@ export const TreeNode = React.memo(function TreeNode({ node }: Props) {
         data-testid={`tree-node-link-${node.id}`}
         aria-current={isActive ? 'page' : undefined}
         draggable={false}
+        onClick={handleLinkClick}
       >
         <span
           className={clsx('tree-node__title', {


### PR DESCRIPTION
Fixes #1437.

## Root cause

Clicking an already-active section title kept the same page.id, so the existing openNode() lifecycle did not rerun.

## Fix

- Active section title clicks now toggle tree expansion.
- Inactive section titles retain the existing #680 navigation and automatic-open behavior.
- Chevron behavior is unchanged.
- Modified and new-tab clicks do not alter tree expansion.
- No SidebarAccordionSection/Radix refactor was needed.

## Regression coverage

Added focused Chromium E2E coverage for inactive selection, active collapse/expand, manual chevron collapse/reopen, modifier clicks, and middle-click.

## Validation

- Frontend: 67 files / 466 tests passed
- Frontend lint passed
- Frontend build/typecheck passed
- Focused Chromium E2E passed
- Changed-file formatting/lint passed
- git diff --check passed
- Firefox E2E was attempted but could not be completed reliably in the local environment; Firefox is explicitly unverified locally.
- Repository-wide Prettier/E2E lint remains blocked by pre-existing CRLF/style issues.