### PR TITLE
fix(sidebar): recover invalid persisted panel state

### DIFF
--- a/ui/leafwiki-ui/src/stores/sidebarPanels.test.ts
+++ b/ui/leafwiki-ui/src/stores/sidebarPanels.test.ts
@@ -3,12 +3,14 @@ import { useSidebarPanelsStore } from './sidebarPanels'
 
 describe('useSidebarPanelsStore', () => {
   beforeEach(() => {
-    useSidebarPanelsStore.setState({ openSections: ['pinned', 'pages'] })
+    localStorage.clear()
+    useSidebarPanelsStore.setState(useSidebarPanelsStore.getInitialState())
   })
 
-  it('starts with pinned and pages expanded by default', () => {
+  it('starts with pinned, favorites, and pages expanded by default', () => {
     expect(useSidebarPanelsStore.getState().openSections).toEqual([
       'pinned',
+      'favorites',
       'pages',
     ])
   })
@@ -32,5 +34,40 @@ describe('useSidebarPanelsStore', () => {
       'pages',
       'favorites',
     ])
+  })
+
+  it.each([
+    null,
+    {},
+    { openSections: null },
+    { openSections: {} },
+    { openSections: ['pages', 1] },
+  ])('restores defaults for invalid persisted state %#', async (state) => {
+    localStorage.setItem(
+      'leafwiki-sidebar-panels',
+      JSON.stringify({ state, version: 0 }),
+    )
+
+    await useSidebarPanelsStore.persist.rehydrate()
+
+    expect(useSidebarPanelsStore.getState().openSections).toEqual([
+      'pinned',
+      'favorites',
+      'pages',
+    ])
+    expect(useSidebarPanelsStore.getState().setOpenSections).toBeTypeOf(
+      'function',
+    )
+  })
+
+  it('preserves an empty persisted section list', async () => {
+    localStorage.setItem(
+      'leafwiki-sidebar-panels',
+      JSON.stringify({ state: { openSections: [] }, version: 0 }),
+    )
+
+    await useSidebarPanelsStore.persist.rehydrate()
+
+    expect(useSidebarPanelsStore.getState().openSections).toEqual([])
   })
 })

--- a/ui/leafwiki-ui/src/stores/sidebarPanels.ts
+++ b/ui/leafwiki-ui/src/stores/sidebarPanels.ts
@@ -18,6 +18,20 @@ export const useSidebarPanelsStore = create<SidebarPanelsStore>()(
     }),
     {
       name: 'leafwiki-sidebar-panels', // localStorage key
+      merge: (persistedState, currentState) => {
+        const openSections = (
+          persistedState as Partial<SidebarPanelsStore> | null | undefined
+        )?.openSections
+
+        return {
+          ...currentState,
+          openSections:
+            Array.isArray(openSections) &&
+            openSections.every((id) => typeof id === 'string')
+              ? openSections
+              : currentState.openSections,
+        }
+      },
     },
   ),
 )


### PR DESCRIPTION
## Related issue

Fixes #1477

## What changed

- Validate persisted `openSections` before merging it into the sidebar store.
- Restore the current defaults for missing or invalid persisted values.
- Preserve a valid empty array because it represents an intentionally collapsed sidebar.
- Correct the default-state test to include the Favorites panel.

## Verification

- `vitest run src/stores/sidebarPanels.test.ts`
- ESLint on the changed files
- Prettier check on the changed files
- Production UI build

## Checklist

- [ ] I discussed the approach on the linked issue before starting (or this is a trivial fix: typo, docs, obvious one-liner)
- [x] This PR is focused on a single change
- [x] I ran `npm run format` in `ui/leafwiki-ui` (and in `e2e` if e2e tests changed)
- [x] I updated documentation if needed
