### PR TITLE
fix(auth): preserve external login return URLs

### DIFF
--- a/ui/leafwiki-ui/src/lib/redirectToExternal.test.ts
+++ b/ui/leafwiki-ui/src/lib/redirectToExternal.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { redirectToExternal } from './redirectToExternal'
+
+describe('redirectToExternal', () => {
+  const originalLocation = window.location
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    })
+  })
+
+  it('preserves the configured query and hash when adding the return URL', () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, href: '' },
+    })
+
+    redirectToExternal(
+      'https://idp.example.com/login?tenant=a&redirect_uri=https%3A%2F%2Fold.example.com#section',
+      '/protected?tab=x#anchor',
+    )
+
+    const redirected = new URL(window.location.href)
+    expect(redirected.searchParams.get('tenant')).toBe('a')
+    expect(redirected.searchParams.getAll('redirect_uri')).toHaveLength(1)
+    expect(redirected.searchParams.get('redirect_uri')).toBe(
+      `${originalLocation.origin}/protected?tab=x#anchor`,
+    )
+    expect(redirected.hash).toBe('#section')
+  })
+
+  it('preserves query and hash placement for a legacy relative URL', () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, href: '' },
+    })
+
+    redirectToExternal('/login?tenant=a#section', '/protected?tab=x#anchor')
+
+    expect(window.location.href.indexOf('?')).toBeLessThan(
+      window.location.href.indexOf('#'),
+    )
+    const redirected = new URL(window.location.href, originalLocation.origin)
+    expect(redirected.origin).toBe(originalLocation.origin)
+    expect(redirected.searchParams.get('tenant')).toBe('a')
+    expect(redirected.searchParams.get('redirect_uri')).toBe(
+      `${originalLocation.origin}/protected?tab=x#anchor`,
+    )
+    expect(redirected.hash).toBe('#section')
+  })
+})

--- a/ui/leafwiki-ui/src/lib/redirectToExternal.ts
+++ b/ui/leafwiki-ui/src/lib/redirectToExternal.ts
@@ -6,7 +6,17 @@ export function redirectToExternal(url: string, returnTo?: string) {
     window.location.href = url
     return
   }
-  const separator = url.includes('?') ? '&' : '?'
   const absoluteReturnTo = `${window.location.origin}${returnTo}`
-  window.location.href = `${url}${separator}redirect_uri=${encodeURIComponent(absoluteReturnTo)}`
+
+  try {
+    const redirectUrl = new URL(url)
+    redirectUrl.searchParams.set('redirect_uri', absoluteReturnTo)
+    window.location.href = redirectUrl.toString()
+  } catch {
+    const hashIndex = url.indexOf('#')
+    const base = hashIndex === -1 ? url : url.slice(0, hashIndex)
+    const hash = hashIndex === -1 ? '' : url.slice(hashIndex)
+    const separator = base.includes('?') ? '&' : '?'
+    window.location.href = `${base}${separator}redirect_uri=${encodeURIComponent(absoluteReturnTo)}${hash}`
+  }
 }


### PR DESCRIPTION
## Related issue

Fixes #1476

## What changed

- Preserve the configured external login URL's query string and fragment when adding the return URL.
- Replace an existing `redirect_uri` instead of appending a duplicate.
- Keep compatibility with legacy relative login URLs.
- Add regression tests for absolute and relative URLs.

## Verification

- `vitest run src/lib/redirectToExternal.test.ts`
- ESLint on the changed files
- Prettier check on the changed files
- Production UI build

## Checklist

- [ ] I discussed the approach on the linked issue before starting (or this is a trivial fix: typo, docs, obvious one-liner)
- [x] This PR is focused on a single change
- [x] I ran `npm run format` in `ui/leafwiki-ui` (and in `e2e` if e2e tests changed)
- [x] I updated documentation if needed
