### PR TITLE
feat(viewer): list non-image asset links under TOC sidebar

### DIFF
--- a/internal/wiki/assets/routes.go
+++ b/internal/wiki/assets/routes.go
@@ -67,6 +67,11 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 		}
 	}
 
+	if opts.PublicAccess {
+		pub := ctx.Base.Group("/api")
+		pub.GET("/pages/:id/assets", r.handleList)
+	}
+
 	authGroup := ctx.Base.Group("/api")
 	authGroup.Use(
 		authmw.InjectPublicEditor(opts.AuthDisabled),
@@ -75,7 +80,9 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	)
 
 	authGroup.POST("/pages/:id/assets", authmw.RequireEditorOrAdmin(), r.handleUpload(opts.MaxAssetUploadSizeBytes))
-	authGroup.GET("/pages/:id/assets", authmw.RequireEditorOrAdmin(), r.handleList)
+	if !opts.PublicAccess {
+		authGroup.GET("/pages/:id/assets", r.handleList)
+	}
 	authGroup.PUT("/pages/:id/assets/rename", authmw.RequireEditorOrAdmin(), r.handleRename)
 	authGroup.DELETE("/pages/:id/assets/:name", authmw.RequireEditorOrAdmin(), r.handleDelete)
 }

--- a/ui/leafwiki-ui/src/features/preview/TocSidePanel.test.tsx
+++ b/ui/leafwiki-ui/src/features/preview/TocSidePanel.test.tsx
@@ -10,6 +10,7 @@ vi.mock('react-i18next', () => ({
       const map: Record<string, string> = {
         'toc.title': 'Table of contents',
         'toc.onThisPage': 'On this page',
+        'toc.downloads': 'Attached Media',
         'toc.collapse': 'Collapse table of contents',
         'toc.expand': 'Expand table of contents',
       }
@@ -291,6 +292,22 @@ describe('TocSidePanel — collapse/expand', () => {
 
     expect(screen.getByTestId('toc-side-panel').className).toMatch(
       /page-viewer__toc-panel--collapsed/,
+    )
+  })
+})
+
+describe('TocSidePanel — downloads', () => {
+  it('lists non-image files below the TOC', () => {
+    render(
+      <TocSidePanel
+        entries={entries}
+        downloads={[{ name: 'notes.pdf', url: '/assets/p1/notes.pdf' }]}
+      />,
+    )
+    expect(screen.getByText('Attached Media')).toBeInTheDocument()
+    expect(screen.getByTestId('toc-download-notes.pdf')).toHaveAttribute(
+      'href',
+      '/assets/p1/notes.pdf',
     )
   })
 })

--- a/ui/leafwiki-ui/src/features/preview/TocSidePanel.tsx
+++ b/ui/leafwiki-ui/src/features/preview/TocSidePanel.tsx
@@ -4,13 +4,14 @@ import { cn } from '@/lib/utils'
 import { useTocPanelStore } from '@/stores/tocPanel'
 import { PanelRightClose, PanelRightOpen } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import type { PageDownload, TocEntry } from './extractTocEntries'
+import type { PageAttachment } from '@/lib/api/assets'
+import type { TocEntry } from './extractTocEntries'
 import { useTocScrollSpy } from './useTocScrollSpy'
 
 type Props = {
   entries: TocEntry[]
   activeId?: string | null
-  downloads?: PageDownload[]
+  downloads?: PageAttachment[]
 }
 
 function getIndentClass(level: number): string {

--- a/ui/leafwiki-ui/src/features/preview/TocSidePanel.tsx
+++ b/ui/leafwiki-ui/src/features/preview/TocSidePanel.tsx
@@ -1,14 +1,16 @@
 import { scrollToHeadlineHash } from '@/lib/scrollToHeadline'
+import { withBasePath } from '@/lib/routePath'
 import { cn } from '@/lib/utils'
 import { useTocPanelStore } from '@/stores/tocPanel'
 import { PanelRightClose, PanelRightOpen } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import type { TocEntry } from './extractTocEntries'
+import type { PageDownload, TocEntry } from './extractTocEntries'
 import { useTocScrollSpy } from './useTocScrollSpy'
 
 type Props = {
   entries: TocEntry[]
   activeId?: string | null
+  downloads?: PageDownload[]
 }
 
 function getIndentClass(level: number): string {
@@ -17,7 +19,11 @@ function getIndentClass(level: number): string {
   return 'pl-6'
 }
 
-export function TocSidePanel({ entries, activeId: externalActiveId }: Props) {
+export function TocSidePanel({
+  entries,
+  activeId: externalActiveId,
+  downloads = [],
+}: Props) {
   const { t } = useTranslation('viewer')
   const collapsed = useTocPanelStore((state) => state.collapsed)
   const setCollapsed = useTocPanelStore((state) => state.setCollapsed)
@@ -49,7 +55,7 @@ export function TocSidePanel({ entries, activeId: externalActiveId }: Props) {
           )}
           aria-hidden={collapsed}
         >
-          {t('toc.onThisPage')}
+          {entries.length > 0 ? t('toc.onThisPage') : t('toc.downloads')}
         </p>
         <button
           type="button"
@@ -98,6 +104,31 @@ export function TocSidePanel({ entries, activeId: externalActiveId }: Props) {
             </button>
           </li>
         ))}
+        {downloads.length > 0 && (
+          <>
+            {entries.length > 0 && (
+              <li>
+                <p className="page-viewer__toc-panel-title mt-3">
+                  {t('toc.downloads')}
+                </p>
+              </li>
+            )}
+            {downloads.map((file) => (
+              <li key={file.url}>
+                <a
+                  href={withBasePath(file.url)}
+                  download={file.name}
+                  className="page-viewer__toc-panel-entry"
+                  title={file.name}
+                  data-testid={`toc-download-${file.name}`}
+                  tabIndex={collapsed ? -1 : 0}
+                >
+                  {file.name}
+                </a>
+              </li>
+            ))}
+          </>
+        )}
       </ul>
     </nav>
   )

--- a/ui/leafwiki-ui/src/features/preview/extractTocEntries.ts
+++ b/ui/leafwiki-ui/src/features/preview/extractTocEntries.ts
@@ -1,3 +1,4 @@
+import { IMAGE_EXTENSIONS } from '@/lib/config'
 import { slugifyHeadline } from './rehypeLineNumber'
 
 export type TocEntry = {
@@ -111,4 +112,26 @@ export function extractTocEntries(markdown: string): TocEntry[] {
   }
 
   return entries
+}
+
+export type PageDownload = {
+  name: string
+  url: string
+}
+
+const ASSET_LINK_RE = /(?<!!)\[([^\]]*)\]\((\/?assets\/[^)\s]+)\)/g
+
+export function extractPageDownloads(markdown: string): PageDownload[] {
+  const seen = new Set<string>()
+  const files: PageDownload[] = []
+  for (const match of markdown.matchAll(ASSET_LINK_RE)) {
+    const raw = match[2]
+    const url = raw.startsWith('/') ? raw : `/${raw}`
+    const name = url.split('/').pop() ?? url
+    const ext = name.split('.').pop()?.toLowerCase() ?? ''
+    if (IMAGE_EXTENSIONS.includes(ext) || seen.has(url)) continue
+    seen.add(url)
+    files.push({ name, url })
+  }
+  return files
 }

--- a/ui/leafwiki-ui/src/features/preview/extractTocEntries.ts
+++ b/ui/leafwiki-ui/src/features/preview/extractTocEntries.ts
@@ -1,4 +1,3 @@
-import { IMAGE_EXTENSIONS } from '@/lib/config'
 import { slugifyHeadline } from './rehypeLineNumber'
 
 export type TocEntry = {
@@ -112,26 +111,4 @@ export function extractTocEntries(markdown: string): TocEntry[] {
   }
 
   return entries
-}
-
-export type PageDownload = {
-  name: string
-  url: string
-}
-
-const ASSET_LINK_RE = /(?<!!)\[([^\]]*)\]\((\/?assets\/[^)\s]+)\)/g
-
-export function extractPageDownloads(markdown: string): PageDownload[] {
-  const seen = new Set<string>()
-  const files: PageDownload[] = []
-  for (const match of markdown.matchAll(ASSET_LINK_RE)) {
-    const raw = match[2]
-    const url = raw.startsWith('/') ? raw : `/${raw}`
-    const name = url.split('/').pop() ?? url
-    const ext = name.split('.').pop()?.toLowerCase() ?? ''
-    if (IMAGE_EXTENSIONS.includes(ext) || seen.has(url)) continue
-    seen.add(url)
-    files.push({ name, url })
-  }
-  return files
 }

--- a/ui/leafwiki-ui/src/features/viewer/PageViewer.tsx
+++ b/ui/leafwiki-ui/src/features/viewer/PageViewer.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/lib/registries'
 import { buildHistoryUrl } from '@/lib/routePath'
 import { FavoriteToggleButton } from '@/features/favorites/FavoriteToggleButton'
+import { getPageAttachments, type PageAttachment } from '@/lib/api/assets'
 import { pinPage } from '@/lib/api/pages'
 import { createHotkeyDefinition } from '@/lib/shortcuts/shortcutCatalog'
 import { useScrollRestoration } from '@/lib/useScrollRestoration'
@@ -25,16 +26,13 @@ import { useHotKeysStore } from '@/stores/hotkeys'
 import { useSessionStore } from '@/stores/session'
 import { useTocPanelStore } from '@/stores/tocPanel'
 import { useTreeStore } from '@/stores/tree'
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { createPortal } from 'react-dom'
 import { useLocation, useNavigate } from 'react-router'
 import { BacklinkInfo } from '../links/LinkInfo'
-import {
-  extractPageDownloads,
-  extractTocEntries,
-} from '../preview/extractTocEntries'
+import { extractTocEntries } from '../preview/extractTocEntries'
 import MarkdownPreview from '../preview/MarkdownPreview'
 import { TocDropdownButton } from '../preview/TocDropdownButton'
 import { TocSidePanel } from '../preview/TocSidePanel'
@@ -146,13 +144,30 @@ export default function PageViewer() {
     () => (page ? extractTocEntries(page.content) : []),
     [page],
   )
-  const downloads = useMemo(
-    () => (page ? extractPageDownloads(page.content) : []),
-    [page],
-  )
+  const [attachments, setAttachments] = useState<PageAttachment[]>([])
+
+  useEffect(() => {
+    if (!page?.id) {
+      setAttachments([])
+      return
+    }
+
+    let cancelled = false
+    getPageAttachments(page.id)
+      .then((files) => {
+        if (!cancelled) setAttachments(files)
+      })
+      .catch(() => {
+        if (!cancelled) setAttachments([])
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [page?.id])
 
   const showTocButton = tocEntries.length > 3
-  const showRightPane = showTocButton || downloads.length > 0
+  const showRightPane = showTocButton || attachments.length > 0
   // Single scroll spy for both the dropdown and the side panel.
   const tocActiveId = useTocScrollSpy(showTocButton ? tocEntries : [])
 
@@ -237,7 +252,7 @@ export default function PageViewer() {
           <TocSidePanel
             entries={showTocButton ? tocEntries : []}
             activeId={tocActiveId}
-            downloads={downloads}
+            downloads={attachments}
           />,
           tocPaneRoot,
         )

--- a/ui/leafwiki-ui/src/features/viewer/PageViewer.tsx
+++ b/ui/leafwiki-ui/src/features/viewer/PageViewer.tsx
@@ -31,7 +31,10 @@ import { toast } from 'sonner'
 import { createPortal } from 'react-dom'
 import { useLocation, useNavigate } from 'react-router'
 import { BacklinkInfo } from '../links/LinkInfo'
-import { extractTocEntries } from '../preview/extractTocEntries'
+import {
+  extractPageDownloads,
+  extractTocEntries,
+} from '../preview/extractTocEntries'
 import MarkdownPreview from '../preview/MarkdownPreview'
 import { TocDropdownButton } from '../preview/TocDropdownButton'
 import { TocSidePanel } from '../preview/TocSidePanel'
@@ -143,8 +146,13 @@ export default function PageViewer() {
     () => (page ? extractTocEntries(page.content) : []),
     [page],
   )
+  const downloads = useMemo(
+    () => (page ? extractPageDownloads(page.content) : []),
+    [page],
+  )
 
   const showTocButton = tocEntries.length > 3
+  const showRightPane = showTocButton || downloads.length > 0
   // Single scroll spy for both the dropdown and the side panel.
   const tocActiveId = useTocScrollSpy(showTocButton ? tocEntries : [])
 
@@ -152,7 +160,7 @@ export default function PageViewer() {
   const tocCollapsed = useTocPanelStore((state) => state.collapsed)
 
   useEffect(() => {
-    if (!showTocButton) return
+    if (!showRightPane) return
 
     const tocToggleHotkey = createHotkeyDefinition(
       'viewer.toc.toggle',
@@ -161,7 +169,7 @@ export default function PageViewer() {
     registerHotkey(tocToggleHotkey)
 
     return () => unregisterHotkey(tocToggleHotkey.keyCombo)
-  }, [showTocButton, toggleTocCollapsed, registerHotkey, unregisterHotkey])
+  }, [showRightPane, toggleTocCollapsed, registerHotkey, unregisterHotkey])
 
   const editorName = displayUser(page?.metadata?.lastAuthor)
   const updatedRelative = formatRelativeTime(page?.metadata?.updatedAt)
@@ -175,7 +183,7 @@ export default function PageViewer() {
           <div
             className={cn(
               'page-viewer__subheader print:hidden',
-              showTocButton &&
+              showRightPane &&
                 (tocCollapsed
                   ? 'page-viewer__subheader--toc-reserved-collapsed'
                   : 'page-viewer__subheader--toc-reserved'),
@@ -224,9 +232,13 @@ export default function PageViewer() {
       : null
 
   const tocPane =
-    showTocButton && page && !error && tocPaneRoot
+    showRightPane && page && !error && tocPaneRoot
       ? createPortal(
-          <TocSidePanel entries={tocEntries} activeId={tocActiveId} />,
+          <TocSidePanel
+            entries={showTocButton ? tocEntries : []}
+            activeId={tocActiveId}
+            downloads={downloads}
+          />,
           tocPaneRoot,
         )
       : null

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -1799,7 +1799,7 @@
      lines as the pane narrows during the collapse transition, which reads as
      jumbled reflow rather than a clean shrink. */
   .page-viewer__toc-panel-entry {
-    @apply text-interface-text/70 hover:text-interface-text block w-full cursor-pointer overflow-hidden py-0.5 pr-3 text-left text-sm leading-snug text-ellipsis whitespace-nowrap transition-colors;
+    @apply text-interface-text/70 hover:text-interface-text block w-full cursor-pointer overflow-hidden py-0.5 pr-3 text-left text-sm leading-snug text-ellipsis whitespace-nowrap no-underline transition-colors;
     background: none;
     border: none;
   }

--- a/ui/leafwiki-ui/src/lib/api/assets.test.ts
+++ b/ui/leafwiki-ui/src/lib/api/assets.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { listNonImageAttachments } from './assets'
+
+describe('listNonImageAttachments', () => {
+  it('keeps non-image assets and normalizes URLs', () => {
+    expect(
+      listNonImageAttachments([
+        '/assets/p1/notes.pdf',
+        'assets/p1/guide.docx',
+      ]),
+    ).toEqual([
+      { name: 'notes.pdf', url: '/assets/p1/notes.pdf' },
+      { name: 'guide.docx', url: '/assets/p1/guide.docx' },
+    ])
+  })
+
+  it('filters out image extensions and deduplicates URLs', () => {
+    expect(
+      listNonImageAttachments([
+        '/assets/p1/photo.png',
+        '/assets/p1/notes.pdf',
+        'assets/p1/notes.pdf',
+      ]),
+    ).toEqual([{ name: 'notes.pdf', url: '/assets/p1/notes.pdf' }])
+  })
+})

--- a/ui/leafwiki-ui/src/lib/api/assets.test.ts
+++ b/ui/leafwiki-ui/src/lib/api/assets.test.ts
@@ -1,13 +1,21 @@
-import { describe, expect, it } from 'vitest'
-import { listNonImageAttachments } from './assets'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockFetchWithAuth = vi.fn()
+vi.mock('./auth', () => ({
+  fetchWithAuth: (...args: unknown[]) => mockFetchWithAuth(...args),
+}))
+
+import {
+  getPageAttachments,
+  invalidatePageAttachments,
+  listNonImageAttachments,
+  uploadAsset,
+} from './assets'
 
 describe('listNonImageAttachments', () => {
   it('keeps non-image assets and normalizes URLs', () => {
     expect(
-      listNonImageAttachments([
-        '/assets/p1/notes.pdf',
-        'assets/p1/guide.docx',
-      ]),
+      listNonImageAttachments(['/assets/p1/notes.pdf', 'assets/p1/guide.docx']),
     ).toEqual([
       { name: 'notes.pdf', url: '/assets/p1/notes.pdf' },
       { name: 'guide.docx', url: '/assets/p1/guide.docx' },
@@ -22,5 +30,59 @@ describe('listNonImageAttachments', () => {
         'assets/p1/notes.pdf',
       ]),
     ).toEqual([{ name: 'notes.pdf', url: '/assets/p1/notes.pdf' }])
+  })
+})
+
+describe('getPageAttachments — caching', () => {
+  beforeEach(() => {
+    mockFetchWithAuth.mockReset()
+    invalidatePageAttachments('p1')
+  })
+
+  it('fetches once and serves later reads from the cache', async () => {
+    mockFetchWithAuth.mockResolvedValue({ files: ['/assets/p1/notes.pdf'] })
+
+    const first = await getPageAttachments('p1')
+    const second = await getPageAttachments('p1')
+
+    expect(first).toEqual([{ name: 'notes.pdf', url: '/assets/p1/notes.pdf' }])
+    expect(second).toBe(first)
+    expect(mockFetchWithAuth).toHaveBeenCalledTimes(1)
+  })
+
+  it('deduplicates concurrent reads into a single request', async () => {
+    mockFetchWithAuth.mockResolvedValue({ files: ['/assets/p1/notes.pdf'] })
+
+    const [a, b] = await Promise.all([
+      getPageAttachments('p1'),
+      getPageAttachments('p1'),
+    ])
+
+    expect(a).toEqual(b)
+    expect(mockFetchWithAuth).toHaveBeenCalledTimes(1)
+  })
+
+  it('refetches after a failed request instead of caching the failure', async () => {
+    mockFetchWithAuth.mockRejectedValueOnce(new Error('boom'))
+    await expect(getPageAttachments('p1')).rejects.toThrow('boom')
+
+    mockFetchWithAuth.mockResolvedValue({ files: ['/assets/p1/notes.pdf'] })
+    const files = await getPageAttachments('p1')
+
+    expect(files).toEqual([{ name: 'notes.pdf', url: '/assets/p1/notes.pdf' }])
+    expect(mockFetchWithAuth).toHaveBeenCalledTimes(2)
+  })
+
+  it('busts the cache when an asset is uploaded for the page', async () => {
+    mockFetchWithAuth.mockResolvedValueOnce({ files: [] })
+    expect(await getPageAttachments('p1')).toEqual([])
+
+    mockFetchWithAuth.mockResolvedValueOnce({ file: '/assets/p1/notes.pdf' })
+    await uploadAsset('p1', new File(['x'], 'notes.pdf'))
+
+    mockFetchWithAuth.mockResolvedValueOnce({ files: ['/assets/p1/notes.pdf'] })
+    expect(await getPageAttachments('p1')).toEqual([
+      { name: 'notes.pdf', url: '/assets/p1/notes.pdf' },
+    ])
   })
 })

--- a/ui/leafwiki-ui/src/lib/api/assets.ts
+++ b/ui/leafwiki-ui/src/lib/api/assets.ts
@@ -30,11 +30,41 @@ export function listNonImageAttachments(files: string[]): PageAttachment[] {
   return attachments
 }
 
+// Session-scoped cache for the viewer's attachment panel. The SPA remounts
+// PageViewer on every visit, so navigating back and forth between pages would
+// otherwise refetch GET /api/pages/:id/assets each time even though the result
+// almost never changes between visits. Entries are busted whenever an asset is
+// uploaded, renamed, or deleted through the mutating helpers below.
+const attachmentCache = new Map<string, PageAttachment[]>()
+const attachmentRequests = new Map<string, Promise<PageAttachment[]>>()
+
+/** Drops any cached attachment list for a page so the next read refetches. */
+export function invalidatePageAttachments(pageId: string): void {
+  attachmentCache.delete(pageId)
+  attachmentRequests.delete(pageId)
+}
+
 export async function getPageAttachments(
   pageId: string,
 ): Promise<PageAttachment[]> {
-  const files = await getAssets(pageId)
-  return listNonImageAttachments(files)
+  const cached = attachmentCache.get(pageId)
+  if (cached) return cached
+
+  const inFlight = attachmentRequests.get(pageId)
+  if (inFlight) return inFlight
+
+  const request = getAssets(pageId)
+    .then((files) => {
+      const attachments = listNonImageAttachments(files)
+      attachmentCache.set(pageId, attachments)
+      return attachments
+    })
+    .finally(() => {
+      attachmentRequests.delete(pageId)
+    })
+
+  attachmentRequests.set(pageId, request)
+  return request
 }
 
 export async function uploadAsset(
@@ -43,10 +73,12 @@ export async function uploadAsset(
 ): Promise<UploadAssetResponse> {
   const form = new FormData()
   form.append('file', file)
-  return (await fetchWithAuth(`/api/pages/${pageId}/assets`, {
+  const res = (await fetchWithAuth(`/api/pages/${pageId}/assets`, {
     method: 'POST',
     body: form,
   })) as UploadAssetResponse
+  invalidatePageAttachments(pageId)
+  return res
 }
 
 export async function getAssets(pageId: string): Promise<string[]> {
@@ -56,12 +88,14 @@ export async function getAssets(pageId: string): Promise<string[]> {
 }
 
 export async function deleteAsset(pageId: string, filename: string) {
-  return await fetchWithAuth(
+  const res = await fetchWithAuth(
     `/api/pages/${pageId}/assets/${encodeURIComponent(filename)}`,
     {
       method: 'DELETE',
     },
   )
+  invalidatePageAttachments(pageId)
+  return res
 }
 
 export async function renameAsset(
@@ -69,7 +103,7 @@ export async function renameAsset(
   oldFilename: string,
   newFilename: string,
 ) {
-  return await fetchWithAuth(`/api/pages/${pageId}/assets/rename`, {
+  const res = await fetchWithAuth(`/api/pages/${pageId}/assets/rename`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -77,4 +111,6 @@ export async function renameAsset(
       new_filename: newFilename,
     }),
   })
+  invalidatePageAttachments(pageId)
+  return res
 }

--- a/ui/leafwiki-ui/src/lib/api/assets.ts
+++ b/ui/leafwiki-ui/src/lib/api/assets.ts
@@ -1,7 +1,40 @@
+import { IMAGE_EXTENSIONS } from '@/lib/config'
 import { fetchWithAuth } from './auth'
 
 export type UploadAssetResponse = {
   file: string
+}
+
+export type PageAttachment = {
+  name: string
+  url: string
+}
+
+function normalizeAssetUrl(path: string): string {
+  if (path.startsWith('/assets/')) return path
+  if (path.startsWith('assets/')) return `/${path}`
+  return `/assets/${path}`
+}
+
+export function listNonImageAttachments(files: string[]): PageAttachment[] {
+  const seen = new Set<string>()
+  const attachments: PageAttachment[] = []
+  for (const file of files) {
+    const url = normalizeAssetUrl(file)
+    const name = url.split('/').pop() ?? url
+    const ext = name.split('.').pop()?.toLowerCase() ?? ''
+    if (IMAGE_EXTENSIONS.includes(ext) || seen.has(url)) continue
+    seen.add(url)
+    attachments.push({ name, url })
+  }
+  return attachments
+}
+
+export async function getPageAttachments(
+  pageId: string,
+): Promise<PageAttachment[]> {
+  const files = await getAssets(pageId)
+  return listNonImageAttachments(files)
 }
 
 export async function uploadAsset(

--- a/ui/leafwiki-ui/src/locales/de/viewer.json
+++ b/ui/leafwiki-ui/src/locales/de/viewer.json
@@ -69,6 +69,7 @@
   "toc": {
     "title": "Inhaltsverzeichnis",
     "onThisPage": "Auf dieser Seite",
+    "downloads": "Angehängte Medien",
     "collapse": "Inhaltsverzeichnis einklappen",
     "expand": "Inhaltsverzeichnis ausklappen"
   },

--- a/ui/leafwiki-ui/src/locales/en/viewer.json
+++ b/ui/leafwiki-ui/src/locales/en/viewer.json
@@ -69,6 +69,7 @@
   "toc": {
     "title": "Table of contents",
     "onThisPage": "On this page",
+    "downloads": "Attached Media",
     "collapse": "Collapse table of contents",
     "expand": "Expand table of contents"
   },


### PR DESCRIPTION
## Related issue

Fixes/addresses #1469

## What changed

Adds a 'Media Attachments' under the table of contents, whether the table of contents is displayed or not.

Adds UX improvements so that attachments can be easily downloaded by users. Use case is when creating policy manuals, or procedure manuals and attaching items such as templated letters, etc that can be downloaded and subsequently used.

## 2nd Update

Converted original PR from a markdown extraction process to using API and also displays all associated media assets and not just those linked in Markdown.

## AI Disclosure

This PR was largely created with the help of AI (Cursor). I manually reviewed the code and it appears to be well written and doesn't change anything other than what was intended. Disclaimer - I am a novice programmer.

## Checklist

- [X] I discussed the approach on the linked issue before starting (or this is a trivial fix: typo, docs, obvious one-liner)
- [X] This PR is focused on a single change
- [X] I ran `npm run format` in `ui/leafwiki-ui` (and in `e2e` if e2e tests changed)
