### PR TITLE
fix(e2e): build the binary in run.sh local mode instead of go run

### DIFF
--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -9,6 +9,7 @@ app_url="${E2E_BASE_URL:-http://localhost:${app_port}}"
 run_mode="${E2E_RUN_MODE:-docker}"
 server_pid=""
 server_log=""
+server_bin=""
 local_data_dir=""
 docker_data_volume=""
 
@@ -102,12 +103,24 @@ start_local() {
 
   local_data_dir="$(mktemp -d /tmp/leafwiki-e2e-data.XXXXXX)"
   server_log="$(mktemp /tmp/leafwiki-e2e-server.XXXXXX.log)"
+  server_bin="$(mktemp /tmp/leafwiki-e2e-bin.XXXXXX)"
+
+  # Build the binary first, then run it directly in the background. Using
+  # `go run` here would make `$!` the PID of the `go run` wrapper, not of the
+  # compiled server it execs as a child — so `stop_local`'s `kill` would leave
+  # the real server orphaned, holding the port after the script exits.
+  echo "🔨 Building leafwiki binary for local E2E run..."
+  (
+    cd "$repo_root"
+    go build \
+      -ldflags="-X github.com/perber/wiki/internal/http.EmbedFrontend=true -X github.com/perber/wiki/internal/http.Environment=production -X github.com/perber/wiki/internal/wiki/auth.DisableRefreshTokenRateLimit=true" \
+      -o "$server_bin" \
+      ./cmd/leafwiki
+  )
 
   (
     cd "$repo_root"
-    go run \
-      -ldflags="-X github.com/perber/wiki/internal/http.EmbedFrontend=true -X github.com/perber/wiki/internal/http.Environment=production -X github.com/perber/wiki/internal/wiki/auth.DisableRefreshTokenRateLimit=true" \
-      ./cmd/leafwiki \
+    exec "$server_bin" \
       --host 127.0.0.1 \
       --port "$app_port" \
       --data-dir "$local_data_dir" \
@@ -136,6 +149,10 @@ stop_local() {
 
   if [ -n "$server_log" ] && [ -f "$server_log" ]; then
     rm -f "$server_log"
+  fi
+
+  if [ -n "$server_bin" ] && [ -f "$server_bin" ]; then
+    rm -f "$server_bin"
   fi
 }
 


### PR DESCRIPTION
## Problem

`E2E_RUN_MODE=local ./e2e/run.sh` (`make run-e2e-local`) starts the server with:

```sh
go run -ldflags="..." ./cmd/leafwiki ... &
server_pid=$!
```

`go run` compiles to a temp binary and execs it as a **child**, so `$!` is the PID of the `go run` wrapper, not of the server. `stop_local()` then does `kill "$server_pid"` / `wait`, which reaps the wrapper but leaves the compiled binary running and holding the port (default 8085) after the script exits. Every local run then fails with `❌ Port 8085 is already in use.` until both PIDs are killed by hand. Docker mode is unaffected — the container boundary kills the whole tree on `docker stop`.

## Fix

`start_local()` now builds the binary once with `go build -o "$server_bin"` (same ldflags as before) and runs it directly in a backgrounded subshell via `exec`, so `$!` is the real server PID and the existing plain `kill` in `stop_local()` reaps it. The temp binary is cleaned up in `stop_local()` alongside the data dir and log.

## Verification

- `bash -n e2e/run.sh` clean
- `go build` with the exact E2E ldflags compiles; the binary boots and accepts the flags
- Confirmed the `( cd …; exec "$bin" ) &` pattern makes `$!` resolve to the binary itself and leaves no orphan after `kill`
- Docker path untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)