### PR TITLE
feat(metrics): scrape-time content/user gauges + Go & process collectors

### DIFF
--- a/internal/core/tree/tree_service.go
+++ b/internal/core/tree/tree_service.go
@@ -814,6 +814,23 @@ func (t *TreeService) HasPages() bool {
 	return t.tree != nil && len(t.tree.Children) > 0
 }
 
+// NodeCounts returns how many page and section nodes the tree currently holds,
+// excluding the synthetic root. It reads the in-memory id index under the read
+// lock and allocates nothing, so it is cheap enough to call on every metrics
+// scrape. A node whose kind is unset is counted as a page.
+func (t *TreeService) NodeCounts() (pages, sections int) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	for _, node := range t.nodesByID {
+		if node.Kind == NodeKindSection {
+			sections++
+			continue
+		}
+		pages++
+	}
+	return pages, sections
+}
+
 // WalkNodes calls fn with the ID of every non-root node (pages and sections)
 // in depth-first order. The read lock is held only while collecting IDs; fn
 // is called without any lock held so it may safely call other TreeService

--- a/internal/core/tree/tree_service_test.go
+++ b/internal/core/tree/tree_service_test.go
@@ -3401,3 +3401,34 @@ func TestTreeService_GetPage_RawContent_NotSerializedToJSON(t *testing.T) {
 		t.Errorf("RawContent must not appear in JSON output, got: %s", s)
 	}
 }
+
+func TestTreeService_NodeCounts_TalliesPagesAndSectionsSeparately(t *testing.T) {
+	svc, tmpDir := newLoadedService(t)
+
+	if pages, sections := svc.NodeCounts(); pages != 0 || sections != 0 {
+		t.Fatalf("empty tree: expected 0 pages / 0 sections, got %d / %d", pages, sections)
+	}
+
+	if _, err := svc.CreateNode("system", nil, "Alpha", "alpha", ptrKind(NodeKindPage)); err != nil {
+		t.Fatalf("CreateNode Alpha failed: %v", err)
+	}
+	if _, err := svc.CreateNode("system", nil, "Beta", "beta", ptrKind(NodeKindPage)); err != nil {
+		t.Fatalf("CreateNode Beta failed: %v", err)
+	}
+	if _, err := svc.CreateNode("system", nil, "Docs", "docs", ptrKind(NodeKindSection)); err != nil {
+		t.Fatalf("CreateNode Docs failed: %v", err)
+	}
+
+	if pages, sections := svc.NodeCounts(); pages != 2 || sections != 1 {
+		t.Fatalf("expected 2 pages / 1 section, got %d / %d", pages, sections)
+	}
+
+	// Counts must survive a reload from disk (index rebuilt in LoadTree).
+	reloaded := NewTreeService(tmpDir)
+	if err := reloaded.LoadTree(); err != nil {
+		t.Fatalf("LoadTree failed: %v", err)
+	}
+	if pages, sections := reloaded.NodeCounts(); pages != 2 || sections != 1 {
+		t.Fatalf("after reload: expected 2 pages / 1 section, got %d / %d", pages, sections)
+	}
+}

--- a/internal/http/metrics/metrics.go
+++ b/internal/http/metrics/metrics.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -231,6 +232,16 @@ func NewHTTPMetrics(version string) *HTTPMetrics {
 			Help:      "Total number of TOTP enrollment changes by event type.",
 		},
 		[]string{"event"},
+	)
+
+	// Standard Go runtime and process collectors, so the endpoint also carries
+	// the baseline ops signals (goroutines, heap, GC pauses, open FDs, RSS,
+	// CPU seconds) under their conventional go_* / process_* names. The process
+	// collector reads /proc and is a silent no-op on Windows; the Go collector
+	// works everywhere.
+	registry.MustRegister(
+		collectors.NewGoCollector(),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 	)
 
 	registry.MustRegister(

--- a/internal/http/metrics/metrics_test.go
+++ b/internal/http/metrics/metrics_test.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -62,6 +63,27 @@ func TestHTTPMetrics_ExportsBuildInfoWithVersionLabel(t *testing.T) {
 	expected := `leafwiki_build_info{version="v0.12.0"} 1`
 	if !strings.Contains(body, expected) {
 		t.Fatalf("expected metrics output to contain %q, got: %s", expected, body)
+	}
+}
+
+func TestHTTPMetrics_ExportsGoRuntimeAndProcessMetrics(t *testing.T) {
+	metrics := NewHTTPMetrics("test")
+
+	body := getMetricsBody(t, metrics.HTTPHandler())
+
+	for _, want := range []string{"go_goroutines", "go_gc_duration_seconds", "go_memstats_alloc_bytes"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected Go runtime metric %q in /metrics output, got: %s", want, body)
+		}
+	}
+
+	// The process collector reads /proc and only emits on Linux.
+	if runtime.GOOS == "linux" {
+		for _, want := range []string{"process_resident_memory_bytes", "process_cpu_seconds_total", "process_open_fds"} {
+			if !strings.Contains(body, want) {
+				t.Fatalf("expected process metric %q in /metrics output, got: %s", want, body)
+			}
+		}
 	}
 }
 

--- a/internal/http/metrics/runtime_collector.go
+++ b/internal/http/metrics/runtime_collector.go
@@ -1,0 +1,121 @@
+package metrics
+
+import (
+	"log/slog"
+	"sort"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// PageStats is a point-in-time snapshot of how much content the wiki holds.
+type PageStats struct {
+	Pages    int
+	Sections int
+}
+
+// UserStats is a point-in-time snapshot of the user base. ByRole should be
+// pre-seeded by the caller with every role it wants exported (zero included),
+// so a role's series does not vanish when its count drops to zero.
+type UserStats struct {
+	ByRole        map[string]int
+	TOTPEnabled   int
+	PendingInvite int
+}
+
+// RuntimeStatsSource supplies the values behind the scrape-time content and
+// user gauges. Both methods are called on every /metrics scrape, so they must
+// be cheap; an error makes that scrape skip the affected gauges.
+type RuntimeStatsSource interface {
+	PageStats() (PageStats, error)
+	UserStats() (UserStats, error)
+}
+
+// runtimeCollector is a prometheus.Collector that reads its values from a
+// RuntimeStatsSource at scrape time rather than tracking them incrementally.
+// Counts like "how many pages" and "how many users" have no natural event to
+// hook a counter onto and are always a current total, so a pull-based gauge
+// collector is the honest representation.
+type runtimeCollector struct {
+	src RuntimeStatsSource
+	log *slog.Logger
+
+	pages         *prometheus.Desc
+	users         *prometheus.Desc
+	usersWithTOTP *prometheus.Desc
+	usersPending  *prometheus.Desc
+}
+
+func newRuntimeCollector(src RuntimeStatsSource) *runtimeCollector {
+	return &runtimeCollector{
+		src: src,
+		log: slog.Default().With("component", "metrics.runtime"),
+		pages: prometheus.NewDesc(
+			"leafwiki_pages",
+			"Current number of nodes in the page tree by kind (page or section).",
+			[]string{"kind"}, nil,
+		),
+		users: prometheus.NewDesc(
+			"leafwiki_users",
+			"Current number of user accounts by role.",
+			[]string{"role"}, nil,
+		),
+		usersWithTOTP: prometheus.NewDesc(
+			"leafwiki_users_with_totp",
+			"Current number of user accounts with TOTP two-factor authentication enabled.",
+			nil, nil,
+		),
+		usersPending: prometheus.NewDesc(
+			"leafwiki_users_pending_invite",
+			"Current number of invited user accounts that have not yet completed sign-up.",
+			nil, nil,
+		),
+	}
+}
+
+func (c *runtimeCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.pages
+	ch <- c.users
+	ch <- c.usersWithTOTP
+	ch <- c.usersPending
+}
+
+// Collect emits the current gauge values. A source error skips only the
+// affected gauges for this scrape (logged at debug, since a persistent
+// failure would otherwise flood the log on every scrape interval) and keeps
+// the rest of /metrics serving normally.
+func (c *runtimeCollector) Collect(ch chan<- prometheus.Metric) {
+	if ps, err := c.src.PageStats(); err != nil {
+		c.log.Debug("skipping page gauges for this scrape", "error", err)
+	} else {
+		ch <- prometheus.MustNewConstMetric(c.pages, prometheus.GaugeValue, float64(ps.Pages), "page")
+		ch <- prometheus.MustNewConstMetric(c.pages, prometheus.GaugeValue, float64(ps.Sections), "section")
+	}
+
+	us, err := c.src.UserStats()
+	if err != nil {
+		c.log.Debug("skipping user gauges for this scrape", "error", err)
+		return
+	}
+
+	roles := make([]string, 0, len(us.ByRole))
+	for role := range us.ByRole {
+		roles = append(roles, role)
+	}
+	sort.Strings(roles)
+	for _, role := range roles {
+		ch <- prometheus.MustNewConstMetric(c.users, prometheus.GaugeValue, float64(us.ByRole[role]), role)
+	}
+
+	ch <- prometheus.MustNewConstMetric(c.usersWithTOTP, prometheus.GaugeValue, float64(us.TOTPEnabled))
+	ch <- prometheus.MustNewConstMetric(c.usersPending, prometheus.GaugeValue, float64(us.PendingInvite))
+}
+
+// RegisterRuntimeStats wires a RuntimeStatsSource into the Prometheus registry
+// as a scrape-time collector. It is a no-op when metrics are disabled (m nil)
+// or no source is given. Call it exactly once, after the wiki is fully built.
+func (m *HTTPMetrics) RegisterRuntimeStats(src RuntimeStatsSource) {
+	if m == nil || src == nil {
+		return
+	}
+	m.registry.MustRegister(newRuntimeCollector(src))
+}

--- a/internal/http/metrics/runtime_collector_test.go
+++ b/internal/http/metrics/runtime_collector_test.go
@@ -1,0 +1,68 @@
+package metrics
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+type fakeRuntimeSource struct {
+	pages    PageStats
+	pagesErr error
+	users    UserStats
+	usersErr error
+}
+
+func (f fakeRuntimeSource) PageStats() (PageStats, error) { return f.pages, f.pagesErr }
+func (f fakeRuntimeSource) UserStats() (UserStats, error) { return f.users, f.usersErr }
+
+func TestHTTPMetrics_RegisterRuntimeStats_ExportsContentAndUserGauges(t *testing.T) {
+	m := NewHTTPMetrics("test")
+	m.RegisterRuntimeStats(fakeRuntimeSource{
+		pages: PageStats{Pages: 42, Sections: 7},
+		users: UserStats{
+			ByRole:        map[string]int{"admin": 1, "editor": 3, "viewer": 0},
+			TOTPEnabled:   2,
+			PendingInvite: 1,
+		},
+	})
+
+	body := getMetricsBody(t, m.HTTPHandler())
+
+	for _, want := range []string{
+		`leafwiki_pages{kind="page"} 42`,
+		`leafwiki_pages{kind="section"} 7`,
+		`leafwiki_users{role="admin"} 1`,
+		`leafwiki_users{role="editor"} 3`,
+		`leafwiki_users{role="viewer"} 0`,
+		`leafwiki_users_with_totp 2`,
+		`leafwiki_users_pending_invite 1`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected metrics output to contain %q, got:\n%s", want, body)
+		}
+	}
+}
+
+func TestHTTPMetrics_RegisterRuntimeStats_SkipsGaugesWhenSourceErrors(t *testing.T) {
+	m := NewHTTPMetrics("test")
+	m.RegisterRuntimeStats(fakeRuntimeSource{
+		pagesErr: errors.New("tree not loaded"),
+		usersErr: errors.New("user store unavailable"),
+	})
+
+	// A source error must not break the whole endpoint: /metrics still
+	// serves 200 with the other metrics, just without the runtime gauges.
+	body := getMetricsBody(t, m.HTTPHandler())
+	if !strings.Contains(body, "leafwiki_build_info") {
+		t.Fatalf("expected the rest of /metrics to keep working, got:\n%s", body)
+	}
+	if strings.Contains(body, "leafwiki_pages{") || strings.Contains(body, "leafwiki_users{") {
+		t.Errorf("expected no runtime gauge samples when source errors, got:\n%s", body)
+	}
+}
+
+func TestHTTPMetrics_RegisterRuntimeStats_NilReceiverIsNoop(t *testing.T) {
+	var m *HTTPMetrics
+	m.RegisterRuntimeStats(fakeRuntimeSource{}) // must not panic
+}

--- a/internal/wiki/metrics_runtime.go
+++ b/internal/wiki/metrics_runtime.go
@@ -1,0 +1,46 @@
+package wiki
+
+import (
+	"github.com/perber/wiki/internal/core/auth"
+	httpmetrics "github.com/perber/wiki/internal/http/metrics"
+)
+
+// runtimeStatsSource adapts the wiki's tree and user services to the
+// httpmetrics.RuntimeStatsSource interface behind the scrape-time
+// leafwiki_pages / leafwiki_users gauges. It holds the *Wiki rather than the
+// concrete services so UserStats always reads the current, restore-swap-aware
+// UserService (see Wiki.UserService).
+type runtimeStatsSource struct {
+	w *Wiki
+}
+
+func (s runtimeStatsSource) PageStats() (httpmetrics.PageStats, error) {
+	pages, sections := s.w.tree.NodeCounts()
+	return httpmetrics.PageStats{Pages: pages, Sections: sections}, nil
+}
+
+func (s runtimeStatsSource) UserStats() (httpmetrics.UserStats, error) {
+	users, err := s.w.UserService().GetUsers()
+	if err != nil {
+		return httpmetrics.UserStats{}, err
+	}
+
+	// Seed every known role so its series stays present at zero.
+	stats := httpmetrics.UserStats{
+		ByRole: map[string]int{
+			auth.RoleAdmin:  0,
+			auth.RoleEditor: 0,
+			auth.RoleViewer: 0,
+		},
+	}
+	for _, u := range users {
+		stats.ByRole[u.Role]++
+		if u.TOTPEnabled {
+			stats.TOTPEnabled++
+		}
+		if u.MustSetPassword {
+			stats.PendingInvite++
+		}
+	}
+	return stats, nil
+}

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -176,6 +176,7 @@ func NewWiki(options *WikiOptions) (*Wiki, error) {
 			})
 		w.ensureBaselineRevisions()
 	}
+	w.metrics.RegisterRuntimeStats(runtimeStatsSource{w: w})
 	w.buildRoutes(options)
 	return w, nil
 }

--- a/internal/wiki/wiki_test.go
+++ b/internal/wiki/wiki_test.go
@@ -168,6 +168,34 @@ func TestWiki_TriggerResyncAsync_EmitsMetrics(t *testing.T) {
 	}
 }
 
+func TestWiki_Metrics_ExposesPageAndUserGauges(t *testing.T) {
+	metrics := httpmetrics.NewHTTPMetrics("test")
+	w := createWikiTestInstanceWithMetrics(t, metrics)
+	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
+
+	body := metricsBody(t, metrics)
+	// Fresh instance: the seeded admin plus the auto-created welcome page.
+	if !strings.Contains(body, `leafwiki_users{role="admin"} 1`) {
+		t.Fatalf("expected one admin user gauge, got: %s", body)
+	}
+	if !strings.Contains(body, `leafwiki_users{role="editor"} 0`) {
+		t.Fatalf("expected editor role series seeded at zero, got: %s", body)
+	}
+	if !strings.Contains(body, `leafwiki_users_with_totp 0`) {
+		t.Fatalf("expected totp gauge at zero, got: %s", body)
+	}
+	if !strings.Contains(body, `leafwiki_pages{kind="page"} 1`) {
+		t.Fatalf("expected one page (welcome) gauge, got: %s", body)
+	}
+
+	createPageForTest(t, w, "system", nil, "Second", "second", pageNodeKind())
+
+	body = metricsBody(t, metrics)
+	if !strings.Contains(body, `leafwiki_pages{kind="page"} 2`) {
+		t.Fatalf("expected page gauge to reflect the new page, got: %s", body)
+	}
+}
+
 func TestWiki_DeletePage_PurgesRevisionData(t *testing.T) {
 	w := createWikiTestInstance(t)
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)


### PR DESCRIPTION
## Related issue

No GitHub issue — tracked internally as *Prometheus Plan 3: Content and User Gauges* plus a baseline-ops follow-up.

## What changed

Two commits.

### 1. Scrape-time content and user gauges

The existing exposition instruments *flow* (requests, page-save, refactor, resync, auth events) but could not answer the two most basic "how big is this instance" questions. Adds a pull-based `prometheus.Collector` that reads fresh values in `Collect()`:

| Metric | Labels |
| --- | --- |
| `leafwiki_pages` | `kind="page"｜"section"` |
| `leafwiki_users` | `role="admin"｜"editor"｜"viewer"` |
| `leafwiki_users_with_totp` | – |
| `leafwiki_users_pending_invite` | – |

- Page/section counts: new `TreeService.NodeCounts()` — walk of the in-memory id index under `RLock`, no allocation.
- User counts: a single `UserService().GetUsers()` snapshot per scrape.
- The metrics package defines `RuntimeStatsSource` over plain structs; the `internal/wiki` adapter holds `*Wiki` so `UserStats` always reads the current, restore-swap-aware `UserService`.
- Role series are seeded so `leafwiki_users{role="editor"} 0` does not vanish when the last editor is deleted.
- A source error skips only the affected gauges for that scrape (logged at debug) and keeps the rest of `/metrics` serving 200.
- Wired once from `NewWiki` via `HTTPMetrics.RegisterRuntimeStats` (no-op when metrics are disabled).

### 2. Go runtime and process collectors

`/metrics` used a bare custom registry, so it carried only `leafwiki_*` and none of the baseline ops signals. Registers `collectors.NewGoCollector()` and `collectors.NewProcessCollector()` so scrapes also expose goroutines, heap, GC pauses, open FDs, RSS and CPU seconds under their conventional `go_*` / `process_*` names. The process collector reads `/proc` and is a silent no-op on Windows; the Go collector is portable.

## Checklist

- [x] Approach tracked on the internal plan before starting
- [x] Focused on a single change (metrics/observability)
- [x] No frontend changes — `npm run format` N/A
- [x] Docs updated (internal source map + plan)

## Tests

- New: `TestTreeService_NodeCounts_*`, `TestHTTPMetrics_RegisterRuntimeStats_*`, `TestWiki_Metrics_ExposesPageAndUserGauges`, `TestHTTPMetrics_ExportsGoRuntimeAndProcessMetrics`.
- `go test ./internal/http/metrics/ ./internal/core/tree/ ./internal/wiki/ ./internal/http/` green; `golangci-lint` v2 clean.