### PR TITLE
fix(wikilinks): resolve [[Title]] links whose title contains a slash

### DIFF
--- a/ui/leafwiki-ui/src/features/preview/MarkdownPreview.test.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownPreview.test.tsx
@@ -1,6 +1,9 @@
 import { render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import type { PageNode } from '@/lib/api/pages'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { useDesignModeStore } from '@/features/designtoggle/designmode'
+import { useTreeStore } from '@/stores/tree'
 import MarkdownPreview from './MarkdownPreview'
 
 function renderPreview(content: string) {
@@ -183,5 +186,67 @@ echo two
 
     expect(container.querySelector('mark')).toBeNull()
     expect(container.querySelector('code')?.textContent).toContain('==')
+  })
+})
+
+describe('MarkdownPreview wikilinks with a slash in the title', () => {
+  const node = (id: string, path: string, title: string): PageNode => ({
+    id,
+    title,
+    slug: path.split('/').pop() ?? path,
+    path,
+    version: 'v1',
+    kind: 'page',
+    children: null,
+    parentId: null,
+  })
+
+  beforeEach(() => {
+    useTreeStore.setState({ byId: {}, byPath: {} })
+    localStorage.setItem('design-mode', 'light')
+    useDesignModeStore.setState({ mode: 'light' })
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(prefers-color-scheme: light)',
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  })
+
+  // Regression for the ADR index bug: [[ADR-0011: SMTP as a CLI/ENV-Only
+  // Optional Feature]] used to hit the path-hint branch (because of the "/" in
+  // "CLI/ENV") and emit a bare markdown link whose destination contained
+  // spaces — invalid CommonMark, so the preview showed the raw "[text](url)".
+  it('renders a slash-and-space title as a resolved link, not raw text', () => {
+    const adr = node(
+      'adr-11',
+      'ai-gen-infos/adr/adr-0011-smtp',
+      'ADR-0011: SMTP as a CLI/ENV-Only Optional Feature',
+    )
+    useTreeStore.setState({
+      byId: { 'adr-11': adr },
+      byPath: { 'ai-gen-infos/adr/adr-0011-smtp': adr },
+    })
+
+    const { container } = render(
+      <MemoryRouter>
+        <TooltipProvider>
+          <MarkdownPreview content="[[ADR-0011: SMTP as a CLI/ENV-Only Optional Feature]]" />
+        </TooltipProvider>
+      </MemoryRouter>,
+    )
+
+    const link = container.querySelector(
+      'a[href="/ai-gen-infos/adr/adr-0011-smtp"]',
+    )
+    expect(link).not.toBeNull()
+    expect(link?.textContent).toBe(
+      'ADR-0011: SMTP as a CLI/ENV-Only Optional Feature',
+    )
+    expect(container.textContent).not.toContain('](')
   })
 })

--- a/ui/leafwiki-ui/src/lib/preprocessWikilinks.test.ts
+++ b/ui/leafwiki-ui/src/lib/preprocessWikilinks.test.ts
@@ -79,14 +79,57 @@ describe('preprocessWikilinks', () => {
   })
 
   describe('path hints ([[Folder/Title]])', () => {
-    it('converts a slash-containing target to a direct path link', () => {
+    it('converts a slash-containing target with no title match to a direct path link', () => {
       const result = preprocessWikilinks('[[docs/intro]]', noMatch)
-      expect(result).toBe('[docs/intro](/docs/intro)')
+      expect(result).toBe('[docs/intro](</docs/intro>)')
     })
 
     it('uses the alias as display text for path hints', () => {
       const result = preprocessWikilinks('[[docs/intro|Introduction]]', noMatch)
-      expect(result).toBe('[Introduction](/docs/intro)')
+      expect(result).toBe('[Introduction](</docs/intro>)')
+    })
+
+    // Regression: a slash in the *title* must not short-circuit the title
+    // lookup. Mirrors the backend's resolveWikiLinkTargets, which always tries
+    // a title match first (its motivating examples: "TCP/IP", "C/C++ Guide").
+    it('resolves a slash-containing target by title when a single page matches', () => {
+      const guide = page('1', 'dev/c-cpp-guide', 'C/C++ Guide')
+      const result = preprocessWikilinks('[[C/C++ Guide]]', singleMatch(guide))
+      expect(result).toBe('[C/C++ Guide](/dev/c-cpp-guide)')
+    })
+
+    // Regression for the ADR-0011 index bug: title contains "/" ("CLI/ENV") and
+    // also spaces, so the old path-hint branch emitted a bare markdown link
+    // whose destination had spaces — invalid CommonMark, rendered as raw text.
+    it('resolves a slash-and-space title against the tree instead of emitting raw text', () => {
+      const adr = page(
+        '1',
+        'ai-gen-infos/adr/adr-0011-smtp',
+        'ADR-0011: SMTP as a CLI/ENV-Only Optional Feature',
+      )
+      const result = preprocessWikilinks(
+        '[[ADR-0011: SMTP as a CLI/ENV-Only Optional Feature]]',
+        singleMatch(adr),
+      )
+      expect(result).toBe(
+        '[ADR-0011: SMTP as a CLI/ENV-Only Optional Feature](/ai-gen-infos/adr/adr-0011-smtp)',
+      )
+    })
+
+    // A slash-containing target with no title match AND spaces still has to
+    // produce a parseable link — angle-bracket the destination.
+    it('angle-brackets an unresolved slash target so spaces stay parseable', () => {
+      const result = preprocessWikilinks('[[some/nested page]]', noMatch)
+      expect(result).toBe('[some/nested page](</some/nested page>)')
+    })
+
+    it('treats an ambiguous slash-containing title as ambiguous, not a path hint', () => {
+      const matches = multiMatch([
+        page('1', 'a/tcp-ip', 'TCP/IP'),
+        page('2', 'b/tcp-ip', 'TCP/IP'),
+      ])
+      const result = preprocessWikilinks('[[TCP/IP]]', matches)
+      expect(result).toBe('[TCP/IP](wikilink-ambiguous:TCP%2FIP)')
     })
   })
 

--- a/ui/leafwiki-ui/src/lib/preprocessWikilinks.test.ts
+++ b/ui/leafwiki-ui/src/lib/preprocessWikilinks.test.ts
@@ -123,6 +123,24 @@ describe('preprocessWikilinks', () => {
       expect(result).toBe('[some/nested page](</some/nested page>)')
     })
 
+    // The path-hint destination must not become a protocol-relative "//host"
+    // URL just because the target had a leading slash.
+    it('collapses leading slashes in the path-hint destination to exactly one', () => {
+      const result = preprocessWikilinks('[[//evil.example/path]]', noMatch)
+      expect(result).toBe('[//evil.example/path](</evil.example/path>)')
+    })
+
+    it('strips a single leading slash from the path-hint destination', () => {
+      const result = preprocessWikilinks('[[/docs/intro]]', noMatch)
+      expect(result).toBe('[/docs/intro](</docs/intro>)')
+    })
+
+    // "<" / ">" in the target must not terminate the <...> destination early.
+    it('percent-escapes angle brackets in the path-hint destination', () => {
+      const result = preprocessWikilinks('[[docs/<script>]]', noMatch)
+      expect(result).toBe('[docs/<script>](</docs/%3Cscript%3E>)')
+    })
+
     it('treats an ambiguous slash-containing title as ambiguous, not a path hint', () => {
       const matches = multiMatch([
         page('1', 'a/tcp-ip', 'TCP/IP'),

--- a/ui/leafwiki-ui/src/lib/preprocessWikilinks.ts
+++ b/ui/leafwiki-ui/src/lib/preprocessWikilinks.ts
@@ -54,10 +54,17 @@ export function preprocessWikilinks(
 
       if (matches.length === 0) {
         // No exact title match. A slash-containing target is retried as a
-        // route-path hint ([[Folder/Title]] → /Folder/Title); angle-bracket
-        // the destination so spaces in the target stay parseable.
-        if (trimmedTarget.includes('/')) {
-          return `[${displayText}](</${trimmedTarget}>)`
+        // route-path hint ([[Folder/Title]] → /Folder/Title). The destination
+        // is angle-bracketed so spaces in the target stay parseable; leading
+        // slashes are collapsed to exactly one (so the target can't become a
+        // protocol-relative "//host" URL) and "<"/">" are percent-escaped (so
+        // they can't terminate the <...> destination early).
+        const routePath = trimmedTarget
+          .replace(/^\/+/, '')
+          .replace(/</g, '%3C')
+          .replace(/>/g, '%3E')
+        if (trimmedTarget.includes('/') && routePath !== '') {
+          return `[${displayText}](</${routePath}>)`
         }
         return `[${displayText}](wikilink-notfound:${encodeURIComponent(trimmedTarget)})`
       }

--- a/ui/leafwiki-ui/src/lib/preprocessWikilinks.ts
+++ b/ui/leafwiki-ui/src/lib/preprocessWikilinks.ts
@@ -15,12 +15,19 @@ const CODE_SPLIT_RE = /(```[\s\S]*?```|`[^`\n]+`)/g
  * Repeated [[Title]] occurrences within a single call are resolved only once
  * (cached) to avoid O(numLinks × numPages) scans.
  *
- * Resolution rules:
- *  - [[Folder/Title]]         → [Folder/Title](/Folder/Title)  (treated as a path hint)
+ * Resolution rules (mirrors the backend's resolveWikiLinkTargets):
  *  - [[Title]]                → [Title](/path)                 (single match in tree)
  *  - [[Title|Alias]]          → [Alias](/path)                 (with custom display text)
- *  - no match                 → uses wikilink-notfound: scheme (rendered red)
  *  - multiple matches         → uses wikilink-ambiguous: scheme (opens disambiguation)
+ *  - no match, no "/"         → uses wikilink-notfound: scheme (rendered red)
+ *  - no match, contains "/"   → [Folder/Title](</Folder/Title>)  (path hint fallback)
+ *
+ * A "/" in the target does NOT short-circuit the title lookup: a target like
+ * "TCP/IP" or "ADR-0011: SMTP as a CLI/ENV-Only Optional Feature" is resolved
+ * by title first, and only retried as a route-path hint when no page title
+ * matches at all. The path-hint destination is angle-bracketed so targets
+ * containing spaces still parse as a CommonMark link instead of rendering as
+ * raw text.
  */
 export function preprocessWikilinks(
   content: string,
@@ -39,10 +46,6 @@ export function preprocessWikilinks(
       const trimmedTarget = target.trim()
       const displayText = alias ? alias.trim() : trimmedTarget
 
-      if (trimmedTarget.includes('/')) {
-        return `[${displayText}](/${trimmedTarget})`
-      }
-
       const matches = getMatches(trimmedTarget)
 
       if (matches.length === 1) {
@@ -50,6 +53,12 @@ export function preprocessWikilinks(
       }
 
       if (matches.length === 0) {
+        // No exact title match. A slash-containing target is retried as a
+        // route-path hint ([[Folder/Title]] → /Folder/Title); angle-bracket
+        // the destination so spaces in the target stay parseable.
+        if (trimmedTarget.includes('/')) {
+          return `[${displayText}](</${trimmedTarget}>)`
+        }
         return `[${displayText}](wikilink-notfound:${encodeURIComponent(trimmedTarget)})`
       }
 


### PR DESCRIPTION
Fixes #1482

## Problem

A `[[Title]]` wikilink whose **title contains a `/`** is not resolved in the rendered preview/viewer — it renders as literal markdown text instead of a link.

Seen on an ADR index page:

```
[[ADR-0011: SMTP as a CLI/ENV-Only Optional Feature]]
```

renders as the raw string

```
[ADR-0011: SMTP as a CLI/ENV-Only Optional Feature](/ADR-0011: SMTP as a CLI/ENV-Only Optional Feature)
```

while the ten sibling `[[ADR-000x: ...]]` entries (no slash in the title) resolve fine.

## Root cause

[`preprocessWikilinks.ts`](ui/leafwiki-ui/src/lib/preprocessWikilinks.ts) short-circuited on any `/` in the target and treated it as a `[[Folder/Title]]` path hint, skipping the title lookup:

```js
if (trimmedTarget.includes('/')) {
  return `[${displayText}](/${trimmedTarget})`
}
```

The emitted `[Title](/Title with spaces)` has an unbracketed destination containing spaces — invalid CommonMark — so react-markdown renders it verbatim. (A slash title without spaces, e.g. `[[TCP/IP]]`, would instead resolve to the wrong target: route path `/TCP/IP` rather than the matching page.)

The backend (`internal/links/helpers.go`, `resolveWikiLinkTargets`) already does this correctly — title lookup first, route-path only as a fallback when there is no title match. This PR aligns the frontend with that behavior.

## Change

- `preprocessWikilinks`: try the title lookup first for every target. A slash-containing target is only retried as a route-path hint when there is **no** title match, and the fallback destination is angle-bracketed (`[text](</Folder/Title>)`) so targets with spaces still parse as a CommonMark link.
- Ambiguous (N>1) slash titles now go through the existing `wikilink-ambiguous:` scheme like any other ambiguous title, instead of silently becoming a path link.

## Tests

Both regression tests were confirmed failing before the fix:

- `preprocessWikilinks.test.ts` — slash-and-space title resolves by title; unresolved slash target is angle-bracketed; ambiguous slash title stays ambiguous.
- `MarkdownPreview.test.tsx` — the exact `[[ADR-0011: SMTP as a CLI/ENV-Only Optional Feature]]` string renders as an `<a>` with the resolved href and no literal `](` in the output.

Full `ui/leafwiki-ui` suite (498 passed), `tsc -b`, eslint and `npm run format` all green.