### PR TITLE
fix(permalink): clarify that shared links are permanent, not public

### DIFF
--- a/ui/leafwiki-ui/src/features/page/PermalinkDialog.test.tsx
+++ b/ui/leafwiki-ui/src/features/page/PermalinkDialog.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { PermalinkDialog } from './PermalinkDialog'
+
+vi.mock('@/components/BaseDialog', () => ({
+  default: ({
+    children,
+    dialogDescription,
+  }: {
+    children?: ReactNode
+    dialogDescription?: ReactNode
+  }) => (
+    <div>
+      <div>{dialogDescription}</div>
+      {children}
+    </div>
+  ),
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string, opts?: { title?: string }) =>
+      ({
+        'permalinkDialog.description': `Permanent link to ${opts?.title ?? ''}`,
+        'permalinkDialog.urlLabel': 'Permanent link',
+        'permalinkDialog.copyLink': 'Copy link',
+        'permalinkDialog.openLink': 'Open link',
+        'permalinkDialog.purposeNote':
+          'This is a permanent internal link. It keeps working even after the page is renamed or moved.',
+        'permalinkDialog.accessNote':
+          'It is not a public link. Anyone you send it to still needs to sign in to this wiki.',
+        'permalinkDialog.copiedToast': 'Permalink copied',
+        'permalinkDialog.copyErrorToast': 'Could not copy permalink',
+      })[key] ?? key,
+  }),
+}))
+
+const copyMock = vi.fn(() => true)
+vi.mock('copy-to-clipboard', () => ({
+  default: (text: string) => copyMock(text),
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+const page = { id: 'abc123', slug: 'my-page', title: 'My Page' }
+
+describe('PermalinkDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('explains that the link is permanent and still requires sign-in', () => {
+    render(<PermalinkDialog page={page} />)
+
+    expect(
+      screen.getByTestId('permalink-dialog-purpose-note').textContent,
+    ).toMatch(/permanent internal link/i)
+    expect(
+      screen.getByTestId('permalink-dialog-access-note').textContent,
+    ).toMatch(/not a public link/i)
+  })
+
+  it('copies the fully-qualified permalink URL', async () => {
+    const user = userEvent.setup()
+    render(<PermalinkDialog page={page} />)
+
+    await user.click(screen.getByTestId('permalink-dialog-copy-button'))
+
+    expect(copyMock).toHaveBeenCalledTimes(1)
+    expect(copyMock.mock.calls[0][0]).toContain('/p/abc123/my-page')
+  })
+})

--- a/ui/leafwiki-ui/src/features/page/PermalinkDialog.test.tsx
+++ b/ui/leafwiki-ui/src/features/page/PermalinkDialog.test.tsx
@@ -38,7 +38,7 @@ vi.mock('react-i18next', () => ({
   }),
 }))
 
-const copyMock = vi.fn(() => true)
+const copyMock = vi.fn<(text: string) => boolean>(() => true)
 vi.mock('copy-to-clipboard', () => ({
   default: (text: string) => copyMock(text),
 }))
@@ -72,6 +72,8 @@ describe('PermalinkDialog', () => {
     await user.click(screen.getByTestId('permalink-dialog-copy-button'))
 
     expect(copyMock).toHaveBeenCalledTimes(1)
-    expect(copyMock.mock.calls[0][0]).toContain('/p/abc123/my-page')
+    expect(copyMock).toHaveBeenCalledWith(
+      expect.stringContaining('/p/abc123/my-page'),
+    )
   })
 })

--- a/ui/leafwiki-ui/src/features/page/PermalinkDialog.tsx
+++ b/ui/leafwiki-ui/src/features/page/PermalinkDialog.tsx
@@ -5,7 +5,7 @@ import type { Page } from '@/lib/api/pages'
 import { DIALOG_PAGE_PERMALINK } from '@/lib/registries'
 import { buildPermalinkPath, withBasePath } from '@/lib/routePath'
 import copy from 'copy-to-clipboard'
-import { Copy, ExternalLink } from 'lucide-react'
+import { Copy, ExternalLink, Lock } from 'lucide-react'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -80,6 +80,19 @@ export function PermalinkDialog({ page }: PermalinkDialogProps) {
               {t('permalinkDialog.openLink')}
             </a>
           </Button>
+        </div>
+        <p
+          className="text-muted-foreground text-sm"
+          data-testid="permalink-dialog-purpose-note"
+        >
+          {t('permalinkDialog.purposeNote')}
+        </p>
+        <div
+          className="flex items-start gap-2 rounded border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900"
+          data-testid="permalink-dialog-access-note"
+        >
+          <Lock className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>{t('permalinkDialog.accessNote')}</span>
         </div>
       </div>
     </BaseDialog>

--- a/ui/leafwiki-ui/src/locales/de/page.json
+++ b/ui/leafwiki-ui/src/locales/de/page.json
@@ -80,11 +80,13 @@
     "copyErrorToast": "Permalink konnte nicht kopiert werden",
     "copiedToast": "Permalink kopiert",
     "title": "Seite teilen",
-    "description": "Teilbare URL für {{title}}",
+    "description": "Permanenter Link zu {{title}}",
     "close": "Schließen",
-    "urlLabel": "Teilbare URL",
+    "urlLabel": "Permanenter Link",
     "copyLink": "Link kopieren",
-    "openLink": "Link öffnen"
+    "openLink": "Link öffnen",
+    "purposeNote": "Dies ist ein permanenter interner Link. Er funktioniert auch nach dem Umbenennen oder Verschieben der Seite weiter und eignet sich daher für Lesezeichen oder Verweise von anderen Seiten.",
+    "accessNote": "Es ist kein öffentlicher Link. Wer ihn erhält, muss sich weiterhin in diesem Wiki anmelden, um ihn zu öffnen – es sei denn, das gesamte Wiki ist auf öffentlichen Zugriff gestellt. LeafWiki kann keine einzelne Seite öffentlich machen, während der Rest privat bleibt."
   },
   "createByPathDialog": {
     "createdToast": "Seite erfolgreich erstellt",

--- a/ui/leafwiki-ui/src/locales/en/page.json
+++ b/ui/leafwiki-ui/src/locales/en/page.json
@@ -80,11 +80,13 @@
     "copyErrorToast": "Could not copy permalink",
     "copiedToast": "Permalink copied",
     "title": "Share page",
-    "description": "Shareable URL for {{title}}",
+    "description": "Permanent link to {{title}}",
     "close": "Close",
-    "urlLabel": "Shareable URL",
+    "urlLabel": "Permanent link",
     "copyLink": "Copy link",
-    "openLink": "Open link"
+    "openLink": "Open link",
+    "purposeNote": "This is a permanent internal link. It keeps working even after the page is renamed or moved, so it's safe to bookmark or reference from other pages.",
+    "accessNote": "It is not a public link. Anyone you send it to still needs to sign in to this wiki to open it, unless the whole wiki is set to public access. LeafWiki can't make a single page public while the rest stays private."
   },
   "createByPathDialog": {
     "createdToast": "Page created successfully",


### PR DESCRIPTION
## Why

Follow-up to #1258 ("When I share a page with others, it requires login"). The **Share page** dialog only rendered a bare URL labelled "Shareable URL", so users reasonably expected a link anyone could open. LeafWiki authentication is all-or-nothing per instance, so a permalink from a login-required wiki always prompts the recipient to sign in — and there is no per-page public flag.

Rather than change the auth model, this makes the dialog say what the link actually is.

## Changes

- Reworded around **"Permanent link"** instead of "Shareable URL" (`description`, `urlLabel`).
- Added a muted helper line: the link keeps working after the page is renamed or moved, so it's safe to bookmark or reference.
- Added an amber caveat box (lock icon, same idiom as the backlink warning in `DeletePageDialog`): it is **not** a public link — recipients still need an account unless the whole wiki is set to public access, and a single page can't be made public while the rest stays private.
- Strings added to the `en` and `de` `page` namespaces.
- New `PermalinkDialog.test.tsx` covering both notes and that the copy button copies the fully-qualified permalink URL.

## Verification

- `vitest run src/features/page/` — 16 passing (5 files).
- eslint / prettier / tsc clean.