### PR TITLE
refactor(cli): build the command line with urfave/cli v3

### DIFF
--- a/cmd/leafwiki/cli.go
+++ b/cmd/leafwiki/cli.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/perber/wiki/internal/core/auth"
+)
+
+const (
+	catServer    = "Server"
+	catLogging   = "Logging"
+	catAuth      = "Authentication"
+	catAdmin     = "Admin bootstrap"
+	catProxyAuth = "Reverse-proxy authentication"
+	catURLs      = "External URLs"
+	catFrontend  = "Frontend"
+	catFeatures  = "Features"
+	catRevisions = "Revisions"
+	catMetrics   = "Metrics"
+	catGitBackup = "Git backup"
+	catSnapshots = "Snapshots & restore"
+	catEmail     = "Email (SMTP)"
+)
+
+const rootUsageText = `leafwiki --jwt-secret <SECRET> --admin-password <PASSWORD> [--host <HOST>] [--port <PORT>] [--unix-socket <PATH>] [--data-dir <DIR>]
+leafwiki --disable-auth [--host <HOST>] [--port <PORT>] [--unix-socket <PATH>] [--data-dir <DIR>]
+leafwiki reset-admin-password
+leafwiki [--data-dir <DIR>] restore-snapshot <path-to-zip>
+leafwiki --help`
+
+const rootDescription = `Every option can also be set through the environment variable shown next to it.
+Command line flags win over environment variables, which win over the defaults.
+An environment variable that is set but empty counts as unset.
+
+LEAFWIKI_LOG_LEVEL (debug, info, warn, error; default info) is available as an
+environment variable only.
+
+When --snapshot is enabled, live restore-from-snapshot is also available via the
+admin UI (Settings > Full Backup) and gates writes (503) while a restore is
+swapping files. For disaster recovery or migrating a snapshot to a fresh
+instance, use the "restore-snapshot" command instead: run it before starting the
+server against that data directory.`
+
+// serverConfig is every resolved option, grouped the way --help groups them.
+// Each group owns its declarations in its own file, so adding an option means
+// touching one struct and one literal next to each other.
+type serverConfig struct {
+	server   serverOptions
+	auth     authOptions
+	proxy    proxyOptions
+	frontend frontendOptions
+	metrics  metricsOptions
+	backup   backupOptions
+	email    emailOptions
+}
+
+// flags collects the groups. A group missing from this list would silently
+// have no flags, which TestRootCommandHelp_DocumentsFlagsAndEnvVars catches.
+func (c *serverConfig) flags() []cli.Flag {
+	return slices.Concat(
+		c.server.Flags(),
+		c.auth.Flags(),
+		c.proxy.Flags(),
+		c.frontend.Flags(),
+		c.metrics.Flags(),
+		c.backup.Flags(),
+		c.email.Flags(),
+	)
+}
+
+// newRootCommand builds the leafwiki command tree. Running it without a
+// subcommand starts the server.
+func newRootCommand() *cli.Command {
+	return newRootCommandWithConfig(&serverConfig{})
+}
+
+func newRootCommandWithConfig(cfg *serverConfig) *cli.Command {
+	return &cli.Command{
+		Name:        "LeafWiki",
+		Usage:       "lightweight selfhosted wiki 🌿",
+		UsageText:   rootUsageText,
+		Description: rootDescription,
+		Version:     Version,
+		Suggest:     true,
+		// Adds a "completion" command emitting bash, zsh, fish and PowerShell
+		// scripts, generated from the same declarations as --help.
+		EnableShellCompletion: true,
+		// urfave/cli would print the error itself and dump the whole help; it
+		// reports the same failure main would, so handle it here once and hand
+		// back errReported to keep main quiet.
+		OnUsageError: reportUsageError,
+		Flags:        cfg.flags(),
+		Commands: []*cli.Command{
+			newResetAdminPasswordCommand(cfg),
+			newRestoreSnapshotCommand(cfg),
+		},
+		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
+			// The log-format validator has already rejected anything parseLogFormat
+			// cannot handle, including the default; this only normalizes the case.
+			format, _ := parseLogFormat(cfg.server.logFormat)
+			setupLogger(os.Stdout, format)
+			return ctx, nil
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			if cmd.Args().Present() {
+				return cli.Exit(fmt.Sprintf("Unknown command: %s\nRun \"leafwiki --help\" to see the available commands and options.", cmd.Args().First()), 1)
+			}
+			return runServerCommand(ctx, cmd, cfg)
+		},
+	}
+}
+
+func newResetAdminPasswordCommand(cfg *serverConfig) *cli.Command {
+	return &cli.Command{
+		Name:  "reset-admin-password",
+		Usage: "Reset the admin password and print the new one",
+		Action: func(_ context.Context, _ *cli.Command) error {
+			return runResetAdminPasswordCommand(cfg)
+		},
+	}
+}
+
+func newRestoreSnapshotCommand(cfg *serverConfig) *cli.Command {
+	return &cli.Command{
+		Name:      "restore-snapshot",
+		Usage:     "Restore a snapshot ZIP into the data directory while the server is stopped",
+		ArgsUsage: "<path-to-zip>",
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			return runRestoreSnapshotCommand(cfg.server.dataDir, cmd.Args().First())
+		},
+	}
+}
+
+// reportUsageError prints a flag parsing failure, with urfave/cli's "did you
+// mean" hint when it can name the offending flag, and points at --help instead
+// of dumping every option.
+func reportUsageError(_ context.Context, cmd *cli.Command, err error, _ bool) error {
+	out := cmd.Root().ErrWriter
+	_, _ = fmt.Fprintf(out, "Incorrect usage: %s\n", err)
+	if name := unknownFlagName(err); name != "" && cmd.Root().Suggest {
+		if suggestion := cli.SuggestFlag(cmd.Flags, name, true); suggestion != "" && suggestion != name {
+			_, _ = fmt.Fprintf(out, "Did you mean %q?\n", suggestion)
+		}
+	}
+	_, _ = fmt.Fprintf(out, "Run %q to see the available commands and options.\n", "leafwiki --help")
+	return errReported
+}
+
+// unknownFlagName digs the rejected flag out of a parse error so a suggestion
+// can be offered. The error text belongs to the flag package, so a miss just
+// means no hint.
+func unknownFlagName(err error) string {
+	_, name, found := strings.Cut(err.Error(), "not defined: ")
+	if !found {
+		return ""
+	}
+	return strings.TrimLeft(name, "-")
+}
+
+// Flag validators run for values from the command line and from the
+// environment alike, and - with ValidateDefaults set - for the declared default
+// too. A flag Action would not: urfave/cli only runs those for flags that were
+// actually set, so a default would go unchecked.
+
+func validateLogFormatValue(v string) error {
+	if _, ok := parseLogFormat(v); !ok {
+		return fmt.Errorf("expected text or json, got %q", v)
+	}
+	return nil
+}
+
+func validateByteSizeValue(v string) error {
+	_, err := parseByteSize(v)
+	return err
+}
+
+func redirectURLValidator(flagName string) func(string) error {
+	return func(v string) error {
+		return validateRedirectURL(flagName, v)
+	}
+}
+
+func validateTOTPEncryptionKey(v string) error {
+	if v != "" && len(v) < auth.MinTOTPEncryptionKeyLen {
+		return fmt.Errorf("key is too short: need at least %d bytes, got %d", auth.MinTOTPEncryptionKeyLen, len(v))
+	}
+	return nil
+}
+
+// trimmed makes a string flag drop surrounding whitespace, for both command
+// line and environment variable values.
+var trimmed = cli.StringConfig{TrimSpace: true}
+
+// envVars is cli.EnvVars with LeafWiki's long-standing environment variable
+// semantics: a variable that is set but empty (or only whitespace) counts as
+// unset, and values are whitespace trimmed. Deployments rely on this, since
+// compose and .env files routinely declare variables without a value - taking
+// an empty LEAFWIKI_HOST literally would bind the server to every interface.
+func envVars(keys ...string) cli.ValueSourceChain {
+	sources := make([]cli.ValueSource, 0, len(keys))
+	for _, key := range keys {
+		sources = append(sources, &envVarSource{key: key})
+	}
+	return cli.NewValueSourceChain(sources...)
+}
+
+// envBoolVars is envVars for bool flags. It additionally accepts the spellings
+// LeafWiki has always allowed in environment variables (yes/no, on/off, y/n),
+// which strconv.ParseBool - and therefore the command line - does not. An
+// unparseable value is handed to the flag as-is so that urfave/cli reports it
+// and startup fails fast.
+func envBoolVars(keys ...string) cli.ValueSourceChain {
+	sources := make([]cli.ValueSource, 0, len(keys))
+	for _, key := range keys {
+		sources = append(sources, &envVarSource{key: key, normalize: normalizeBoolValue})
+	}
+	return cli.NewValueSourceChain(sources...)
+}
+
+func normalizeBoolValue(raw string) string {
+	if b, ok := parseBool(raw); ok {
+		if b {
+			return "true"
+		}
+		return "false"
+	}
+	return raw
+}
+
+// envVarSource is a cli.ValueSource over one environment variable. It also
+// implements cli.EnvValueSource so that generated help still shows the
+// variable name next to its flag.
+type envVarSource struct {
+	key       string
+	normalize func(string) string
+}
+
+func (e *envVarSource) Lookup() (string, bool) {
+	val := strings.TrimSpace(os.Getenv(e.key))
+	if val == "" {
+		return "", false
+	}
+	if e.normalize != nil {
+		val = e.normalize(val)
+	}
+	return val, true
+}
+
+func (e *envVarSource) IsFromEnv() bool { return true }
+
+func (e *envVarSource) Key() string { return e.key }
+
+func (e *envVarSource) String() string { return fmt.Sprintf("environment variable %q", e.key) }
+
+func (e *envVarSource) GoString() string { return fmt.Sprintf("&envVarSource{Key:%q}", e.key) }

--- a/cmd/leafwiki/flags_auth.go
+++ b/cmd/leafwiki/flags_auth.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"time"
+
+	"github.com/urfave/cli/v3"
+)
+
+// authOptions holds the options for authentication, tokens and the initial admin.
+type authOptions struct {
+	jwtSecret           string
+	totpEncryptionKey   string
+	disableAuth         bool
+	publicAccess        bool
+	accessTokenTimeout  time.Duration
+	refreshTokenTimeout time.Duration
+	adminUsername       string
+	adminEmail          string
+	adminPassword       string
+	editorLimit         int
+}
+
+// Flags declares them. Adding an option here is the whole change: the flag,
+// its default, its environment variable and its help text are one literal,
+// and --help is generated from it.
+func (o *authOptions) Flags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:        "jwt-secret",
+			Destination: &o.jwtSecret,
+			Category:    catAuth,
+			Usage:       "secret for signing auth tokens (JWT); required unless --disable-auth is set",
+			Sources:     envVars("LEAFWIKI_JWT_SECRET"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "totp-encryption-key",
+			Destination: &o.totpEncryptionKey,
+			Category:    catAuth,
+			Usage:       "key to encrypt per-user TOTP secrets at rest, min 32 bytes; unset keeps TOTP unavailable",
+			Sources:     envVars("LEAFWIKI_TOTP_ENCRYPTION_KEY"),
+			Validator:   validateTOTPEncryptionKey,
+			Config:      trimmed,
+		},
+		&cli.BoolFlag{
+			Name:        "disable-auth",
+			Destination: &o.disableAuth,
+			Category:    catAuth,
+			Usage:       "disable authentication completely (WARNING: only use in trusted networks!)",
+			Sources:     envBoolVars("LEAFWIKI_DISABLE_AUTH"),
+		},
+		&cli.BoolFlag{
+			Name:        "public-access",
+			Destination: &o.publicAccess,
+			Category:    catAuth,
+			Usage:       "allow public access to the wiki with read access",
+			Sources:     envBoolVars("LEAFWIKI_PUBLIC_ACCESS"),
+		},
+		&cli.DurationFlag{
+			Name:        "access-token-timeout",
+			Destination: &o.accessTokenTimeout,
+			Category:    catAuth,
+			Usage:       "access token timeout duration (e.g. 24h, 15m)",
+			Value:       15 * time.Minute,
+			Sources:     envVars("LEAFWIKI_ACCESS_TOKEN_TIMEOUT"),
+			DefaultText: "15m",
+		},
+		&cli.DurationFlag{
+			Name:        "refresh-token-timeout",
+			Destination: &o.refreshTokenTimeout,
+			Category:    catAuth,
+			Usage:       "refresh token timeout duration (e.g. 168h)",
+			Value:       7 * 24 * time.Hour,
+			Sources:     envVars("LEAFWIKI_REFRESH_TOKEN_TIMEOUT"),
+			DefaultText: "168h",
+		},
+		&cli.StringFlag{
+			Name:        "admin-username",
+			Destination: &o.adminUsername,
+			Category:    catAdmin,
+			Usage:       "initial admin username, used only if no admin exists (default: admin)",
+			Sources:     envVars("LEAFWIKI_ADMIN_USERNAME"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "admin-email",
+			Destination: &o.adminEmail,
+			Category:    catAdmin,
+			Usage:       "initial admin email, used only if no admin exists (default: admin@localhost)",
+			Sources:     envVars("LEAFWIKI_ADMIN_EMAIL"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "admin-password",
+			Destination: &o.adminPassword,
+			Category:    catAdmin,
+			Usage:       "initial admin password, used only if no admin exists; min 8 characters",
+			Sources:     envVars("LEAFWIKI_ADMIN_PASSWORD"),
+			Config:      trimmed,
+		},
+		&cli.IntFlag{
+			Name:        "editor-limit",
+			Destination: &o.editorLimit,
+			Category:    catAuth,
+			Usage:       "maximum admin+editor users allowed; 0 = unlimited",
+			Sources:     envVars("LEAFWIKI_EDITOR_LIMIT"),
+		},
+	}
+}

--- a/cmd/leafwiki/flags_backup.go
+++ b/cmd/leafwiki/flags_backup.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"time"
+
+	"github.com/urfave/cli/v3"
+)
+
+// backupOptions holds the options for git backup, snapshots and restore.
+type backupOptions struct {
+	gitBackup              bool
+	gitBackupAuthorName    string
+	gitBackupAuthorEmail   string
+	gitBackupRemote        string
+	gitBackupBranch        string
+	gitBackupSSHKeyPath    string
+	gitBackupSSHKey        string
+	gitBackupSSHKnownHosts string
+	gitBackupHTTPUsername  string
+	gitBackupHTTPPassword  string
+	gitBackupInterval      time.Duration
+	snapshot               bool
+	snapshotInterval       time.Duration
+	snapshotRetention      int
+	snapshotDir            string
+	restoreUploadMaxSize   string
+}
+
+// Flags declares them. Adding an option here is the whole change: the flag,
+// its default, its environment variable and its help text are one literal,
+// and --help is generated from it.
+func (o *backupOptions) Flags() []cli.Flag {
+	return []cli.Flag{
+		&cli.BoolFlag{
+			Name:        "git-backup",
+			Destination: &o.gitBackup,
+			Category:    catGitBackup,
+			Usage:       "enable git backup to a remote repository",
+			Sources:     envBoolVars("LEAFWIKI_GIT_BACKUP"),
+		},
+		&cli.StringFlag{
+			Name:        "git-backup-author-name",
+			Destination: &o.gitBackupAuthorName,
+			Category:    catGitBackup,
+			Usage:       "git commit author name for backups",
+			Value:       "LeafWiki Backup",
+			Sources:     envVars("LEAFWIKI_GIT_BACKUP_AUTHOR_NAME"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "git-backup-author-email",
+			Destination: &o.gitBackupAuthorEmail,
+			Category:    catGitBackup,
+			Usage:       "git commit author email for backups",
+			Value:       "backup@leafwiki.local",
+			Sources:     envVars("LEAFWIKI_GIT_BACKUP_AUTHOR_EMAIL"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "git-backup-remote",
+			Destination: &o.gitBackupRemote,
+			Category:    catGitBackup,
+			Usage:       "git remote URL (SSH or HTTP(S)) for backups; leave unset for local-only backups",
+			Sources:     envVars("LEAFWIKI_GIT_BACKUP_REMOTE"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "git-backup-branch",
+			Destination: &o.gitBackupBranch,
+			Category:    catGitBackup,
+			Usage:       "git branch to push to",
+			Value:       "main",
+			Sources:     envVars("LEAFWIKI_GIT_BACKUP_BRANCH"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "git-backup-ssh-key-path",
+			Destination: &o.gitBackupSSHKeyPath,
+			Category:    catGitBackup,
+			Usage:       "path to SSH private key for git backup",
+			Sources:     envVars("LEAFWIKI_GIT_BACKUP_SSH_KEY_PATH"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        gitBackupSSHKeyFlagName,
+			Destination: &o.gitBackupSSHKey,
+			Category:    catGitBackup,
+			Usage:       "raw SSH private key for git backup (env var preferred)",
+			Sources:     envVars("LEAFWIKI_GIT_BACKUP_SSH_KEY"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "git-backup-ssh-known-hosts",
+			Destination: &o.gitBackupSSHKnownHosts,
+			Category:    catGitBackup,
+			Usage:       "known_hosts file for SSH host key verification (MITM protection)",
+			Sources:     envVars("LEAFWIKI_GIT_BACKUP_SSH_KNOWN_HOSTS"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "git-backup-http-username",
+			Destination: &o.gitBackupHTTPUsername,
+			Category:    catGitBackup,
+			Usage:       "username for HTTP(S) basic auth on http(s):// remotes",
+			Sources:     envVars("LEAFWIKI_GIT_BACKUP_HTTP_USERNAME"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        gitBackupHTTPPasswordFlagName,
+			Destination: &o.gitBackupHTTPPassword,
+			Category:    catGitBackup,
+			Usage:       "password or access token for HTTP(S) basic auth (env var preferred)",
+			Sources:     envVars("LEAFWIKI_GIT_BACKUP_HTTP_PASSWORD"),
+			Config:      trimmed,
+		},
+		&cli.DurationFlag{
+			Name:        "git-backup-interval",
+			Destination: &o.gitBackupInterval,
+			Category:    catGitBackup,
+			Usage:       "git backup interval (e.g. 60m, 2h); 0 = manual-only, no automatic scheduling",
+			Value:       60 * time.Minute,
+			Sources:     envVars("LEAFWIKI_GIT_BACKUP_INTERVAL"),
+			DefaultText: "60m",
+		},
+		&cli.BoolFlag{
+			Name:        "snapshot",
+			Destination: &o.snapshot,
+			Category:    catSnapshots,
+			Usage:       "full backup snapshots (ZIP incl. the SQLite database); disable with --snapshot=false",
+			Value:       true,
+			DefaultText: "true",
+			Sources:     envBoolVars("LEAFWIKI_SNAPSHOT"),
+		},
+		&cli.DurationFlag{
+			Name:        "snapshot-interval",
+			Destination: &o.snapshotInterval,
+			Category:    catSnapshots,
+			Usage:       "snapshot interval (e.g. 24h, 6h); 0 = manual-only, no automatic scheduling",
+			Value:       24 * time.Hour,
+			Sources:     envVars("LEAFWIKI_SNAPSHOT_INTERVAL"),
+			DefaultText: "24h",
+		},
+		&cli.IntFlag{
+			Name:        "snapshot-retention",
+			Destination: &o.snapshotRetention,
+			Category:    catSnapshots,
+			Usage:       "number of most recent snapshots to keep; <= 0 = keep all",
+			Value:       10,
+			Sources:     envVars("LEAFWIKI_SNAPSHOT_RETENTION"),
+		},
+		&cli.StringFlag{
+			Name:        "snapshot-dir",
+			Destination: &o.snapshotDir,
+			Category:    catSnapshots,
+			Usage:       "directory to store snapshot ZIPs in",
+			DefaultText: "<data-dir>/snapshots",
+			Sources:     envVars("LEAFWIKI_SNAPSHOT_DIR"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:             "restore-upload-max-size",
+			Destination:      &o.restoreUploadMaxSize,
+			Category:         catSnapshots,
+			Usage:            "maximum size of an uploaded backup ZIP to restore from (e.g. 500MiB, 500MB, 524288000)",
+			Value:            "500MiB",
+			Sources:          envVars("LEAFWIKI_RESTORE_UPLOAD_MAX_SIZE"),
+			Validator:        validateByteSizeValue,
+			ValidateDefaults: true,
+			Config:           trimmed,
+		},
+	}
+}

--- a/cmd/leafwiki/flags_email.go
+++ b/cmd/leafwiki/flags_email.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"time"
+
+	"github.com/urfave/cli/v3"
+)
+
+// emailOptions holds the options for outgoing email (SMTP).
+type emailOptions struct {
+	smtpHost               string
+	smtpPort               int
+	smtpUsername           string
+	smtpPassword           string
+	smtpFrom               string
+	smtpFromName           string
+	smtpSecurity           string
+	smtpInsecureSkipVerify bool
+	smtpTimeout            time.Duration
+	publicURL              string
+}
+
+// Flags declares them. Adding an option here is the whole change: the flag,
+// its default, its environment variable and its help text are one literal,
+// and --help is generated from it.
+func (o *emailOptions) Flags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:        "smtp-host",
+			Destination: &o.smtpHost,
+			Category:    catEmail,
+			Usage:       "SMTP host for password-reset/invite email; unset disables email entirely",
+			Sources:     envVars("LEAFWIKI_SMTP_HOST"),
+			Config:      trimmed,
+		},
+		&cli.IntFlag{
+			Name:        "smtp-port",
+			Destination: &o.smtpPort,
+			Category:    catEmail,
+			Usage:       "SMTP server port",
+			Value:       587,
+			Sources:     envVars("LEAFWIKI_SMTP_PORT"),
+		},
+		&cli.StringFlag{
+			Name:        "smtp-username",
+			Destination: &o.smtpUsername,
+			Category:    catEmail,
+			Usage:       "SMTP auth username",
+			Sources:     envVars("LEAFWIKI_SMTP_USERNAME"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "smtp-password",
+			Destination: &o.smtpPassword,
+			Category:    catEmail,
+			Usage:       "SMTP auth password (env var preferred)",
+			Sources:     envVars("LEAFWIKI_SMTP_PASSWORD"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "smtp-from",
+			Destination: &o.smtpFrom,
+			Category:    catEmail,
+			Usage:       "From address for outgoing email (required when --smtp-host is set)",
+			Sources:     envVars("LEAFWIKI_SMTP_FROM"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "smtp-from-name",
+			Destination: &o.smtpFromName,
+			Category:    catEmail,
+			Usage:       "From display name for outgoing email",
+			Value:       "LeafWiki",
+			Sources:     envVars("LEAFWIKI_SMTP_FROM_NAME"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "smtp-security",
+			Destination: &o.smtpSecurity,
+			Category:    catEmail,
+			Usage:       "SMTP transport security: none, starttls, or tls",
+			Value:       "starttls",
+			Sources:     envVars("LEAFWIKI_SMTP_SECURITY"),
+			Config:      trimmed,
+		},
+		&cli.BoolFlag{
+			Name:        "smtp-insecure-skip-verify",
+			Destination: &o.smtpInsecureSkipVerify,
+			Category:    catEmail,
+			Usage:       "skip TLS certificate verification for SMTP (do not use in production)",
+			Sources:     envBoolVars("LEAFWIKI_SMTP_INSECURE_SKIP_VERIFY"),
+		},
+		&cli.DurationFlag{
+			Name:        "smtp-timeout",
+			Destination: &o.smtpTimeout,
+			Category:    catEmail,
+			Usage:       "timeout for a single SMTP send (e.g. 10s)",
+			Value:       10 * time.Second,
+			Sources:     envVars("LEAFWIKI_SMTP_TIMEOUT"),
+			DefaultText: "10s",
+		},
+		&cli.StringFlag{
+			Name:        "public-url",
+			Destination: &o.publicURL,
+			Category:    catEmail,
+			Usage:       "base URL for links in outgoing email, e.g. https://wiki.example.com (required with --smtp-host)",
+			Sources:     envVars("LEAFWIKI_PUBLIC_URL"),
+			Config:      trimmed,
+		},
+	}
+}

--- a/cmd/leafwiki/flags_frontend.go
+++ b/cmd/leafwiki/flags_frontend.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"time"
+
+	"github.com/urfave/cli/v3"
+)
+
+// frontendOptions holds the options for frontend appearance, features and revisions.
+type frontendOptions struct {
+	defaultLanguage         string
+	injectCodeInHeader      string
+	customStylesheet        string
+	hideLinkMetadataSection bool
+	maxAssetUploadSize      string
+	enableRevision          bool
+	enableLinkRefactor      bool
+	enableAPIKeyManagement  bool
+	maxRevisionHistory      int
+	revisionCoalesceWindow  time.Duration
+}
+
+// Flags declares them. Adding an option here is the whole change: the flag,
+// its default, its environment variable and its help text are one literal,
+// and --help is generated from it.
+func (o *frontendOptions) Flags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:        "default-language",
+			Destination: &o.defaultLanguage,
+			Category:    catFrontend,
+			Usage:       "default UI language code (e.g. en, de); ignored unless the frontend ships it",
+			Sources:     envVars("LEAFWIKI_DEFAULT_LANGUAGE"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "inject-code-in-header",
+			Destination: &o.injectCodeInHeader,
+			Category:    catFrontend,
+			Usage:       "raw HTML/JS injected into <head> (analytics, custom CSS); trusted code only, it is not sanitized",
+			Sources:     envVars("LEAFWIKI_INJECT_CODE_IN_HEADER"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "custom-stylesheet",
+			Destination: &o.customStylesheet,
+			Category:    catFrontend,
+			Usage:       "a .css file inside the data dir, served as /custom.css (under --base-path when set)",
+			Sources:     envVars("LEAFWIKI_CUSTOM_STYLESHEET"),
+			Config:      trimmed,
+		},
+		&cli.BoolFlag{
+			Name:        "hide-link-metadata-section",
+			Destination: &o.hideLinkMetadataSection,
+			Category:    catFrontend,
+			Usage:       "hide the link metadata section in the frontend UI",
+			Sources:     envBoolVars("LEAFWIKI_HIDE_LINK_METADATA_SECTION"),
+		},
+		&cli.StringFlag{
+			Name:             "max-asset-upload-size",
+			Destination:      &o.maxAssetUploadSize,
+			Category:         catFrontend,
+			Usage:            "maximum size for asset uploads (e.g. 50MiB, 50MB, 52428800)",
+			Value:            "50MiB",
+			Sources:          envVars("LEAFWIKI_MAX_ASSET_UPLOAD_SIZE"),
+			Validator:        validateByteSizeValue,
+			ValidateDefaults: true,
+			Config:           trimmed,
+		},
+		&cli.BoolFlag{
+			Name:        "enable-revision",
+			Destination: &o.enableRevision,
+			Category:    catFeatures,
+			Usage:       "enable the revision / page history feature",
+			Sources:     envBoolVars("LEAFWIKI_ENABLE_REVISION"),
+		},
+		&cli.BoolFlag{
+			Name:        "enable-link-refactor",
+			Destination: &o.enableLinkRefactor,
+			Category:    catFeatures,
+			Usage:       "enable the link refactoring dialog and rewrite flow",
+			Sources:     envBoolVars("LEAFWIKI_ENABLE_LINK_REFACTOR"),
+		},
+		&cli.BoolFlag{
+			Name:        "enable-api-key-management",
+			Destination: &o.enableAPIKeyManagement,
+			Category:    catFeatures,
+			Usage:       "enable the experimental API key management feature",
+			Sources:     envBoolVars("LEAFWIKI_ENABLE_API_KEY_MANAGEMENT"),
+		},
+		&cli.IntFlag{
+			Name:        "max-revision-history",
+			Destination: &o.maxRevisionHistory,
+			Category:    catRevisions,
+			Usage:       "maximum revisions kept per page; 0 = unlimited",
+			Value:       100,
+			Sources:     envVars("LEAFWIKI_MAX_REVISION_HISTORY"),
+		},
+		&cli.DurationFlag{
+			Name:        "revision-coalesce-window",
+			Destination: &o.revisionCoalesceWindow,
+			Category:    catRevisions,
+			Usage:       "coalesce rapid successive saves by the same author (e.g. 5m); 0 = disabled",
+			Value:       5 * time.Minute,
+			Sources:     envVars("LEAFWIKI_REVISION_COALESCE_WINDOW"),
+			DefaultText: "5m",
+		},
+	}
+}

--- a/cmd/leafwiki/flags_metrics.go
+++ b/cmd/leafwiki/flags_metrics.go
@@ -1,0 +1,43 @@
+package main
+
+import "github.com/urfave/cli/v3"
+
+// metricsOptions holds the options for the Prometheus metrics listener.
+type metricsOptions struct {
+	enableMetrics bool
+	metricsHost   string
+	metricsPort   string
+}
+
+// Flags declares them. Adding an option here is the whole change: the flag,
+// its default, its environment variable and its help text are one literal,
+// and --help is generated from it.
+func (o *metricsOptions) Flags() []cli.Flag {
+	return []cli.Flag{
+		&cli.BoolFlag{
+			Name:        "enable-metrics",
+			Destination: &o.enableMetrics,
+			Category:    catMetrics,
+			Usage:       "enable the Prometheus /metrics endpoint on a separate listener",
+			Sources:     envBoolVars("LEAFWIKI_ENABLE_METRICS"),
+		},
+		&cli.StringFlag{
+			Name:        "metrics-host",
+			Destination: &o.metricsHost,
+			Category:    catMetrics,
+			Usage:       "host/IP address for the Prometheus metrics listener",
+			Value:       "127.0.0.1",
+			Sources:     envVars("LEAFWIKI_METRICS_HOST"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "metrics-port",
+			Destination: &o.metricsPort,
+			Category:    catMetrics,
+			Usage:       "port for the Prometheus metrics listener",
+			Value:       "9091",
+			Sources:     envVars("LEAFWIKI_METRICS_PORT"),
+			Config:      trimmed,
+		},
+	}
+}

--- a/cmd/leafwiki/flags_proxy.go
+++ b/cmd/leafwiki/flags_proxy.go
@@ -1,0 +1,109 @@
+package main
+
+import "github.com/urfave/cli/v3"
+
+// proxyOptions holds the options for reverse-proxy authentication and external URLs.
+type proxyOptions struct {
+	enableHTTPRemoteUser           bool
+	httpRemoteUserHeader           string
+	enableHTTPRemoteUserAutoCreate bool
+	httpRemoteUserEmailHeader      string
+	httpRemoteUserDefaultRole      string
+	trustedProxyIPs                string
+	httpRemoteUserLogoutURL        string
+	loginURL                       string
+	logoutURL                      string
+	userManagementURL              string
+}
+
+// Flags declares them. Adding an option here is the whole change: the flag,
+// its default, its environment variable and its help text are one literal,
+// and --help is generated from it.
+func (o *proxyOptions) Flags() []cli.Flag {
+	return []cli.Flag{
+		&cli.BoolFlag{
+			Name:        "enable-http-remote-user",
+			Destination: &o.enableHTTPRemoteUser,
+			Category:    catProxyAuth,
+			Usage:       "enable reverse-proxy authentication via HTTP header",
+			Sources:     envBoolVars("LEAFWIKI_ENABLE_HTTP_REMOTE_USER"),
+		},
+		&cli.StringFlag{
+			Name:        "http-remote-user-header-name",
+			Destination: &o.httpRemoteUserHeader,
+			Category:    catProxyAuth,
+			Usage:       "HTTP header carrying the username or email from a trusted proxy",
+			Value:       "Remote-User",
+			Sources:     envVars("LEAFWIKI_HTTP_REMOTE_USER_HEADER_NAME"),
+			Config:      trimmed,
+		},
+		&cli.BoolFlag{
+			Name:        "enable-http-remote-user-auto-create",
+			Destination: &o.enableHTTPRemoteUserAutoCreate,
+			Category:    catProxyAuth,
+			Usage:       "auto-provision users asserted by the proxy but unknown to LeafWiki",
+			Sources:     envBoolVars("LEAFWIKI_ENABLE_HTTP_REMOTE_USER_AUTO_CREATE"),
+		},
+		&cli.StringFlag{
+			Name:        "http-remote-user-email-header-name",
+			Destination: &o.httpRemoteUserEmailHeader,
+			Category:    catProxyAuth,
+			Usage:       "HTTP header carrying the email for auto-created users",
+			Sources:     envVars("LEAFWIKI_HTTP_REMOTE_USER_EMAIL_HEADER_NAME"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "http-remote-user-default-role",
+			Destination: &o.httpRemoteUserDefaultRole,
+			Category:    catProxyAuth,
+			Usage:       "role assigned to auto-created users; must not be admin",
+			Value:       "viewer",
+			Sources:     envVars("LEAFWIKI_HTTP_REMOTE_USER_DEFAULT_ROLE"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "trusted-proxy-ips",
+			Destination: &o.trustedProxyIPs,
+			Category:    catProxyAuth,
+			Usage:       "comma-separated trusted proxy IPs/CIDRs (e.g. 127.0.0.1,172.18.0.0/16)",
+			Sources:     envVars("LEAFWIKI_TRUSTED_PROXY_IPS"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "http-remote-user-logout-url",
+			Destination: &o.httpRemoteUserLogoutURL,
+			Category:    catProxyAuth,
+			Usage:       "deprecated: use --logout-url instead",
+			Sources:     envVars("LEAFWIKI_HTTP_REMOTE_USER_LOGOUT_URL"),
+			Validator:   redirectURLValidator("http-remote-user-logout-url"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "login-url",
+			Destination: &o.loginURL,
+			Category:    catURLs,
+			Usage:       "URL the frontend redirects to instead of the built-in login form (e.g. external SSO/IdP)",
+			Sources:     envVars("LEAFWIKI_LOGIN_URL"),
+			Validator:   redirectURLValidator("login-url"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "logout-url",
+			Destination: &o.logoutURL,
+			Category:    catURLs,
+			Usage:       "URL the frontend redirects to after logout (e.g. external SSO/IdP)",
+			Sources:     envVars("LEAFWIKI_LOGOUT_URL"),
+			Validator:   redirectURLValidator("logout-url"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "user-management-url",
+			Destination: &o.userManagementURL,
+			Category:    catURLs,
+			Usage:       "external user-management page; replaces the built-in User Management UI with a link",
+			Sources:     envVars("LEAFWIKI_USER_MANAGEMENT_URL"),
+			Validator:   redirectURLValidator("user-management-url"),
+			Config:      trimmed,
+		},
+	}
+}

--- a/cmd/leafwiki/flags_server.go
+++ b/cmd/leafwiki/flags_server.go
@@ -1,0 +1,91 @@
+package main
+
+import "github.com/urfave/cli/v3"
+
+// serverOptions holds the options for listener, data directory and logging.
+type serverOptions struct {
+	host              string
+	port              string
+	unixSocket        string
+	dataDir           string
+	basePath          string
+	allowInsecure     bool
+	logFormat         string
+	disableRequestLog bool
+}
+
+// Flags declares them. Adding an option here is the whole change: the flag,
+// its default, its environment variable and its help text are one literal,
+// and --help is generated from it.
+func (o *serverOptions) Flags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:        "host",
+			Destination: &o.host,
+			Category:    catServer,
+			Usage:       "host/IP address to bind the server to (e.g. 127.0.0.1 or 0.0.0.0)",
+			Value:       "127.0.0.1",
+			Sources:     envVars("LEAFWIKI_HOST"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "port",
+			Destination: &o.port,
+			Category:    catServer,
+			Usage:       "port to run the server on",
+			Value:       "8080",
+			Sources:     envVars("LEAFWIKI_PORT"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "unix-socket",
+			Destination: &o.unixSocket,
+			Category:    catServer,
+			Usage:       "path to a unix domain socket to listen on; overrides --host and --port",
+			Sources:     envVars("LEAFWIKI_UNIX_SOCKET"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "data-dir",
+			Destination: &o.dataDir,
+			Category:    catServer,
+			Usage:       "path to data directory",
+			Value:       "./data",
+			Sources:     envVars("LEAFWIKI_DATA_DIR"),
+			Config:      trimmed,
+		},
+		&cli.StringFlag{
+			Name:        "base-path",
+			Destination: &o.basePath,
+			Category:    catServer,
+			Usage:       "URL prefix when served behind a reverse proxy (e.g. /wiki)",
+			Sources:     envVars("LEAFWIKI_BASE_PATH"),
+			Config:      trimmed,
+		},
+		&cli.BoolFlag{
+			Name:        "allow-insecure",
+			Destination: &o.allowInsecure,
+			Category:    catServer,
+			Usage:       "allow insecure HTTP; auth cookies may then travel in plain text",
+			Sources:     envBoolVars("LEAFWIKI_ALLOW_INSECURE"),
+		},
+		&cli.StringFlag{
+			Name:             "log-format",
+			Destination:      &o.logFormat,
+			Category:         catLogging,
+			Usage:            "log output format: text or json",
+			Value:            "text",
+			Sources:          envVars("LEAFWIKI_LOG_FORMAT"),
+			Validator:        validateLogFormatValue,
+			ValidateDefaults: true,
+			Config:           trimmed,
+		},
+		&cli.BoolFlag{
+			Name:        "disable-request-log",
+			Destination: &o.disableRequestLog,
+			Category:    catLogging,
+			Usage:       "suppress per-request HTTP access log lines",
+			Sources:     envBoolVars("LEAFWIKI_DISABLE_REQUEST_LOG"),
+		},
+	}
+}

--- a/cmd/leafwiki/main.go
+++ b/cmd/leafwiki/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"log/slog"
@@ -37,6 +36,7 @@ import (
 	wikibackup "github.com/perber/wiki/internal/wiki/backup"
 	wikirestore "github.com/perber/wiki/internal/wiki/restore"
 	wikisnapshot "github.com/perber/wiki/internal/wiki/snapshot"
+	"github.com/urfave/cli/v3"
 )
 
 // Version is the LeafWiki build version. It defaults to "dev" for
@@ -48,160 +48,7 @@ var Version = "dev"
 const (
 	gitBackupSSHKeyFlagName       = "git-backup-ssh-key"
 	gitBackupHTTPPasswordFlagName = "git-backup-http-password"
-	errInvalidEnvVarValue         = "Invalid environment variable value"
 )
-
-func writeUsage(w io.Writer) {
-	if _, err := fmt.Fprintln(w, `LeafWiki – lightweight selfhosted wiki 🌿
-
-	Usage:
-	leafwiki --jwt-secret <SECRET> --admin-password <PASSWORD> [--host <HOST>] [--port <PORT>] [--unix-socket <PATH>] [--data-dir <DIR>]
-	leafwiki --disable-auth [--host <HOST>] [--port <PORT>] [--unix-socket <PATH>] [--data-dir <DIR>]
-	leafwiki reset-admin-password
-	leafwiki [--data-dir <DIR>] restore-snapshot <path-to-zip>
-	leafwiki --help
-
-	Options:
-	--log-format       Log output format: text or json (default: text)
-	--host             Host/IP address to bind the server to (default: 127.0.0.1)
-	--port             Port to run the server on (default: 8080)
-	--unix-socket      Path to a unix domain socket to listen on (overrides --host and --port)
-	--data-dir         Path to data directory (default: ./data)
-	--admin-password   Initial admin password (used only if no admin exists), min 8 characters
-	--admin-username   Initial admin username (used only if no admin exists) (default: admin)
-	--admin-email      Initial admin email (used only if no admin exists) (default: admin@localhost)
-	--jwt-secret       Secret for signing auth tokens (JWT) (required)
-	--totp-encryption-key    Key to encrypt per-user TOTP secrets at rest, min 32 bytes
-	                         (required only once a user enables TOTP; leave unset to keep
-	                         TOTP self-service unavailable) (default: "")
-	--public-access    Allow public access to the wiki only with read access (default: false)
-	--allow-insecure   Allow insecure HTTP connections (default: false)                      
-	--access-token-timeout  Access token timeout duration (e.g. 24h, 15m) (default: 15m)
-	--refresh-token-timeout Refresh token timeout duration (e.g. 168h) (default: 168h)
-	--inject-code-in-header  Raw HTML/JS code injected into <head> tag (e.g., analytics, custom CSS) (default: "")
-	                         WARNING: Use only with trusted code to avoid XSS vulnerabilities. No sanitization is performed.
-	--custom-stylesheet      Path to a .css file inside the data dir, served publicly as /custom.css
-	                         (or <base-path>/custom.css when --base-path is set) (default: "")
-	--disable-auth                Disable authentication completely (default: false) (WARNING: only use in trusted networks!)
-	--hide-link-metadata-section  Hide link metadata section in the frontend UI (default: false)
-	--base-path                   URL prefix when served behind a reverse proxy (e.g. /wiki) (default: "")
-	--max-asset-upload-size       Maximum size for asset uploads (for example 50MiB, 50MB, 52428800) (default: 50MiB)
-	--enable-revision             Enable the revision / page history feature (default: false)
-	--enable-link-refactor        Enable the link refactoring dialog and rewrite flow (default: false)
-	--enable-api-key-management   Enable the experimental API key management feature (default: false)
-	--enable-metrics              Enable the Prometheus /metrics endpoint on a separate listener (default: false)
-	--metrics-host                Host/IP for the metrics listener (default: 127.0.0.1)
-	--metrics-port                Port for the metrics listener (default: 9091)
-	--max-revision-history        Maximum revisions kept per page; 0 = unlimited (default: 100)
-	--editor-limit                Maximum admin+editor users allowed; 0 = unlimited (default: 0)
-	--revision-coalesce-window    Window for coalescing rapid successive saves by the same author (e.g. 5m, 0 = disabled) (default: 5m)
-	--enable-http-remote-user               Enable reverse-proxy authentication via HTTP header (default: false)
-	--http-remote-user-header-name          HTTP header carrying the username or email from a trusted proxy (default: Remote-User)
-	--enable-http-remote-user-auto-create   Auto-provision users asserted by the trusted proxy but unknown to LeafWiki (default: false)
-	--http-remote-user-email-header-name    HTTP header carrying the email for auto-created users (default: "")
-	--http-remote-user-default-role         Role assigned to auto-created users; must not be "admin" (default: viewer)
-	--trusted-proxy-ips                     Comma-separated trusted proxy IPs/CIDRs (e.g. 127.0.0.1,172.18.0.0/16)
-	--login-url                     URL the frontend redirects to instead of the built-in login form
-	                                 (e.g. an external SSO/IdP login page) (default: "")
-	--logout-url                    URL the frontend redirects to after logout
-	                                 (e.g. an external SSO/IdP logout page) (default: "")
-	--http-remote-user-logout-url   Deprecated: use --logout-url instead
-	--user-management-url           URL to an external user-management page; when set, the built-in
-	                                 User Management UI is replaced with a link to this URL (default: "")
-	--default-language              Default UI language code for the frontend (e.g. en, de); must match
-	                                 a language shipped with the frontend, otherwise it is ignored (default: "")
-	--disable-request-log           Suppress per-request HTTP access log lines (default: false)
-	--git-backup                   Enable git backup to a remote repository (default: false)
-	--git-backup-author-name       Git commit author name for backups (default: LeafWiki Backup)
-	--git-backup-author-email      Git commit author email for backups (default: backup@leafwiki.local)
-	--git-backup-remote            Git remote URL (SSH or HTTP(S)) for backups (required when git-backup is enabled)
-	--git-backup-branch            Git branch to push to (default: main)
-	--git-backup-ssh-key-path      Path to SSH private key for git backup
-	--git-backup-ssh-key           Raw SSH private key for git backup (env var preferred)
-	--git-backup-ssh-known-hosts   Path to known_hosts file for SSH host key verification (MITM protection)
-	--git-backup-http-username     Username for HTTP(S) basic auth (used instead of an SSH key on http(s):// remotes)
-	--git-backup-http-password     Password or access token for HTTP(S) basic auth (env var preferred)
-	--git-backup-interval          Git backup interval (e.g. 60m, 2h); 0 = manual-only, no automatic scheduling (default: 60m)
-	--snapshot                     Enable full backup snapshots (ZIP incl. the SQLite database) (default: true)
-	--snapshot-interval            Snapshot interval (e.g. 24h, 6h); 0 = manual-only, no automatic scheduling (default: 24h)
-	--snapshot-retention           Number of most recent snapshots to keep; <= 0 = keep all (default: 10)
-	--snapshot-dir                 Directory to store snapshot ZIPs in (default: <data-dir>/snapshots)
-	--restore-upload-max-size      Maximum size for an uploaded backup ZIP to restore from
-	                               (for example 500MiB, 500MB, 524288000) (default: 500MiB)
-	                               When --snapshot is enabled, live restore-from-snapshot is also available
-	                               via the admin UI (Settings > Full Backup) and gates writes (503) while a
-	                               restore is swapping files. For disaster recovery or migrating a snapshot
-	                               to a fresh instance, use the "restore-snapshot" subcommand instead (run it
-	                               before starting the server against that data directory; pass --data-dir
-	                               *before* the subcommand, e.g. "leafwiki --data-dir ./data restore-snapshot file.zip").
-
-	Environment variables:
-	LEAFWIKI_HOST
-	LEAFWIKI_PORT
-	LEAFWIKI_UNIX_SOCKET
-	LEAFWIKI_DATA_DIR
-	LEAFWIKI_JWT_SECRET
-	LEAFWIKI_TOTP_ENCRYPTION_KEY
-	LEAFWIKI_LOG_LEVEL
-	LEAFWIKI_LOG_FORMAT
-	LEAFWIKI_ADMIN_PASSWORD
-	LEAFWIKI_ADMIN_USERNAME
-	LEAFWIKI_ADMIN_EMAIL
-	LEAFWIKI_PUBLIC_ACCESS
-	LEAFWIKI_EDITOR_LIMIT
-	LEAFWIKI_ALLOW_INSECURE
-	LEAFWIKI_INJECT_CODE_IN_HEADER
-	LEAFWIKI_CUSTOM_STYLESHEET
-	LEAFWIKI_ACCESS_TOKEN_TIMEOUT
-	LEAFWIKI_REFRESH_TOKEN_TIMEOUT
-	LEAFWIKI_DISABLE_AUTH
-	LEAFWIKI_HIDE_LINK_METADATA_SECTION
-	LEAFWIKI_BASE_PATH
-	LEAFWIKI_MAX_ASSET_UPLOAD_SIZE
-	LEAFWIKI_ENABLE_REVISION
-	LEAFWIKI_ENABLE_LINK_REFACTOR
-	LEAFWIKI_ENABLE_API_KEY_MANAGEMENT
-	LEAFWIKI_ENABLE_METRICS
-	LEAFWIKI_METRICS_HOST
-	LEAFWIKI_METRICS_PORT
-	LEAFWIKI_MAX_REVISION_HISTORY
-	LEAFWIKI_REVISION_COALESCE_WINDOW
-	LEAFWIKI_ENABLE_HTTP_REMOTE_USER
-	LEAFWIKI_HTTP_REMOTE_USER_HEADER_NAME
-	LEAFWIKI_ENABLE_HTTP_REMOTE_USER_AUTO_CREATE
-	LEAFWIKI_HTTP_REMOTE_USER_EMAIL_HEADER_NAME
-	LEAFWIKI_HTTP_REMOTE_USER_DEFAULT_ROLE
-	LEAFWIKI_TRUSTED_PROXY_IPS
-	LEAFWIKI_LOGIN_URL
-	LEAFWIKI_LOGOUT_URL
-	LEAFWIKI_HTTP_REMOTE_USER_LOGOUT_URL  (deprecated: use LEAFWIKI_LOGOUT_URL instead)
-	LEAFWIKI_USER_MANAGEMENT_URL
-	LEAFWIKI_DEFAULT_LANGUAGE
-	LEAFWIKI_DISABLE_REQUEST_LOG
-	LEAFWIKI_GIT_BACKUP
-	LEAFWIKI_GIT_BACKUP_AUTHOR_NAME
-	LEAFWIKI_GIT_BACKUP_AUTHOR_EMAIL
-	LEAFWIKI_GIT_BACKUP_REMOTE
-	LEAFWIKI_GIT_BACKUP_BRANCH
-	LEAFWIKI_GIT_BACKUP_SSH_KEY_PATH
-	LEAFWIKI_GIT_BACKUP_SSH_KEY
-	LEAFWIKI_GIT_BACKUP_SSH_KNOWN_HOSTS
-	LEAFWIKI_GIT_BACKUP_HTTP_USERNAME
-	LEAFWIKI_GIT_BACKUP_HTTP_PASSWORD
-	LEAFWIKI_GIT_BACKUP_INTERVAL
-	LEAFWIKI_SNAPSHOT
-	LEAFWIKI_SNAPSHOT_INTERVAL
-	LEAFWIKI_SNAPSHOT_RETENTION
-	LEAFWIKI_SNAPSHOT_DIR
-	LEAFWIKI_RESTORE_UPLOAD_MAX_SIZE
-	`); err != nil {
-		panic(err)
-	}
-}
-
-func printUsage() {
-	writeUsage(os.Stdout)
-}
 
 func setupLogger(w io.Writer, format string) {
 	level := slog.LevelInfo
@@ -236,414 +83,177 @@ func fail(msg string, args ...any) {
 
 var errRestoreSnapshotUsage = errors.New("restore-snapshot requires a path to a snapshot zip: leafwiki [--data-dir <DIR>] restore-snapshot <path-to-zip>")
 
-// runRestoreSnapshotCommand implements the `restore-snapshot` subcommand: args
-// is flag.Args() (args[0] == "restore-snapshot"), so a snapshot path is
-// present at args[1].
-func runRestoreSnapshotCommand(dataDir string, args []string) error {
-	if len(args) < 2 {
+// runRestoreSnapshotCommand implements the `restore-snapshot` command.
+func runRestoreSnapshotCommand(dataDir, snapshotPath string) error {
+	if snapshotPath == "" {
 		return errRestoreSnapshotUsage
 	}
-	return restore.RestoreOffline(dataDir, args[1])
+	if err := restore.RestoreOffline(dataDir, snapshotPath); err != nil {
+		return fmt.Errorf("restore failed: %w", err)
+	}
+	fmt.Println("Snapshot restored successfully. Start the server normally to pick up the restored data.")
+	return nil
 }
 
 var gracefulShutdownTimeout = 10 * time.Second
 
-type cliFlags struct {
-	logFormat                      *string
-	host                           *string
-	port                           *string
-	unixSocket                     *string
-	dataDir                        *string
-	adminUsername                  *string
-	adminEmail                     *string
-	adminPassword                  *string
-	jwtSecret                      *string
-	totpEncryptionKey              *string
-	publicAccess                   *bool
-	allowInsecure                  *bool
-	injectCodeInHeader             *string
-	customStylesheet               *string
-	disableAuth                    *bool
-	hideLinkMetadataSection        *bool
-	accessTokenTimeout             *time.Duration
-	refreshTokenTimeout            *time.Duration
-	basePath                       *string
-	maxAssetUploadSize             *string
-	enableRevision                 *bool
-	enableLinkRefactor             *bool
-	enableAPIKeyManagement         *bool
-	enableMetrics                  *bool
-	metricsHost                    *string
-	metricsPort                    *string
-	maxRevisionHistory             *int
-	editorLimit                    *int
-	enableHTTPRemoteUser           *bool
-	httpRemoteUserHeader           *string
-	enableHTTPRemoteUserAutoCreate *bool
-	httpRemoteUserEmailHeader      *string
-	httpRemoteUserDefaultRole      *string
-	trustedProxyIPs                *string
-	loginURL                       *string
-	logoutURL                      *string
-	httpRemoteUserLogoutURL        *string
-	userManagementURL              *string
-	defaultLanguage                *string
-	disableRequestLog              *bool
-	gitBackup                      *bool
-	gitBackupAuthorName            *string
-	gitBackupAuthorEmail           *string
-	gitBackupRemote                *string
-	gitBackupBranch                *string
-	gitBackupSSHKeyPath            *string
-	gitBackupSSHKey                *string
-	gitBackupSSHKnownHosts         *string
-	gitBackupHTTPUsername          *string
-	gitBackupHTTPPassword          *string
-	gitBackupInterval              *time.Duration
-	revisionCoalesceWindow         *time.Duration
-	snapshotEnabled                *bool
-	snapshotInterval               *time.Duration
-	snapshotRetention              *int
-	snapshotDir                    *string
-	restoreUploadMaxSize           *string
-	smtpHost                       *string
-	smtpPort                       *int
-	smtpUsername                   *string
-	smtpPassword                   *string
-	smtpFrom                       *string
-	smtpFromName                   *string
-	smtpSecurity                   *string
-	smtpInsecureSkipVerify         *bool
-	smtpTimeout                    *time.Duration
-	publicURL                      *string
-}
-
-func registerFlags(fs *flag.FlagSet) *cliFlags {
-	return &cliFlags{
-		logFormat:                      fs.String("log-format", "", "log output format: text or json (default: text)"),
-		host:                           fs.String("host", "", "host/IP address to bind the server to (e.g. 127.0.0.1 or 0.0.0.0)"),
-		port:                           fs.String("port", "", "port to run the server on"),
-		unixSocket:                     fs.String("unix-socket", "", "path to a unix domain socket to listen on; overrides --host and --port"),
-		dataDir:                        fs.String("data-dir", "", "path to data directory"),
-		adminUsername:                  fs.String("admin-username", "", "initial admin username (used only if no admin exists) (default: admin)"),
-		adminEmail:                     fs.String("admin-email", "", "initial admin email (used only if no admin exists) (default: admin@localhost)"),
-		adminPassword:                  fs.String("admin-password", "", "initial admin password, min 8 characters"),
-		jwtSecret:                      fs.String("jwt-secret", "", "JWT secret for authentication"),
-		totpEncryptionKey:              fs.String("totp-encryption-key", "", "key to encrypt per-user TOTP secrets at rest, min 32 bytes (leave unset to keep TOTP self-service unavailable)"),
-		publicAccess:                   fs.Bool("public-access", false, "allow public access to the wiki with read access (default: false)"),
-		allowInsecure:                  fs.Bool("allow-insecure", false, "allow insecure HTTP connections (default: false)"),
-		injectCodeInHeader:             fs.String("inject-code-in-header", "", "raw string injected into <head> (default: \"\")"),
-		customStylesheet:               fs.String("custom-stylesheet", "", "path to a custom CSS file served as /custom.css"),
-		disableAuth:                    fs.Bool("disable-auth", false, "disable authentication completely (default: false) (WARNING: only use in trusted networks!)"),
-		hideLinkMetadataSection:        fs.Bool("hide-link-metadata-section", false, "hide link metadata section (default: false)"),
-		accessTokenTimeout:             fs.Duration("access-token-timeout", 15*time.Minute, "access token timeout duration (e.g. 24h, 15m) (default: 15m)"),
-		refreshTokenTimeout:            fs.Duration("refresh-token-timeout", 7*24*time.Hour, "refresh token timeout duration (e.g. 168h) (default: 168h)"),
-		basePath:                       fs.String("base-path", "", "URL prefix when served behind a reverse proxy (e.g. /wiki)"),
-		maxAssetUploadSize:             fs.String("max-asset-upload-size", "", "maximum size for asset uploads (for example 50MiB, 50MB, 52428800)"),
-		enableRevision:                 fs.Bool("enable-revision", false, "enable the revision / page history feature (default: false)"),
-		enableLinkRefactor:             fs.Bool("enable-link-refactor", false, "enable the link refactoring dialog and rewrite flow (default: false)"),
-		enableAPIKeyManagement:         fs.Bool("enable-api-key-management", false, "enable the experimental API key management feature (default: false)"),
-		enableMetrics:                  fs.Bool("enable-metrics", false, "enable the Prometheus /metrics endpoint on a separate listener (default: false)"),
-		metricsHost:                    fs.String("metrics-host", "", "host/IP address for the Prometheus metrics listener (default: 127.0.0.1)"),
-		metricsPort:                    fs.String("metrics-port", "", "port for the Prometheus metrics listener (default: 9091)"),
-		maxRevisionHistory:             fs.Int("max-revision-history", 100, "maximum revisions kept per page; 0 = unlimited (default: 100)"),
-		editorLimit:                    fs.Int("editor-limit", 0, "maximum admin+editor users allowed; 0 = unlimited (default: 0)"),
-		enableHTTPRemoteUser:           fs.Bool("enable-http-remote-user", false, "enable reverse-proxy authentication via HTTP header (default: false)"),
-		httpRemoteUserHeader:           fs.String("http-remote-user-header-name", "Remote-User", "HTTP header name carrying the username or email from a trusted proxy (default: Remote-User)"),
-		enableHTTPRemoteUserAutoCreate: fs.Bool("enable-http-remote-user-auto-create", false, "auto-provision users asserted by the trusted proxy but unknown to LeafWiki (default: false)"),
-		httpRemoteUserEmailHeader:      fs.String("http-remote-user-email-header-name", "", "HTTP header name carrying the email for auto-created users (default: \"\")"),
-		httpRemoteUserDefaultRole:      fs.String("http-remote-user-default-role", "viewer", "role assigned to auto-created users; must not be \"admin\" (default: viewer)"),
-		trustedProxyIPs:                fs.String("trusted-proxy-ips", "", "comma-separated list of trusted proxy IPs/CIDRs (e.g. 127.0.0.1,172.18.0.0/16)"),
-		loginURL:                       fs.String("login-url", "", "URL the frontend redirects to instead of the built-in login form (e.g. an external SSO/IdP login page)"),
-		logoutURL:                      fs.String("logout-url", "", "URL the frontend redirects to after logout (e.g. an external SSO/IdP logout page)"),
-		httpRemoteUserLogoutURL:        fs.String("http-remote-user-logout-url", "", "deprecated: use --logout-url instead"),
-		userManagementURL:              fs.String("user-management-url", "", "URL to an external user-management page; when set, the built-in User Management UI is replaced with a link to this URL"),
-		defaultLanguage:                fs.String("default-language", "", "default UI language code for the frontend (e.g. en, de); must match a language shipped with the frontend, otherwise it is ignored"),
-		disableRequestLog:              fs.Bool("disable-request-log", false, "suppress per-request HTTP access log lines (default: false)"),
-		gitBackup:                      fs.Bool("git-backup", false, "enable git backup to a remote repository (default: false)"),
-		gitBackupAuthorName:            fs.String("git-backup-author-name", "", "git commit author name for backups (default: LeafWiki Backup)"),
-		gitBackupAuthorEmail:           fs.String("git-backup-author-email", "", "git commit author email for backups (default: backup@leafwiki.local)"),
-		gitBackupRemote:                fs.String("git-backup-remote", "", "git remote URL (SSH or HTTP(S)) for backups (required when git-backup is enabled)"),
-		gitBackupBranch:                fs.String("git-backup-branch", "", "git branch to push to (default: main)"),
-		gitBackupSSHKeyPath:            fs.String("git-backup-ssh-key-path", "", "path to SSH private key for git backup"),
-		gitBackupSSHKey:                fs.String(gitBackupSSHKeyFlagName, "", "raw SSH private key for git backup (env var preferred)"),
-		gitBackupSSHKnownHosts:         fs.String("git-backup-ssh-known-hosts", "", "path to known_hosts file for SSH host key verification (MITM protection)"),
-		gitBackupHTTPUsername:          fs.String("git-backup-http-username", "", "username for HTTP(S) basic auth on http(s):// remotes"),
-		gitBackupHTTPPassword:          fs.String(gitBackupHTTPPasswordFlagName, "", "password or access token for HTTP(S) basic auth (env var preferred)"),
-		gitBackupInterval:              fs.Duration("git-backup-interval", 60*time.Minute, "git backup interval (e.g. 60m, 2h); 0 = manual-only, no automatic scheduling (default: 60m)"),
-		revisionCoalesceWindow:         fs.Duration("revision-coalesce-window", 5*time.Minute, "window for coalescing rapid successive saves by the same author; 0 = disabled (default: 5m)"),
-		snapshotEnabled:                fs.Bool("snapshot", true, "enable full backup snapshots (ZIP incl. the SQLite database) (default: true)"),
-		snapshotInterval:               fs.Duration("snapshot-interval", 24*time.Hour, "snapshot interval (e.g. 24h, 6h); 0 = manual-only, no automatic scheduling (default: 24h)"),
-		snapshotRetention:              fs.Int("snapshot-retention", 10, "number of most recent snapshots to keep; <= 0 = keep all (default: 10)"),
-		snapshotDir:                    fs.String("snapshot-dir", "", "directory to store snapshot ZIPs in (default: <data-dir>/snapshots)"),
-		restoreUploadMaxSize:           fs.String("restore-upload-max-size", "", "maximum size for an uploaded backup ZIP to restore from (for example 500MiB, 500MB, 524288000) (default: 500MiB)"),
-		smtpHost:                       fs.String("smtp-host", "", "SMTP server host for password-reset/invite email; unset disables the feature entirely (default: \"\")"),
-		smtpPort:                       fs.Int("smtp-port", 587, "SMTP server port (default: 587)"),
-		smtpUsername:                   fs.String("smtp-username", "", "SMTP auth username"),
-		smtpPassword:                   fs.String("smtp-password", "", "SMTP auth password (env var preferred)"),
-		smtpFrom:                       fs.String("smtp-from", "", "From address for outgoing email (required when --smtp-host is set)"),
-		smtpFromName:                   fs.String("smtp-from-name", "LeafWiki", "From display name for outgoing email (default: LeafWiki)"),
-		smtpSecurity:                   fs.String("smtp-security", "starttls", "SMTP transport security: none, starttls, or tls (default: starttls)"),
-		smtpInsecureSkipVerify:         fs.Bool("smtp-insecure-skip-verify", false, "skip TLS certificate verification for SMTP (default: false; do not use in production)"),
-		smtpTimeout:                    fs.Duration("smtp-timeout", 10*time.Second, "timeout for a single SMTP send (e.g. 10s) (default: 10s)"),
-		publicURL:                      fs.String("public-url", "", "absolute base URL used to build links in outgoing email, e.g. https://wiki.example.com (required when --smtp-host is set)"),
-	}
-}
+// errLogged reports a failure that has already been logged through the
+// configured logger; errReported one that was written to stderr before the
+// logger existed. main exits on either without reporting it a second time.
+var (
+	errLogged   = errors.New("logged error")
+	errReported = errors.New("reported error")
+)
 
 func main() {
-	exitCode := 0
-	defer func() {
-		if exitCode != 0 {
-			os.Exit(exitCode)
+	// Errors that surface here come from flag parsing and validation, which
+	// happen before there is a configured logger - they are CLI diagnostics, so
+	// they go to stderr as plain text. Anything that fails once the logger is up
+	// logs itself and returns errLogged.
+	if err := newRootCommand().Run(context.Background(), os.Args); err != nil {
+		if !errors.Is(err, errLogged) && !errors.Is(err, errReported) {
+			fmt.Fprintln(os.Stderr, "Error:", err)
 		}
-	}()
+		os.Exit(1)
+	}
+}
 
-	flag.Usage = func() {
-		writeUsage(flag.CommandLine.Output())
+func runResetAdminPasswordCommand(cfg *serverConfig) error {
+	user, err := tools.ResetAdminPassword(cfg.server.dataDir, cfg.auth.adminUsername, cfg.auth.adminEmail)
+	if err != nil {
+		return fmt.Errorf("password reset failed: %w", err)
 	}
 
-	flags := registerFlags(flag.CommandLine)
-	flag.Parse()
+	fmt.Println("Admin password reset successfully.")
+	fmt.Printf("New password for user %s: %s\n", user.Username, user.Password)
+	return nil
+}
 
-	// Track which flags were explicitly set on CLI
-	visited := map[string]bool{}
-	flag.Visit(func(f *flag.Flag) { visited[f.Name] = true })
+// runServerCommand is the root action: with no subcommand given, leafwiki runs
+// the wiki server.
+func runServerCommand(_ context.Context, cmd *cli.Command, cfg *serverConfig) error {
+	basePath := normalizeBasePath(cfg.server.basePath)
+	maxAssetUploadSize := mustParseByteSize(cfg.frontend.maxAssetUploadSize, "max asset upload size")
+	restoreUploadMaxSize := mustParseByteSize(cfg.backup.restoreUploadMaxSize, "restore upload max size")
 
-	logFormat := resolveLogFormat("log-format", *flags.logFormat, visited, "LEAFWIKI_LOG_FORMAT", "text")
-	setupLogger(os.Stdout, logFormat)
+	// If disable-auth is set, the wiki is public regardless of --public-access.
+	publicAccess := cfg.auth.publicAccess
 
-	host := resolveString("host", *flags.host, visited, "LEAFWIKI_HOST", "127.0.0.1")
-	port := resolveString("port", *flags.port, visited, "LEAFWIKI_PORT", "8080")
-	unixSocket := resolveString("unix-socket", *flags.unixSocket, visited, "LEAFWIKI_UNIX_SOCKET", "")
-	dataDir := resolveString("data-dir", *flags.dataDir, visited, "LEAFWIKI_DATA_DIR", "./data")
-	adminPassword := resolveString("admin-password", *flags.adminPassword, visited, "LEAFWIKI_ADMIN_PASSWORD", "")
-	// Empty stays empty here; auth.UserService applies the "admin"/"admin@localhost"
-	// fallback itself, so that default lives in exactly one place.
-	adminUsername := resolveString("admin-username", *flags.adminUsername, visited, "LEAFWIKI_ADMIN_USERNAME", "")
-	adminEmail := resolveString("admin-email", *flags.adminEmail, visited, "LEAFWIKI_ADMIN_EMAIL", "")
-	jwtSecret := resolveString("jwt-secret", *flags.jwtSecret, visited, "LEAFWIKI_JWT_SECRET", "")
-	totpEncryptionKey := resolveString("totp-encryption-key", *flags.totpEncryptionKey, visited, "LEAFWIKI_TOTP_ENCRYPTION_KEY", "")
-	injectCodeInHeader := resolveString("inject-code-in-header", *flags.injectCodeInHeader, visited, "LEAFWIKI_INJECT_CODE_IN_HEADER", "")
-	customStylesheet := resolveString("custom-stylesheet", *flags.customStylesheet, visited, "LEAFWIKI_CUSTOM_STYLESHEET", "")
-	allowInsecure := resolveBool("allow-insecure", *flags.allowInsecure, visited, "LEAFWIKI_ALLOW_INSECURE")
-	publicAccess := resolveBool("public-access", *flags.publicAccess, visited, "LEAFWIKI_PUBLIC_ACCESS")
-	hideLinkMetadataSection := resolveBool("hide-link-metadata-section", *flags.hideLinkMetadataSection, visited, "LEAFWIKI_HIDE_LINK_METADATA_SECTION")
-	accessTokenTimeout := resolveDuration("access-token-timeout", *flags.accessTokenTimeout, visited, "LEAFWIKI_ACCESS_TOKEN_TIMEOUT")
-	refreshTokenTimeout := resolveDuration("refresh-token-timeout", *flags.refreshTokenTimeout, visited, "LEAFWIKI_REFRESH_TOKEN_TIMEOUT")
-	// If disable-auth is set, later logic will override publicAccess accordingly
-	disableAuth := resolveBool("disable-auth", *flags.disableAuth, visited, "LEAFWIKI_DISABLE_AUTH")
-	basePath := normalizeBasePath(resolveString("base-path", *flags.basePath, visited, "LEAFWIKI_BASE_PATH", ""))
-	maxAssetUploadSize := parseByteSize(
-		resolveString("max-asset-upload-size", *flags.maxAssetUploadSize, visited, "LEAFWIKI_MAX_ASSET_UPLOAD_SIZE", "50MiB"),
-		"max asset upload size",
-	)
-	restoreUploadMaxSize := parseByteSize(
-		resolveString("restore-upload-max-size", *flags.restoreUploadMaxSize, visited, "LEAFWIKI_RESTORE_UPLOAD_MAX_SIZE", "500MiB"),
-		"restore upload max size",
-	)
-	enableRevision := resolveBool("enable-revision", *flags.enableRevision, visited, "LEAFWIKI_ENABLE_REVISION")
-	enableLinkRefactor := resolveBool("enable-link-refactor", *flags.enableLinkRefactor, visited, "LEAFWIKI_ENABLE_LINK_REFACTOR")
-	enableAPIKeyManagement := resolveBool("enable-api-key-management", *flags.enableAPIKeyManagement, visited, "LEAFWIKI_ENABLE_API_KEY_MANAGEMENT")
-	enableMetrics := resolveBool("enable-metrics", *flags.enableMetrics, visited, "LEAFWIKI_ENABLE_METRICS")
-	metricsHost := resolveString("metrics-host", *flags.metricsHost, visited, "LEAFWIKI_METRICS_HOST", "127.0.0.1")
-	metricsPort := resolveString("metrics-port", *flags.metricsPort, visited, "LEAFWIKI_METRICS_PORT", "9091")
-	maxRevisionHistory := resolveInt("max-revision-history", *flags.maxRevisionHistory, visited, "LEAFWIKI_MAX_REVISION_HISTORY", 100)
-	editorLimit := resolveInt("editor-limit", *flags.editorLimit, visited, "LEAFWIKI_EDITOR_LIMIT", 0)
-	revisionCoalesceWindow := resolveDuration("revision-coalesce-window", *flags.revisionCoalesceWindow, visited, "LEAFWIKI_REVISION_COALESCE_WINDOW")
-	enableHTTPRemoteUser := resolveBool("enable-http-remote-user", *flags.enableHTTPRemoteUser, visited, "LEAFWIKI_ENABLE_HTTP_REMOTE_USER")
-	httpRemoteUserHeader := resolveString("http-remote-user-header-name", *flags.httpRemoteUserHeader, visited, "LEAFWIKI_HTTP_REMOTE_USER_HEADER_NAME", "Remote-User")
-	enableHTTPRemoteUserAutoCreate := resolveBool("enable-http-remote-user-auto-create", *flags.enableHTTPRemoteUserAutoCreate, visited, "LEAFWIKI_ENABLE_HTTP_REMOTE_USER_AUTO_CREATE")
-	httpRemoteUserEmailHeader := resolveString("http-remote-user-email-header-name", *flags.httpRemoteUserEmailHeader, visited, "LEAFWIKI_HTTP_REMOTE_USER_EMAIL_HEADER_NAME", "")
-	httpRemoteUserDefaultRole := resolveString("http-remote-user-default-role", *flags.httpRemoteUserDefaultRole, visited, "LEAFWIKI_HTTP_REMOTE_USER_DEFAULT_ROLE", "viewer")
-	trustedProxyIPsRaw := resolveString("trusted-proxy-ips", *flags.trustedProxyIPs, visited, "LEAFWIKI_TRUSTED_PROXY_IPS", "")
-	loginURL := resolveString("login-url", *flags.loginURL, visited, "LEAFWIKI_LOGIN_URL", "")
-	logoutURL := resolveString("logout-url", *flags.logoutURL, visited, "LEAFWIKI_LOGOUT_URL", "")
-	if resolved, usedDeprecated := resolveLogoutURL(logoutURL, *flags.httpRemoteUserLogoutURL, visited, "LEAFWIKI_HTTP_REMOTE_USER_LOGOUT_URL"); usedDeprecated {
+	logoutURL := cfg.proxy.logoutURL
+	if resolved, usedDeprecated := resolveLogoutURL(logoutURL, cfg.proxy.httpRemoteUserLogoutURL); usedDeprecated {
 		slog.Default().Warn("--http-remote-user-logout-url/LEAFWIKI_HTTP_REMOTE_USER_LOGOUT_URL is deprecated, use --logout-url/LEAFWIKI_LOGOUT_URL instead")
 		logoutURL = resolved
 	}
-	userManagementURL := resolveString("user-management-url", *flags.userManagementURL, visited, "LEAFWIKI_USER_MANAGEMENT_URL", "")
-	defaultLanguage := resolveString("default-language", *flags.defaultLanguage, visited, "LEAFWIKI_DEFAULT_LANGUAGE", "")
-	disableRequestLog := resolveBool("disable-request-log", *flags.disableRequestLog, visited, "LEAFWIKI_DISABLE_REQUEST_LOG")
-	gitBackupEnabled := resolveBool("git-backup", *flags.gitBackup, visited, "LEAFWIKI_GIT_BACKUP")
-	gitBackupAuthorName := resolveString("git-backup-author-name", *flags.gitBackupAuthorName, visited, "LEAFWIKI_GIT_BACKUP_AUTHOR_NAME", "LeafWiki Backup")
-	gitBackupAuthorEmail := resolveString("git-backup-author-email", *flags.gitBackupAuthorEmail, visited, "LEAFWIKI_GIT_BACKUP_AUTHOR_EMAIL", "backup@leafwiki.local")
-	gitBackupRemote := resolveString("git-backup-remote", *flags.gitBackupRemote, visited, "LEAFWIKI_GIT_BACKUP_REMOTE", "")
-	gitBackupBranch := resolveString("git-backup-branch", *flags.gitBackupBranch, visited, "LEAFWIKI_GIT_BACKUP_BRANCH", "main")
-	gitBackupSSHKeyPath := resolveString("git-backup-ssh-key-path", *flags.gitBackupSSHKeyPath, visited, "LEAFWIKI_GIT_BACKUP_SSH_KEY_PATH", "")
-	gitBackupSSHKey := resolveString(gitBackupSSHKeyFlagName, *flags.gitBackupSSHKey, visited, "LEAFWIKI_GIT_BACKUP_SSH_KEY", "")
-	gitBackupInterval := resolveDuration("git-backup-interval", *flags.gitBackupInterval, visited, "LEAFWIKI_GIT_BACKUP_INTERVAL")
-	gitBackupSSHKnownHosts := resolveString("git-backup-ssh-known-hosts", *flags.gitBackupSSHKnownHosts, visited, "LEAFWIKI_GIT_BACKUP_SSH_KNOWN_HOSTS", "")
-	gitBackupHTTPUsername := resolveString("git-backup-http-username", *flags.gitBackupHTTPUsername, visited, "LEAFWIKI_GIT_BACKUP_HTTP_USERNAME", "")
-	gitBackupHTTPPassword := resolveString(gitBackupHTTPPasswordFlagName, *flags.gitBackupHTTPPassword, visited, "LEAFWIKI_GIT_BACKUP_HTTP_PASSWORD", "")
-	snapshotEnabled := resolveBool("snapshot", *flags.snapshotEnabled, visited, "LEAFWIKI_SNAPSHOT")
-	snapshotInterval := resolveDuration("snapshot-interval", *flags.snapshotInterval, visited, "LEAFWIKI_SNAPSHOT_INTERVAL")
-	snapshotRetention := resolveInt("snapshot-retention", *flags.snapshotRetention, visited, "LEAFWIKI_SNAPSHOT_RETENTION", 10)
-	snapshotDir := resolveString("snapshot-dir", *flags.snapshotDir, visited, "LEAFWIKI_SNAPSHOT_DIR", "")
-	smtpHost := resolveString("smtp-host", *flags.smtpHost, visited, "LEAFWIKI_SMTP_HOST", "")
-	smtpPort := resolveInt("smtp-port", *flags.smtpPort, visited, "LEAFWIKI_SMTP_PORT", 587)
-	smtpUsername := resolveString("smtp-username", *flags.smtpUsername, visited, "LEAFWIKI_SMTP_USERNAME", "")
-	smtpPassword := resolveString("smtp-password", *flags.smtpPassword, visited, "LEAFWIKI_SMTP_PASSWORD", "")
-	smtpFrom := resolveString("smtp-from", *flags.smtpFrom, visited, "LEAFWIKI_SMTP_FROM", "")
-	smtpFromName := resolveString("smtp-from-name", *flags.smtpFromName, visited, "LEAFWIKI_SMTP_FROM_NAME", "LeafWiki")
-	smtpSecurity := resolveString("smtp-security", *flags.smtpSecurity, visited, "LEAFWIKI_SMTP_SECURITY", "starttls")
-	smtpInsecureSkipVerify := resolveBool("smtp-insecure-skip-verify", *flags.smtpInsecureSkipVerify, visited, "LEAFWIKI_SMTP_INSECURE_SKIP_VERIFY")
-	smtpTimeout := resolveDuration("smtp-timeout", *flags.smtpTimeout, visited, "LEAFWIKI_SMTP_TIMEOUT")
-	publicURL := resolveString("public-url", *flags.publicURL, visited, "LEAFWIKI_PUBLIC_URL", "")
-	smtpEnabled := smtpHost != ""
-	trustedProxies, err := authmw.ParseTrustedProxies(trustedProxyIPsRaw)
+
+	smtpEnabled := cfg.email.smtpHost != ""
+
+	trustedProxies, err := authmw.ParseTrustedProxies(cfg.proxy.trustedProxyIPs)
 	if err != nil {
 		fail("invalid --trusted-proxy-ips value", "error", err)
 	}
-	if err := validateListenConfig(unixSocket, visited); err != nil {
+	if err := validateListenConfig(cfg.server.unixSocket, cmd.IsSet("host"), cmd.IsSet("port")); err != nil {
 		fail("Invalid listen configuration", "error", err)
 	}
 
-	if err := validateHTTPRemoteUserConfig(enableHTTPRemoteUser, trustedProxyIPsRaw); err != nil {
+	if err := validateHTTPRemoteUserConfig(cfg.proxy.enableHTTPRemoteUser, cfg.proxy.trustedProxyIPs); err != nil {
 		fail("Invalid HTTP remote user configuration", "error", err)
 	}
 
-	if err := validateHTTPRemoteUserAutoCreateConfig(enableHTTPRemoteUserAutoCreate, enableHTTPRemoteUser, httpRemoteUserDefaultRole); err != nil {
+	if err := validateHTTPRemoteUserAutoCreateConfig(cfg.proxy.enableHTTPRemoteUserAutoCreate, cfg.proxy.enableHTTPRemoteUser, cfg.proxy.httpRemoteUserDefaultRole); err != nil {
 		fail("Invalid HTTP remote user auto-create configuration", "error", err)
 	}
 
-	if err := validateRedirectURL("login-url", loginURL); err != nil {
-		fail("Invalid login URL configuration", "error", err)
-	}
-	if err := validateRedirectURL("logout-url", logoutURL); err != nil {
-		fail("Invalid logout URL configuration", "error", err)
-	}
-
-	if err := validateSMTPConfig(smtpHost, smtpFrom, publicURL, smtpSecurity); err != nil {
+	if err := validateSMTPConfig(cfg.email.smtpHost, cfg.email.smtpFrom, cfg.email.publicURL, cfg.email.smtpSecurity); err != nil {
 		fail("Invalid SMTP configuration", "error", err)
 	}
 	if smtpEnabled {
 		// A misconfigured public URL produces broken links in emails that
 		// have already gone out — irreversible — so log the resolved value
 		// once at boot rather than only on first use.
-		slog.Default().Info("SMTP email enabled", "host", smtpHost, "port", smtpPort, "security", smtpSecurity, "publicUrl", publicURL)
-	}
-	if err := validateRedirectURL("user-management-url", userManagementURL); err != nil {
-		fail("Invalid user management URL configuration", "error", err)
+		slog.Default().Info("SMTP email enabled", "host", cfg.email.smtpHost, "port", cfg.email.smtpPort, "security", cfg.email.smtpSecurity, "publicUrl", cfg.email.publicURL)
 	}
 
-	if enableHTTPRemoteUser {
+	if cfg.proxy.enableHTTPRemoteUser {
 		slog.Default().Info("Reverse-proxy authentication enabled",
-			"header", httpRemoteUserHeader,
-			"trusted_proxies", trustedProxyIPsRaw,
-			"auto_create", enableHTTPRemoteUserAutoCreate,
-			"default_role", httpRemoteUserDefaultRole,
+			"header", cfg.proxy.httpRemoteUserHeader,
+			"trusted_proxies", cfg.proxy.trustedProxyIPs,
+			"auto_create", cfg.proxy.enableHTTPRemoteUserAutoCreate,
+			"default_role", cfg.proxy.httpRemoteUserDefaultRole,
 		)
 	}
-	if enableMetrics {
+	if cfg.metrics.enableMetrics {
 		slog.Default().Info("Prometheus metrics enabled",
-			"metrics_host", metricsHost,
-			"metrics_port", metricsPort,
+			"metrics_host", cfg.metrics.metricsHost,
+			"metrics_port", cfg.metrics.metricsPort,
 		)
 	}
 
 	// Validate git backup configuration
 	// Note: git-backup-remote is optional (local-only mode is supported)
-	if gitBackupEnabled {
-		if err := validateGitBackupRemote(gitBackupRemote, gitBackupSSHKey, gitBackupSSHKeyPath, gitBackupHTTPUsername, gitBackupHTTPPassword); err != nil {
+	if cfg.backup.gitBackup {
+		if err := validateGitBackupRemote(cfg.backup.gitBackupRemote, cfg.backup.gitBackupSSHKey, cfg.backup.gitBackupSSHKeyPath, cfg.backup.gitBackupHTTPUsername, cfg.backup.gitBackupHTTPPassword); err != nil {
 			fail("Invalid git backup configuration", "error", err)
 		}
 	}
 
-	args := flag.Args()
-	if len(args) > 0 {
-		switch args[0] {
-		case "reset-admin-password":
-			user, err := tools.ResetAdminPassword(dataDir, adminUsername, adminEmail)
-			if err != nil {
-				fail("Password reset failed", "error", err)
-			}
-
-			fmt.Println("Admin password reset successfully.")
-			fmt.Printf("New password for user %s: %s\n", user.Username, user.Password)
-			return
-		case "restore-snapshot":
-			if err := runRestoreSnapshotCommand(dataDir, args); err != nil {
-				if errors.Is(err, errRestoreSnapshotUsage) {
-					fail(err.Error())
-				} else {
-					fail("Restore failed", "error", err)
-				}
-			}
-			fmt.Println("Snapshot restored successfully. Start the server normally to pick up the restored data.")
-			return
-		case "--help", "-h", "help":
-			printUsage()
-			return
-		default:
-			fmt.Printf("Unknown command: %s\n\n", args[0])
-			printUsage()
-			return
-		}
-	}
-
-	if disableAuth {
+	if cfg.auth.disableAuth {
 		publicAccess = true
 		slog.Default().Warn("Authentication disabled. Wiki is publicly accessible without authentication.")
 	}
 
-	if allowInsecure {
+	if cfg.server.allowInsecure {
 		slog.Default().Warn("allow-insecure enabled. Auth cookies may be transmitted over plain HTTP (INSECURE).")
 	}
 
 	// Check if data directory exists
-	if _, err := os.Stat(dataDir); os.IsNotExist(err) {
-		if err := os.MkdirAll(dataDir, 0755); err != nil {
+	if _, err := os.Stat(cfg.server.dataDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(cfg.server.dataDir, 0755); err != nil {
 			fail("Failed to create data directory", "error", err)
 		}
-		slog.Default().Info("Data directory created", "path", dataDir)
+		slog.Default().Info("Data directory created", "path", cfg.server.dataDir)
 	}
 
-	if !disableAuth {
-		if jwtSecret == "" {
+	if !cfg.auth.disableAuth {
+		if cfg.auth.jwtSecret == "" {
 			fail("JWT secret is required. Set it using --jwt-secret or LEAFWIKI_JWT_SECRET environment variable.")
 		}
 
-		if adminPassword == "" {
+		if cfg.auth.adminPassword == "" {
 			fail("admin password is required. Set it using --admin-password or LEAFWIKI_ADMIN_PASSWORD environment variable.")
 		}
 	}
 
-	if totpEncryptionKey != "" && len(totpEncryptionKey) < auth.MinTOTPEncryptionKeyLen {
-		fail("--totp-encryption-key/LEAFWIKI_TOTP_ENCRYPTION_KEY is too short", "minimum_bytes", auth.MinTOTPEncryptionKeyLen, "got", len(totpEncryptionKey))
-	}
-
 	var metrics *httpmetrics.HTTPMetrics
-	if enableMetrics {
+	if cfg.metrics.enableMetrics {
 		metrics = httpmetrics.NewHTTPMetrics(Version)
 	}
 
 	w, err := wiki.NewWiki(&wiki.WikiOptions{
-		StorageDir:             dataDir,
-		AdminUsername:          adminUsername,
-		AdminEmail:             adminEmail,
-		AdminPassword:          adminPassword,
-		JWTSecret:              jwtSecret,
-		TOTPEncryptionKey:      totpEncryptionKey,
-		AccessTokenTimeout:     accessTokenTimeout,
-		RefreshTokenTimeout:    refreshTokenTimeout,
-		AuthDisabled:           disableAuth,
-		EnableRevision:         enableRevision,
-		EnableAPIKeyManagement: enableAPIKeyManagement,
-		MaxRevisionHistory:     maxRevisionHistory,
-		EditorLimit:            editorLimit,
-		RevisionCoalesceWindow: revisionCoalesceWindow,
+		StorageDir:             cfg.server.dataDir,
+		AdminUsername:          cfg.auth.adminUsername,
+		AdminEmail:             cfg.auth.adminEmail,
+		AdminPassword:          cfg.auth.adminPassword,
+		JWTSecret:              cfg.auth.jwtSecret,
+		TOTPEncryptionKey:      cfg.auth.totpEncryptionKey,
+		AccessTokenTimeout:     cfg.auth.accessTokenTimeout,
+		RefreshTokenTimeout:    cfg.auth.refreshTokenTimeout,
+		AuthDisabled:           cfg.auth.disableAuth,
+		EnableRevision:         cfg.frontend.enableRevision,
+		EnableAPIKeyManagement: cfg.frontend.enableAPIKeyManagement,
+		MaxRevisionHistory:     cfg.frontend.maxRevisionHistory,
+		EditorLimit:            cfg.auth.editorLimit,
+		RevisionCoalesceWindow: cfg.frontend.revisionCoalesceWindow,
 		SMTP: email.Config{
-			Host:               smtpHost,
-			Port:               smtpPort,
-			Username:           smtpUsername,
-			Password:           smtpPassword,
-			From:               smtpFrom,
-			FromName:           smtpFromName,
-			Security:           email.Security(smtpSecurity),
-			InsecureSkipVerify: smtpInsecureSkipVerify,
-			Timeout:            smtpTimeout,
-			PublicURL:          publicURL,
+			Host:               cfg.email.smtpHost,
+			Port:               cfg.email.smtpPort,
+			Username:           cfg.email.smtpUsername,
+			Password:           cfg.email.smtpPassword,
+			From:               cfg.email.smtpFrom,
+			FromName:           cfg.email.smtpFromName,
+			Security:           email.Security(cfg.email.smtpSecurity),
+			InsecureSkipVerify: cfg.email.smtpInsecureSkipVerify,
+			Timeout:            cfg.email.smtpTimeout,
+			PublicURL:          cfg.email.publicURL,
 		},
 		Metrics: metrics,
 	})
@@ -652,7 +262,7 @@ func main() {
 	}
 
 	// Log .leafwikiignore status
-	rootDir := filepath.Join(dataDir, "root")
+	rootDir := filepath.Join(cfg.server.dataDir, "root")
 	if ignoreFile, err := ignore.LoadFromDir(rootDir); err != nil {
 		slog.Default().Warn("invalid .leafwikiignore", "error", err)
 	} else if ignoreFile != nil {
@@ -667,30 +277,30 @@ func main() {
 
 	// Initialize git backup if enabled
 	var backupScheduler *backup.Scheduler
-	if gitBackupEnabled {
-		if visited[gitBackupSSHKeyFlagName] {
+	if cfg.backup.gitBackup {
+		if cfg.backup.gitBackupSSHKey != "" && os.Getenv("LEAFWIKI_GIT_BACKUP_SSH_KEY") == "" {
 			slog.Warn("SSH private key passed via --git-backup-ssh-key flag is visible in process listings; prefer the LEAFWIKI_GIT_BACKUP_SSH_KEY environment variable")
 		}
-		if visited[gitBackupHTTPPasswordFlagName] {
+		if cfg.backup.gitBackupHTTPPassword != "" && os.Getenv("LEAFWIKI_GIT_BACKUP_HTTP_PASSWORD") == "" {
 			slog.Warn("HTTP password passed via --git-backup-http-password flag is visible in process listings; prefer the LEAFWIKI_GIT_BACKUP_HTTP_PASSWORD environment variable")
 		}
-		if strings.HasPrefix(strings.ToLower(gitBackupRemote), "http://") {
+		if strings.HasPrefix(strings.ToLower(cfg.backup.gitBackupRemote), "http://") {
 			slog.Warn("--git-backup-remote uses plain http://; git backup credentials and wiki content are transmitted unencrypted — use https:// unless the remote is on a trusted network")
 		}
 		backupRepo, err := backup.Init(backup.Config{
 			Enabled:           true,
-			RootDir:           filepath.Join(dataDir, "root"),
-			AssetsDir:         filepath.Join(dataDir, "assets"),
-			AuthorName:        gitBackupAuthorName,
-			AuthorEmail:       gitBackupAuthorEmail,
-			RemoteURL:         gitBackupRemote,
-			Branch:            gitBackupBranch,
-			SSHKeyPath:        gitBackupSSHKeyPath,
-			SSHKey:            gitBackupSSHKey,
-			SSHKnownHostsPath: gitBackupSSHKnownHosts,
-			HTTPUsername:      gitBackupHTTPUsername,
-			HTTPPassword:      gitBackupHTTPPassword,
-			Interval:          gitBackupInterval,
+			RootDir:           filepath.Join(cfg.server.dataDir, "root"),
+			AssetsDir:         filepath.Join(cfg.server.dataDir, "assets"),
+			AuthorName:        cfg.backup.gitBackupAuthorName,
+			AuthorEmail:       cfg.backup.gitBackupAuthorEmail,
+			RemoteURL:         cfg.backup.gitBackupRemote,
+			Branch:            cfg.backup.gitBackupBranch,
+			SSHKeyPath:        cfg.backup.gitBackupSSHKeyPath,
+			SSHKey:            cfg.backup.gitBackupSSHKey,
+			SSHKnownHostsPath: cfg.backup.gitBackupSSHKnownHosts,
+			HTTPUsername:      cfg.backup.gitBackupHTTPUsername,
+			HTTPPassword:      cfg.backup.gitBackupHTTPPassword,
+			Interval:          cfg.backup.gitBackupInterval,
 		})
 		if err != nil {
 			fail("git backup init failed: %v", err)
@@ -702,35 +312,35 @@ func main() {
 
 	// Initialize full backup snapshots if enabled
 	var writeGate *restore.WriteGate
-	if snapshotEnabled {
-		snapshotsDir := snapshotDir
+	if cfg.backup.snapshot {
+		snapshotsDir := cfg.backup.snapshotDir
 		if snapshotsDir == "" {
-			snapshotsDir = filepath.Join(dataDir, "snapshots")
+			snapshotsDir = filepath.Join(cfg.server.dataDir, "snapshots")
 		}
 		snapshotManager := snapshot.NewManager(snapshot.Config{
 			BackupsDir:         snapshotsDir,
-			RootDir:            filepath.Join(dataDir, "root"),
-			AssetsDir:          filepath.Join(dataDir, "assets"),
-			BrandingDir:        filepath.Join(dataDir, "branding"),
-			AvatarsDir:         filepath.Join(dataDir, "avatars"),
-			BrandingConfigFile: filepath.Join(dataDir, "branding.json"),
-			SchemaFile:         filepath.Join(dataDir, "schema.json"),
-			UsersDBPath:        filepath.Join(dataDir, "users.db"),
-			APIKeysDBPath:      filepath.Join(dataDir, "api_keys.db"),
-			FavoritesDBPath:    filepath.Join(dataDir, "favorites.db"),
-			UserSettingsDBPath: filepath.Join(dataDir, "usersettings.db"),
+			RootDir:            filepath.Join(cfg.server.dataDir, "root"),
+			AssetsDir:          filepath.Join(cfg.server.dataDir, "assets"),
+			BrandingDir:        filepath.Join(cfg.server.dataDir, "branding"),
+			AvatarsDir:         filepath.Join(cfg.server.dataDir, "avatars"),
+			BrandingConfigFile: filepath.Join(cfg.server.dataDir, "branding.json"),
+			SchemaFile:         filepath.Join(cfg.server.dataDir, "schema.json"),
+			UsersDBPath:        filepath.Join(cfg.server.dataDir, "users.db"),
+			APIKeysDBPath:      filepath.Join(cfg.server.dataDir, "api_keys.db"),
+			FavoritesDBPath:    filepath.Join(cfg.server.dataDir, "favorites.db"),
+			UserSettingsDBPath: filepath.Join(cfg.server.dataDir, "usersettings.db"),
 			WikiVersion:        Version,
-			Interval:           snapshotInterval,
-			RetentionCount:     snapshotRetention,
+			Interval:           cfg.backup.snapshotInterval,
+			RetentionCount:     cfg.backup.snapshotRetention,
 		})
 		snapshotScheduler := snapshot.NewScheduler(snapshotManager)
 		defer snapshotScheduler.Stop()
-		w.SetSnapshotRoutes(wikisnapshot.NewRoutes(snapshotManager, snapshotScheduler, w.AuthService(), snapshotRetention))
+		w.SetSnapshotRoutes(wikisnapshot.NewRoutes(snapshotManager, snapshotScheduler, w.AuthService(), cfg.backup.snapshotRetention))
 
 		writeGate = restore.NewWriteGate()
 		restoreManager := restore.NewManager(restore.Config{
 			SnapshotManager:    snapshotManager,
-			DataDir:            dataDir,
+			DataDir:            cfg.server.dataDir,
 			WikiVersion:        Version,
 			WriteGate:          writeGate,
 			AuthService:        w.AuthService(),
@@ -751,38 +361,38 @@ func main() {
 
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
 		PublicAccess:            publicAccess,
-		EditorLimit:             editorLimit,
-		InjectCodeInHeader:      injectCodeInHeader,
-		CustomStylesheet:        customStylesheet,
-		AllowInsecure:           allowInsecure,
-		HideLinkMetadataSection: hideLinkMetadataSection,
-		AccessTokenTimeout:      accessTokenTimeout,
-		RefreshTokenTimeout:     refreshTokenTimeout,
-		AuthDisabled:            disableAuth,
+		EditorLimit:             cfg.auth.editorLimit,
+		InjectCodeInHeader:      cfg.frontend.injectCodeInHeader,
+		CustomStylesheet:        cfg.frontend.customStylesheet,
+		AllowInsecure:           cfg.server.allowInsecure,
+		HideLinkMetadataSection: cfg.frontend.hideLinkMetadataSection,
+		AccessTokenTimeout:      cfg.auth.accessTokenTimeout,
+		RefreshTokenTimeout:     cfg.auth.refreshTokenTimeout,
+		AuthDisabled:            cfg.auth.disableAuth,
 		BasePath:                basePath,
 		MaxAssetUploadSizeBytes: maxAssetUploadSize,
-		EnableRevision:          enableRevision,
-		EnableLinkRefactor:      enableLinkRefactor,
-		EnableAPIKeyManagement:  enableAPIKeyManagement,
+		EnableRevision:          cfg.frontend.enableRevision,
+		EnableLinkRefactor:      cfg.frontend.enableLinkRefactor,
+		EnableAPIKeyManagement:  cfg.frontend.enableAPIKeyManagement,
 		Metrics:                 metrics,
-		GitBackupEnabled:        gitBackupEnabled,
-		SnapshotEnabled:         snapshotEnabled,
+		GitBackupEnabled:        cfg.backup.gitBackup,
+		SnapshotEnabled:         cfg.backup.snapshot,
 		SMTPEnabled:             smtpEnabled,
 		TOTPAvailable:           w.TOTPService() != nil,
 		HTTPRemoteUser: httpinternal.HTTPRemoteUserConfig{
-			Enabled:         enableHTTPRemoteUser,
-			HeaderName:      httpRemoteUserHeader,
-			AutoCreate:      enableHTTPRemoteUserAutoCreate,
-			EmailHeaderName: httpRemoteUserEmailHeader,
-			DefaultRole:     httpRemoteUserDefaultRole,
+			Enabled:         cfg.proxy.enableHTTPRemoteUser,
+			HeaderName:      cfg.proxy.httpRemoteUserHeader,
+			AutoCreate:      cfg.proxy.enableHTTPRemoteUserAutoCreate,
+			EmailHeaderName: cfg.proxy.httpRemoteUserEmailHeader,
+			DefaultRole:     cfg.proxy.httpRemoteUserDefaultRole,
 			TrustedProxies:  trustedProxies,
 			UserService:     w.UserService,
 		},
 		APIKeyService:     w.APIKeyService(),
-		DisableRequestLog: disableRequestLog,
-		UserManagementURL: userManagementURL,
-		DefaultLanguage:   defaultLanguage,
-		LoginURL:          loginURL,
+		DisableRequestLog: cfg.server.disableRequestLog,
+		UserManagementURL: cfg.proxy.userManagementURL,
+		DefaultLanguage:   cfg.frontend.defaultLanguage,
+		LoginURL:          cfg.proxy.loginURL,
 		LogoutURL:         logoutURL,
 		WriteGate:         writeGate,
 	})
@@ -795,11 +405,12 @@ func main() {
 	signal.Notify(shutdownSignals, syscall.SIGINT, syscall.SIGTERM)
 	defer signal.Stop(shutdownSignals)
 
-	if err := runServer(router, host, port, unixSocket, dataDir, metrics, metricsHost, metricsPort, w.TriggerResyncAsync, reloadSignals, shutdownSignals); err != nil {
+	if err := runServer(router, cfg.server.host, cfg.server.port, cfg.server.unixSocket, cfg.server.dataDir, metrics, cfg.metrics.metricsHost, cfg.metrics.metricsPort, w.TriggerResyncAsync, reloadSignals, shutdownSignals); err != nil {
 		slog.Default().Error("Failed to start server", "error", err)
-		exitCode = 1
-		return
+		return errLogged
 	}
+
+	return nil
 }
 
 func runServer(
@@ -928,38 +539,6 @@ func removeStaleUnixSocket(socketPath string) error {
 	return err
 }
 
-// CLI > ENV > default(flag)
-func resolveString(flagName, flagVal string, visited map[string]bool, envVar string, def string) string {
-	// If flag was explicitly set, it takes precedence
-	if visited[flagName] {
-		return strings.TrimSpace(flagVal)
-	}
-	// Next, check environment variable
-	if env := strings.TrimSpace(os.Getenv(envVar)); env != "" {
-		return env
-	}
-	// Fall back to provided default when flag wasn't set and no env var is present
-	return def
-}
-
-// CLI > ENV > default
-func resolveLogFormat(flagName, flagVal string, visited map[string]bool, envVar string, def string) string {
-	if visited[flagName] {
-		if f, ok := parseLogFormat(flagVal); ok {
-			return f
-		}
-		fail("Invalid flag value", "flag", flagName, "value", flagVal, "expected", "text or json")
-	}
-	if env := strings.TrimSpace(os.Getenv(envVar)); env != "" {
-		if f, ok := parseLogFormat(env); ok {
-			return f
-		}
-		// If env var is set but invalid, fail fast (helps operators)
-		fail(errInvalidEnvVarValue, "variable", envVar, "value", env, "expected", "text or json")
-	}
-	return def
-}
-
 func parseLogFormat(s string) (string, bool) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "text":
@@ -968,63 +547,6 @@ func parseLogFormat(s string) (string, bool) {
 		return "json", true
 	}
 	return "", false
-}
-
-// CLI > ENV > default(flag)
-func resolveBool(flagName string, flagVal bool, visited map[string]bool, envVar string) bool {
-	if visited[flagName] {
-		return flagVal
-	}
-	if env := strings.TrimSpace(os.Getenv(envVar)); env != "" {
-		if b, ok := parseBool(env); ok {
-			return b
-		}
-		// If env var is set but invalid, fail fast (helps operators)
-		fail(errInvalidEnvVarValue, "variable", envVar, "value", env, "expected", "true/false/1/0/yes/no")
-	}
-	return flagVal // default from flag
-}
-
-func resolveInt(flagName string, flagVal int, visited map[string]bool, envVar string, def int) int {
-	if visited[flagName] {
-		return flagVal
-	}
-	if env := strings.TrimSpace(os.Getenv(envVar)); env != "" {
-		var n int
-		if _, err := fmt.Sscanf(env, "%d", &n); err == nil {
-			return n
-		}
-		fail(errInvalidEnvVarValue, "variable", envVar, "value", env, "expected", "integer")
-	}
-	return def
-}
-
-func resolveDuration(flagName string, flagVal time.Duration, visited map[string]bool, envVar string) time.Duration {
-	if visited[flagName] {
-		return flagVal
-	}
-	if env := strings.TrimSpace(os.Getenv(envVar)); env != "" {
-		if d, ok := parseDuration(env); ok {
-			return d
-		}
-		// If env var is set but invalid, fail fast (helps operators)
-		fail(errInvalidEnvVarValue, "variable", envVar, "value", env, "expected", "duration like 24h, 15m")
-	}
-	return flagVal // default from flag
-}
-
-func parseByteSize(raw string, label string) int64 {
-	size, err := humanize.ParseBytes(strings.TrimSpace(raw))
-	if err != nil {
-		fail("Invalid byte size value", "setting", label, "value", raw, "error", err)
-	}
-	if size == 0 {
-		fail("Byte size value must be greater than zero", "setting", label, "value", raw)
-	}
-	if size > math.MaxInt64 {
-		fail("Byte size value is too large", "setting", label, "value", raw)
-	}
-	return int64(size)
 }
 
 func parseBool(s string) (bool, bool) {
@@ -1039,12 +561,27 @@ func parseBool(s string) (bool, bool) {
 	return false, false
 }
 
-func parseDuration(s string) (time.Duration, bool) {
-	d, err := time.ParseDuration(s)
+func parseByteSize(raw string) (int64, error) {
+	size, err := humanize.ParseBytes(strings.TrimSpace(raw))
 	if err != nil {
-		return 0, false
+		return 0, fmt.Errorf("invalid byte size %q: %w", raw, err)
 	}
-	return d, true
+	if size == 0 {
+		return 0, fmt.Errorf("byte size must be greater than zero, got %q", raw)
+	}
+	if size > math.MaxInt64 {
+		return 0, fmt.Errorf("byte size %q is too large", raw)
+	}
+	return int64(size), nil
+}
+
+// mustParseByteSize is for values a flag validator has already accepted.
+func mustParseByteSize(raw, label string) int64 {
+	size, err := parseByteSize(raw)
+	if err != nil {
+		fail("Invalid byte size value", "setting", label, "error", err)
+	}
+	return size
 }
 
 func validateHTTPRemoteUserConfig(enabled bool, trustedProxyIPsRaw string) error {
@@ -1115,11 +652,10 @@ func validateSMTPConfig(host, from, publicURL, security string) error {
 // the deprecated --http-remote-user-logout-url/LEAFWIKI_HTTP_REMOTE_USER_LOGOUT_URL
 // when the new option isn't set. usedDeprecated tells the caller whether to log
 // a deprecation warning.
-func resolveLogoutURL(logoutURL, deprecatedFlagVal string, visited map[string]bool, deprecatedEnvVar string) (resolved string, usedDeprecated bool) {
+func resolveLogoutURL(logoutURL, deprecated string) (resolved string, usedDeprecated bool) {
 	if logoutURL != "" {
 		return logoutURL, false
 	}
-	deprecated := resolveString("http-remote-user-logout-url", deprecatedFlagVal, visited, deprecatedEnvVar, "")
 	if deprecated == "" {
 		return "", false
 	}
@@ -1174,11 +710,11 @@ func validateRedirectURL(flagName, url string) error {
 	return nil
 }
 
-func validateListenConfig(unixSocket string, visited map[string]bool) error {
+func validateListenConfig(unixSocket string, hostSet, portSet bool) error {
 	if unixSocket == "" {
 		return nil
 	}
-	if visited["host"] || visited["port"] {
+	if hostSet || portSet {
 		return fmt.Errorf("--unix-socket cannot be used together with --host or --port")
 	}
 	return nil

--- a/cmd/leafwiki/main_test.go
+++ b/cmd/leafwiki/main_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"flag"
 	"io"
 	"log/slog"
 	"net"
@@ -20,13 +19,39 @@ import (
 	"testing"
 	"time"
 
+	"github.com/urfave/cli/v3"
+
 	httpmetrics "github.com/perber/wiki/internal/http/metrics"
 )
 
-func TestWriteUsage_UsesLongFlags(t *testing.T) {
+// runRootCommand parses args through the real command tree and hands the
+// resolved config to inspect, instead of running the server.
+func runRootCommand(t *testing.T, args []string, inspect func(cfg *serverConfig)) {
+	t.Helper()
+
+	cfg := &serverConfig{}
+	cmd := newRootCommandWithConfig(cfg)
+	cmd.Writer = io.Discard
+	cmd.ErrWriter = io.Discard
+	cmd.Action = func(_ context.Context, _ *cli.Command) error {
+		inspect(cfg)
+		return nil
+	}
+
+	if err := cmd.Run(context.Background(), append([]string{"leafwiki"}, args...)); err != nil {
+		t.Fatalf("cmd.Run(%q) error = %v", args, err)
+	}
+}
+
+func TestRootCommandHelp_DocumentsFlagsAndEnvVars(t *testing.T) {
 	var buf bytes.Buffer
 
-	writeUsage(&buf)
+	cmd := newRootCommand()
+	cmd.Writer = &buf
+	cmd.ErrWriter = &buf
+	if err := cmd.Run(context.Background(), []string{"leafwiki", "--help"}); err != nil {
+		t.Fatalf("cmd.Run(--help) error = %v", err)
+	}
 
 	output := buf.String()
 	for _, expected := range []string{
@@ -48,6 +73,8 @@ func TestWriteUsage_UsesLongFlags(t *testing.T) {
 		"LEAFWIKI_ENABLE_METRICS",
 		"LEAFWIKI_METRICS_HOST",
 		"LEAFWIKI_METRICS_PORT",
+		"reset-admin-password",
+		"restore-snapshot",
 	} {
 		if !strings.Contains(output, expected) {
 			t.Fatalf("expected usage output to contain %q, got %q", expected, output)
@@ -55,13 +82,8 @@ func TestWriteUsage_UsesLongFlags(t *testing.T) {
 	}
 }
 
-func TestRegisterFlags_AcceptsSingleDashLongFlags(t *testing.T) {
-	fs := flag.NewFlagSet("leafwiki", flag.ContinueOnError)
-	var errOut bytes.Buffer
-	fs.SetOutput(&errOut)
-	flags := registerFlags(fs)
-
-	err := fs.Parse([]string{
+func TestRootCommand_AcceptsSingleDashLongFlags(t *testing.T) {
+	runRootCommand(t, []string{
 		"-jwt-secret=test-secret",
 		"-admin-password=test-password",
 		"-admin-username=test-admin",
@@ -71,38 +93,31 @@ func TestRegisterFlags_AcceptsSingleDashLongFlags(t *testing.T) {
 		"-metrics-host=127.0.0.2",
 		"-metrics-port=9100",
 		"-unix-socket=/tmp/leafwiki.sock",
+	}, func(cfg *serverConfig) {
+		for _, tc := range []struct {
+			flag string
+			got  string
+			want string
+		}{
+			{"jwt-secret", cfg.auth.jwtSecret, "test-secret"},
+			{"admin-password", cfg.auth.adminPassword, "test-password"},
+			{"admin-username", cfg.auth.adminUsername, "test-admin"},
+			{"admin-email", cfg.auth.adminEmail, "test-admin@example.com"},
+			{"metrics-host", cfg.metrics.metricsHost, "127.0.0.2"},
+			{"metrics-port", cfg.metrics.metricsPort, "9100"},
+			{"unix-socket", cfg.server.unixSocket, "/tmp/leafwiki.sock"},
+		} {
+			if tc.got != tc.want {
+				t.Fatalf("expected --%s %q, got %q", tc.flag, tc.want, tc.got)
+			}
+		}
+		if !cfg.server.allowInsecure {
+			t.Fatal("expected --allow-insecure to be true")
+		}
+		if !cfg.metrics.enableMetrics {
+			t.Fatal("expected --enable-metrics to be true")
+		}
 	})
-	if err != nil {
-		t.Fatalf("expected single-dash long flags to parse, got %v (%s)", err, errOut.String())
-	}
-
-	if got := *flags.jwtSecret; got != "test-secret" {
-		t.Fatalf("expected jwt secret %q, got %q", "test-secret", got)
-	}
-	if got := *flags.adminPassword; got != "test-password" {
-		t.Fatalf("expected admin password %q, got %q", "test-password", got)
-	}
-	if got := *flags.adminUsername; got != "test-admin" {
-		t.Fatalf("expected admin username %q, got %q", "test-admin", got)
-	}
-	if got := *flags.adminEmail; got != "test-admin@example.com" {
-		t.Fatalf("expected admin email %q, got %q", "test-admin@example.com", got)
-	}
-	if !*flags.allowInsecure {
-		t.Fatalf("expected allow-insecure to be true")
-	}
-	if !*flags.enableMetrics {
-		t.Fatalf("expected enable-metrics to be true")
-	}
-	if got := *flags.metricsHost; got != "127.0.0.2" {
-		t.Fatalf("expected metrics host %q, got %q", "127.0.0.2", got)
-	}
-	if got := *flags.metricsPort; got != "9100" {
-		t.Fatalf("expected metrics port %q, got %q", "9100", got)
-	}
-	if got := *flags.unixSocket; got != "/tmp/leafwiki.sock" {
-		t.Fatalf("expected unix socket %q, got %q", "/tmp/leafwiki.sock", got)
-	}
 }
 
 func TestValidateHTTPRemoteUserConfig(t *testing.T) {
@@ -214,7 +229,6 @@ func TestResolveLogoutURL(t *testing.T) {
 		name               string
 		logoutURL          string
 		deprecatedFlagVal  string
-		visited            map[string]bool
 		wantResolved       string
 		wantUsedDeprecated bool
 	}{
@@ -226,7 +240,6 @@ func TestResolveLogoutURL(t *testing.T) {
 		{
 			name:               "only deprecated flag set",
 			deprecatedFlagVal:  "https://idp.example.com/logout",
-			visited:            map[string]bool{"http-remote-user-logout-url": true},
 			wantResolved:       "https://idp.example.com/logout",
 			wantUsedDeprecated: true,
 		},
@@ -237,11 +250,7 @@ func TestResolveLogoutURL(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			visited := tc.visited
-			if visited == nil {
-				visited = map[string]bool{}
-			}
-			resolved, usedDeprecated := resolveLogoutURL(tc.logoutURL, tc.deprecatedFlagVal, visited, "LEAFWIKI_HTTP_REMOTE_USER_LOGOUT_URL")
+			resolved, usedDeprecated := resolveLogoutURL(tc.logoutURL, tc.deprecatedFlagVal)
 			if resolved != tc.wantResolved {
 				t.Fatalf("resolveLogoutURL() resolved = %q, want %q", resolved, tc.wantResolved)
 			}
@@ -252,19 +261,169 @@ func TestResolveLogoutURL(t *testing.T) {
 	}
 }
 
-func TestResolveString_TrimsCLIFlagValue(t *testing.T) {
-	visited := map[string]bool{"login-url": true}
-	got := resolveString("login-url", " https://idp.example.com/login ", visited, "LEAFWIKI_LOGIN_URL", "")
-	if want := "https://idp.example.com/login"; got != want {
-		t.Fatalf("resolveString() = %q, want %q", got, want)
+func TestRootCommand_TrimsStringFlagValue(t *testing.T) {
+	runRootCommand(t, []string{"--login-url= https://idp.example.com/login "}, func(cfg *serverConfig) {
+		if got, want := cfg.proxy.loginURL, "https://idp.example.com/login"; got != want {
+			t.Fatalf("login-url = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestRootCommand_ResolutionPrecedence(t *testing.T) {
+	t.Run("environment variable overrides the default", func(t *testing.T) {
+		t.Setenv("LEAFWIKI_HOST", "0.0.0.0")
+		runRootCommand(t, nil, func(cfg *serverConfig) {
+			if got, want := cfg.server.host, "0.0.0.0"; got != want {
+				t.Fatalf("host = %q, want %q", got, want)
+			}
+		})
+	})
+
+	t.Run("flag overrides the environment variable", func(t *testing.T) {
+		t.Setenv("LEAFWIKI_HOST", "0.0.0.0")
+		runRootCommand(t, []string{"--host=192.168.0.1"}, func(cfg *serverConfig) {
+			if got, want := cfg.server.host, "192.168.0.1"; got != want {
+				t.Fatalf("host = %q, want %q", got, want)
+			}
+		})
+	})
+
+	t.Run("environment variable values are trimmed", func(t *testing.T) {
+		t.Setenv("LEAFWIKI_DATA_DIR", "  /srv/leafwiki  ")
+		runRootCommand(t, nil, func(cfg *serverConfig) {
+			if got, want := cfg.server.dataDir, "/srv/leafwiki"; got != want {
+				t.Fatalf("data-dir = %q, want %q", got, want)
+			}
+		})
+	})
+}
+
+// An environment variable that is declared without a value must not override a
+// default: compose and .env files do that routinely, and taking an empty
+// LEAFWIKI_HOST literally would bind the server to every interface.
+func TestRootCommand_EmptyEnvVarIsUnset(t *testing.T) {
+	t.Setenv("LEAFWIKI_HOST", "")
+	t.Setenv("LEAFWIKI_PORT", "   ")
+	t.Setenv("LEAFWIKI_SNAPSHOT", "")
+
+	runRootCommand(t, nil, func(cfg *serverConfig) {
+		if got, want := cfg.server.host, "127.0.0.1"; got != want {
+			t.Fatalf("host = %q, want %q", got, want)
+		}
+		if got, want := cfg.server.port, "8080"; got != want {
+			t.Fatalf("port = %q, want %q", got, want)
+		}
+		if !cfg.backup.snapshot {
+			t.Fatal("snapshot = false, want the default true")
+		}
+	})
+}
+
+func TestRootCommand_BoolEnvVarSpellings(t *testing.T) {
+	for _, tc := range []struct {
+		env  string
+		want bool
+	}{
+		{"true", true},
+		{"1", true},
+		{"yes", true},
+		{"ON", true},
+		{"y", true},
+		{"false", false},
+		{"0", false},
+		{"no", false},
+		{"off", false},
+		{"n", false},
+	} {
+		t.Run(tc.env, func(t *testing.T) {
+			t.Setenv("LEAFWIKI_PUBLIC_ACCESS", tc.env)
+			runRootCommand(t, nil, func(cfg *serverConfig) {
+				if got := cfg.auth.publicAccess; got != tc.want {
+					t.Fatalf("public-access with LEAFWIKI_PUBLIC_ACCESS=%q = %v, want %v", tc.env, got, tc.want)
+				}
+			})
+		})
 	}
 }
 
-func TestResolveLogFormat_Precedence(t *testing.T) {
+func TestRootCommand_InvalidEnvVarValueFailsFast(t *testing.T) {
+	for _, tc := range []struct{ envVar, value string }{
+		{"LEAFWIKI_PUBLIC_ACCESS", "maybe"},
+		{"LEAFWIKI_SNAPSHOT_RETENTION", "many"},
+		{"LEAFWIKI_SNAPSHOT_INTERVAL", "sometimes"},
+		{"LEAFWIKI_LOG_FORMAT", "yaml"},
+		{"LEAFWIKI_MAX_ASSET_UPLOAD_SIZE", "50 bananas"},
+		{"LEAFWIKI_RESTORE_UPLOAD_MAX_SIZE", "0"},
+		{"LEAFWIKI_LOGIN_URL", "javascript:alert(1)"},
+		{"LEAFWIKI_TOTP_ENCRYPTION_KEY", "too-short"},
+	} {
+		t.Run(tc.envVar, func(t *testing.T) {
+			t.Setenv(tc.envVar, tc.value)
+
+			cmd := newRootCommand()
+			cmd.Writer = io.Discard
+			cmd.ErrWriter = io.Discard
+			cmd.Action = func(_ context.Context, _ *cli.Command) error {
+				t.Fatalf("expected %s=%q to be rejected before the action runs", tc.envVar, tc.value)
+				return nil
+			}
+
+			if err := cmd.Run(context.Background(), []string{"leafwiki"}); err == nil {
+				t.Fatalf("expected an error for %s=%q, got nil", tc.envVar, tc.value)
+			}
+		})
+	}
+}
+
+func TestRootCommand_UsageErrorIsReportedOnce(t *testing.T) {
+	var out bytes.Buffer
+
+	cmd := newRootCommand()
+	cmd.Writer = &out
+	cmd.ErrWriter = &out
+
+	err := cmd.Run(context.Background(), []string{"leafwiki", "--hosts=1.2.3.4"})
+	if !errors.Is(err, errReported) {
+		t.Fatalf("cmd.Run() error = %v, want errReported so main stays quiet", err)
+	}
+	if got := strings.Count(out.String(), "not defined"); got != 1 {
+		t.Fatalf("expected the usage error to be printed exactly once, got %d times in %q", got, out.String())
+	}
+	if !strings.Contains(out.String(), `Did you mean "--host"?`) {
+		t.Fatalf("expected a suggestion for the mistyped flag, got %q", out.String())
+	}
+}
+
+func TestRootCommand_UnknownCommandIsRejected(t *testing.T) {
+	var out bytes.Buffer
+
+	cmd := newRootCommand()
+	cmd.Writer = &out
+	cmd.ErrWriter = &out
+	// The default handler for a cli.ExitCoder calls os.Exit, which would take
+	// the test binary down with it.
+	cmd.ExitErrHandler = func(context.Context, *cli.Command, error) {}
+
+	err := cmd.Run(context.Background(), []string{"leafwiki", "reset-admin-passwort"})
+	if err == nil {
+		t.Fatal("expected an error for an unknown command, got nil")
+	}
+	var exitErr cli.ExitCoder
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected a cli.ExitCoder, got %T: %v", err, err)
+	}
+	if exitErr.ExitCode() != 1 {
+		t.Fatalf("exit code = %d, want 1", exitErr.ExitCode())
+	}
+	if !strings.Contains(err.Error(), "reset-admin-passwort") {
+		t.Fatalf("expected the error to name the unknown command, got %q", err.Error())
+	}
+}
+
+func TestParseLogFormat_Precedence(t *testing.T) {
 	tests := []struct {
 		name     string
-		flagVal  string
-		visited  bool
+		args     []string
 		envVal   string
 		wantForm string
 	}{
@@ -284,8 +443,7 @@ func TestResolveLogFormat_Precedence(t *testing.T) {
 		},
 		{
 			name:     "cli flag overrides env var",
-			flagVal:  "text",
-			visited:  true,
+			args:     []string{"--log-format=text"},
 			envVal:   "json",
 			wantForm: "text",
 		},
@@ -293,14 +451,15 @@ func TestResolveLogFormat_Precedence(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("LEAFWIKI_LOG_FORMAT", tc.envVal)
-			visited := map[string]bool{}
-			if tc.visited {
-				visited["log-format"] = true
-			}
-			got := resolveLogFormat("log-format", tc.flagVal, visited, "LEAFWIKI_LOG_FORMAT", "text")
-			if got != tc.wantForm {
-				t.Fatalf("resolveLogFormat() = %q, want %q", got, tc.wantForm)
-			}
+			runRootCommand(t, tc.args, func(cfg *serverConfig) {
+				got, ok := parseLogFormat(cfg.server.logFormat)
+				if !ok {
+					t.Fatalf("parseLogFormat(%q) reported an invalid format", cfg.server.logFormat)
+				}
+				if got != tc.wantForm {
+					t.Fatalf("parseLogFormat() = %q, want %q", got, tc.wantForm)
+				}
+			})
 		})
 	}
 }
@@ -331,7 +490,7 @@ func TestSetupLogger_SelectsHandlerByFormat(t *testing.T) {
 }
 
 func TestRunRestoreSnapshotCommand_MissingArg_ReturnsUsageError(t *testing.T) {
-	err := runRestoreSnapshotCommand(t.TempDir(), []string{"restore-snapshot"})
+	err := runRestoreSnapshotCommand(t.TempDir(), "")
 	if !errors.Is(err, errRestoreSnapshotUsage) {
 		t.Fatalf("runRestoreSnapshotCommand() error = %v, want errRestoreSnapshotUsage", err)
 	}
@@ -341,7 +500,7 @@ func TestRunRestoreSnapshotCommand_InvalidZipPath_PropagatesError(t *testing.T) 
 	dataDir := t.TempDir()
 	zipPath := filepath.Join(dataDir, "does-not-exist.zip")
 
-	err := runRestoreSnapshotCommand(dataDir, []string{"restore-snapshot", zipPath})
+	err := runRestoreSnapshotCommand(dataDir, zipPath)
 	if err == nil {
 		t.Fatal("runRestoreSnapshotCommand() expected an error for a non-existent snapshot zip, got nil")
 	}
@@ -401,58 +560,56 @@ func TestValidateListenConfig(t *testing.T) {
 	tests := []struct {
 		name       string
 		unixSocket string
-		visited    map[string]bool
+		hostSet    bool
+		portSet    bool
 		wantErr    bool
 	}{
 		{
 			name:       "tcp only is allowed",
 			unixSocket: "",
-			visited:    map[string]bool{"host": true, "port": true},
+			hostSet:    true,
+			portSet:    true,
 			wantErr:    false,
 		},
 		{
 			name:       "unix socket only is allowed",
 			unixSocket: "/tmp/leafwiki.sock",
-			visited:    map[string]bool{},
-			wantErr:    false,
+
+			wantErr: false,
 		},
 		{
 			name:       "unix socket with host is rejected",
 			unixSocket: "/tmp/leafwiki.sock",
-			visited:    map[string]bool{"host": true},
+			hostSet:    true,
 			wantErr:    true,
 		},
 		{
 			name:       "unix socket with port is rejected",
 			unixSocket: "/tmp/leafwiki.sock",
-			visited:    map[string]bool{"port": true},
+			portSet:    true,
 			wantErr:    true,
 		},
 		{
 			name:       "unix socket with host and port is rejected",
 			unixSocket: "/tmp/leafwiki.sock",
-			visited:    map[string]bool{"host": true, "port": true},
+			hostSet:    true,
+			portSet:    true,
 			wantErr:    true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateListenConfig(tc.unixSocket, tc.visited)
+			err := validateListenConfig(tc.unixSocket, tc.hostSet, tc.portSet)
 			if (err != nil) != tc.wantErr {
-				t.Fatalf("validateListenConfig(%q, %v) error = %v, wantErr %v", tc.unixSocket, tc.visited, err, tc.wantErr)
+				t.Fatalf("validateListenConfig(%q, host=%v, port=%v) error = %v, wantErr %v", tc.unixSocket, tc.hostSet, tc.portSet, err, tc.wantErr)
 			}
 		})
 	}
 }
 
-func TestRegisterFlags_AcceptsDoubleDashLongFlags(t *testing.T) {
-	fs := flag.NewFlagSet("leafwiki", flag.ContinueOnError)
-	var errOut bytes.Buffer
-	fs.SetOutput(&errOut)
-	flags := registerFlags(fs)
-
-	err := fs.Parse([]string{
+func TestRootCommand_AcceptsDoubleDashLongFlags(t *testing.T) {
+	runRootCommand(t, []string{
 		"--jwt-secret=test-secret",
 		"--admin-password=test-password",
 		"--admin-username=test-admin",
@@ -462,38 +619,31 @@ func TestRegisterFlags_AcceptsDoubleDashLongFlags(t *testing.T) {
 		"--metrics-host=127.0.0.2",
 		"--metrics-port=9100",
 		"--unix-socket=/tmp/leafwiki.sock",
+	}, func(cfg *serverConfig) {
+		for _, tc := range []struct {
+			flag string
+			got  string
+			want string
+		}{
+			{"jwt-secret", cfg.auth.jwtSecret, "test-secret"},
+			{"admin-password", cfg.auth.adminPassword, "test-password"},
+			{"admin-username", cfg.auth.adminUsername, "test-admin"},
+			{"admin-email", cfg.auth.adminEmail, "test-admin@example.com"},
+			{"metrics-host", cfg.metrics.metricsHost, "127.0.0.2"},
+			{"metrics-port", cfg.metrics.metricsPort, "9100"},
+			{"unix-socket", cfg.server.unixSocket, "/tmp/leafwiki.sock"},
+		} {
+			if tc.got != tc.want {
+				t.Fatalf("expected --%s %q, got %q", tc.flag, tc.want, tc.got)
+			}
+		}
+		if !cfg.server.allowInsecure {
+			t.Fatal("expected --allow-insecure to be true")
+		}
+		if !cfg.metrics.enableMetrics {
+			t.Fatal("expected --enable-metrics to be true")
+		}
 	})
-	if err != nil {
-		t.Fatalf("expected double-dash long flags to parse, got %v (%s)", err, errOut.String())
-	}
-
-	if got := *flags.jwtSecret; got != "test-secret" {
-		t.Fatalf("expected jwt secret %q, got %q", "test-secret", got)
-	}
-	if got := *flags.adminPassword; got != "test-password" {
-		t.Fatalf("expected admin password %q, got %q", "test-password", got)
-	}
-	if got := *flags.adminUsername; got != "test-admin" {
-		t.Fatalf("expected admin username %q, got %q", "test-admin", got)
-	}
-	if got := *flags.adminEmail; got != "test-admin@example.com" {
-		t.Fatalf("expected admin email %q, got %q", "test-admin@example.com", got)
-	}
-	if !*flags.allowInsecure {
-		t.Fatalf("expected allow-insecure to be true")
-	}
-	if !*flags.enableMetrics {
-		t.Fatalf("expected enable-metrics to be true")
-	}
-	if got := *flags.metricsHost; got != "127.0.0.2" {
-		t.Fatalf("expected metrics host %q, got %q", "127.0.0.2", got)
-	}
-	if got := *flags.metricsPort; got != "9100" {
-		t.Fatalf("expected metrics port %q, got %q", "9100", got)
-	}
-	if got := *flags.unixSocket; got != "/tmp/leafwiki.sock" {
-		t.Fatalf("expected unix socket %q, got %q", "/tmp/leafwiki.sock", got)
-	}
 }
 
 func TestStartMetricsServer_ServesOnlyMetricsEndpoint(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/prometheus/client_golang v1.24.1
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/teris-io/shortid v0.0.0-20220617161101-71ec9f2aa569
+	github.com/urfave/cli/v3 v3.11.0
 	github.com/yuin/goldmark v1.8.5
 	golang.org/x/crypto v0.54.0
 	golang.org/x/image v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY=
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
+github.com/urfave/cli/v3 v3.11.0 h1:P/euJp99kb9p0tlVY+iYTLYYTAQlfl0hR2gUO1Img1Q=
+github.com/urfave/cli/v3 v3.11.0/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.8.5 h1:r6N5afV5qj/5S4UTch8agZHJ8UxNCMwX7WjkkJam2NA=


### PR DESCRIPTION
Replaces the hand-rolled flag handling in `cmd/leafwiki` with `urfave/cli` v3. 

As discussed on other channels.

## Why

A flag had to be declared in five places kept in sync by hand: the usage text, the env-var list, `cliFlags`, `registerFlags` and a `resolve*` call. They drifted — all ten `--smtp-*` flags and their `LEAFWIKI_SMTP_*` variables exist on `main` but appear nowhere in `--help`, and `--git-backup-remote` is documented as required although local-only backups work. `--help` and the environment documentation are now generated from the declarations, so that can't happen again.

## Structure

Flags live in `cmd/leafwiki/flags_*.go`, one file per area, each with its own option struct and `Flags()`. Values are read as typed struct fields, so a mistyped lookup is a compile error rather than a silent empty string.

## New for users

`--version`, shell completion (`leafwiki completion bash|zsh|fish|powershell`), categorised help with each flag's environment variable beside it, and subcommands with their own `--help`.

## Behaviour changes

Behaviour is otherwise preserved:

- `--help` is reformatted and now documents the SMTP flags
- `--version`/`-v` is new
- unknown command exits 1 (was 0); a usage error exits 1 (was 2)
- invalid values are reported by urfave, so wording changed, and single-flag validation now fails during parsing rather than mid-startup
- root flags are persistent, so they may follow a subcommand
- `--unix-socket` now clashes with `LEAFWIKI_HOST`/`LEAFWIKI_PORT`, not only with a typed `--host`

## Verification

18 differential probes against a binary built from `main` — resolution, precedence, empty and whitespace environment values, bool spellings, the unix-socket rules, both subcommands, SMTP and git-backup-http validation. The only differences are the ones listed above.

## The second commit

The second commit is the one deliberate behaviour change, kept separate so it can be dropped on its own: environment variables are read through stock `cli.EnvVars`, so `LEAFWIKI_HOST=` means "empty" rather than "unset", and whitespace is no longer trimmed for ints, bools and durations. Two guards keep that from being a footgun — `--host`, `--port`, `--data-dir` and `--metrics-*` reject an empty value by name, and an empty environment variable behind a bool flag is refused, because urfave maps it to `false` before anything can see it (which would silently disable snapshots). The `yes`/`on`/`off` spellings stay, and now work on the command line too.

Drop that commit and the first one still stands.

## Checklist

- [x] I discussed the approach on the linked issue before starting (or this is a trivial fix: typo, docs, obvious one-liner)
- [x] This PR is focused on a single change
- [ ] I ran `npm run format` in `ui/leafwiki-ui` (and in `e2e` if e2e tests changed)
- [x] I updated documentation if needed
