### PR TITLE
fix(page): show page/section name in delete confirmation dialog

### DIFF
--- a/e2e/pages/DeletePageDialog.ts
+++ b/e2e/pages/DeletePageDialog.ts
@@ -5,7 +5,7 @@ export default class DeletePageDialog {
 
   dialogText() {
     return this.page.getByText(
-      /Are you sure you want to delete this (page|section)\? This action cannot be undone\./,
+      /Are you sure you want to delete the (page|section) ".*"\? This action cannot be undone\./,
     );
   }
 

--- a/ui/leafwiki-ui/src/features/page/DeletePageDialog.tsx
+++ b/ui/leafwiki-ui/src/features/page/DeletePageDialog.tsx
@@ -127,7 +127,10 @@ export function DeletePageDialog({
     <BaseDialog
       dialogType={DIALOG_DELETE_PAGE_CONFIRMATION}
       dialogTitle={t('deleteDialog.title', { item: itemLabelCapitalized })}
-      dialogDescription={t('deleteDialog.description', { item: itemLabel })}
+      dialogDescription={t('deleteDialog.description', {
+        item: itemLabel,
+        name: page.title,
+      })}
       onClose={() => true}
       onConfirm={async (): Promise<boolean> => {
         return await handleDelete()

--- a/ui/leafwiki-ui/src/locales/de/page.json
+++ b/ui/leafwiki-ui/src/locales/de/page.json
@@ -35,7 +35,7 @@
     "deletedToast": "{{item}} erfolgreich gelöscht",
     "deleteErrorFallback": "Fehler beim Löschen von {{item}}",
     "title": "{{item}} löschen?",
-    "description": "Möchten Sie {{item}} wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
+    "description": "Möchten Sie {{item}} \"{{name}}\" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
     "deleting": "Wird gelöscht...",
     "delete": "Löschen",
     "modifiedWarningTitle": "Diese Seite wurde von einem anderen Benutzer geändert.",

--- a/ui/leafwiki-ui/src/locales/en/page.json
+++ b/ui/leafwiki-ui/src/locales/en/page.json
@@ -35,7 +35,7 @@
     "deletedToast": "{{item}} deleted successfully",
     "deleteErrorFallback": "Error deleting {{item}}",
     "title": "Delete {{item}}?",
-    "description": "Are you sure you want to delete this {{item}}? This action cannot be undone.",
+    "description": "Are you sure you want to delete the {{item}} \"{{name}}\"? This action cannot be undone.",
     "deleting": "Deleting...",
     "delete": "Delete",
     "modifiedWarningTitle": "This page was modified by another user.",


### PR DESCRIPTION
## Summary
As reported in #1502 (and discussion #1501), the delete confirmation dialog gave no indication of which page/section was about to be deleted — just "Are you sure you want to delete this page? This action cannot be undone." It's easy to accidentally confirm deletion of the wrong item after clicking through the "More Actions" menu, since the reporter noted the row loses its highlight once the menu closes.

This PR addresses the primary, concretely-requested part of the issue: showing the item's name in the dialog, per the reporter's suggested wording ("At the least, this box should state: 'Are you sure you want to delete *\<page-name\>*?...'").

## Changes
- `DeletePageDialog.tsx`: pass `page.title` into the `deleteDialog.description` translation alongside the existing `item` (page/section label).
- `locales/en/page.json` and `locales/de/page.json`: interpolate `{{name}}` into the description string.
- `e2e/pages/DeletePageDialog.ts`: updated the Playwright page object's `dialogText()` regex to match the new copy (name-agnostic, so existing specs that don't care about the specific title still pass).

## Out of scope
The discussion also raised keeping the row visually highlighted while the dialog is open — that's a separate, more involved change to the tree/menu highlighting state, and I've kept this PR focused on the concrete, quoted ask so it stays small and easy to review. Happy to follow up with that separately if useful.

## Testing
- `tsc -b` passes with no errors.
- `eslint` and `prettier --check` pass on all changed files (both `ui/leafwiki-ui` and `e2e`).
- Verified no other test/spec hardcodes the old dialog text (grepped the whole repo).
- Wasn't able to run the full Playwright e2e suite in this environment (it needs the Go backend running + browser install), but the updated regex was checked by hand against the new interpolated string for both the page and section cases.

Closes #1502

🤖 Generated with [Claude Code](https://claude.com/claude-code)