### PR TITLE
feat(publicaccess): runtime-capable public-mode provider (1/6)

### DIFF
--- a/cmd/leafwiki/main.go
+++ b/cmd/leafwiki/main.go
@@ -30,6 +30,7 @@ import (
 	httpinternal "github.com/perber/wiki/internal/http"
 	httpmetrics "github.com/perber/wiki/internal/http/metrics"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
+	"github.com/perber/wiki/internal/publicaccess"
 	"github.com/perber/wiki/internal/restore"
 	"github.com/perber/wiki/internal/snapshot"
 	"github.com/perber/wiki/internal/wiki"
@@ -213,6 +214,8 @@ func runServerCommand(_ context.Context, cmd *cli.Command, cfg *serverConfig) er
 		slog.Default().Info("Data directory created", "path", cfg.server.dataDir)
 	}
 
+	publicAccessService := buildPublicAccessService(cmd, cfg, publicAccess)
+
 	if !cfg.auth.disableAuth {
 		if cfg.auth.jwtSecret == "" {
 			fail("JWT secret is required. Set it using --jwt-secret or LEAFWIKI_JWT_SECRET environment variable.")
@@ -348,6 +351,7 @@ func runServerCommand(_ context.Context, cmd *cli.Command, cfg *serverConfig) er
 			Favorites:          w.Favorites(),
 			UserSettings:       w.UserSettingsService(),
 			BrandingService:    w.BrandingService(),
+			PublicAccess:       publicAccessService,
 			UserResolver:       w.UserResolver(),
 			TriggerResync:      w.TriggerResyncAsync,
 			MaxUploadSizeBytes: restoreUploadMaxSize,
@@ -360,7 +364,7 @@ func runServerCommand(_ context.Context, cmd *cli.Command, cfg *serverConfig) er
 	}
 
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            publicAccess,
+		PublicAccess:            publicAccessService,
 		EditorLimit:             cfg.auth.editorLimit,
 		InjectCodeInHeader:      cfg.frontend.injectCodeInHeader,
 		CustomStylesheet:        cfg.frontend.customStylesheet,
@@ -411,6 +415,24 @@ func runServerCommand(_ context.Context, cmd *cli.Command, cfg *serverConfig) er
 	}
 
 	return nil
+}
+
+// buildPublicAccessService decides whether "public mode" is pinned by
+// environment configuration or toggleable at runtime from Settings.
+//
+// It is env-managed when --public-access / LEAFWIKI_PUBLIC_ACCESS was supplied
+// explicitly, or when --disable-auth forces public mode on. Otherwise it is
+// settings-managed, reading its initial value from
+// <data-dir>/public-access.json (absent ⇒ disabled).
+func buildPublicAccessService(cmd *cli.Command, cfg *serverConfig, resolvedPublicAccess bool) *publicaccess.Service {
+	if cmd.IsSet("public-access") || cfg.auth.disableAuth {
+		return publicaccess.NewEnvManaged(resolvedPublicAccess)
+	}
+	svc, err := publicaccess.NewSettingsManaged(cfg.server.dataDir)
+	if err != nil {
+		fail("Failed to load public-access configuration", "error", err)
+	}
+	return svc
 }
 
 func runServer(

--- a/internal/http/apikeys_router_test.go
+++ b/internal/http/apikeys_router_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/perber/wiki/internal/core/assets"
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	httpinternal "github.com/perber/wiki/internal/http"
+	"github.com/perber/wiki/internal/publicaccess"
 	"github.com/perber/wiki/internal/test_utils"
 	"github.com/perber/wiki/internal/wiki"
 )
@@ -37,7 +38,7 @@ func newAPIKeyRouterTest(t *testing.T) (*wiki.Wiki, http.Handler) {
 	}
 	t.Cleanup(func() { test_utils.WrapCloseWithErrorCheck(w.Close, t) })
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            false,
+		PublicAccess:            publicaccess.NewEnvManaged(false),
 		AllowInsecure:           true,
 		AccessTokenTimeout:      15 * time.Minute,
 		RefreshTokenTimeout:     7 * 24 * time.Hour,

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -88,9 +88,28 @@ type HTTPRemoteUserConfig struct {
 	UserService func() *coreauth.UserService
 }
 
+// PublicAccessProvider reports the current "public mode" state (anonymous read
+// access to every page). It is read per request rather than snapshotted at
+// route-registration time so the flag can be toggled at runtime with no
+// restart. *publicaccess.Service satisfies it. EnvManaged reports whether the
+// value is pinned by environment configuration (Settings UI shows it
+// read-only); it never changes for the life of the process.
+type PublicAccessProvider interface {
+	Enabled() bool
+	EnvManaged() bool
+}
+
+// staticPublicAccess is the fallback PublicAccessProvider used when
+// RouterOptions.PublicAccess is left nil (tests, embedders that don't care).
+// It reports a fixed value and, being immutable, presents as env-managed.
+type staticPublicAccess bool
+
+func (s staticPublicAccess) Enabled() bool    { return bool(s) }
+func (s staticPublicAccess) EnvManaged() bool { return true }
+
 // RouterOptions holds global HTTP server configuration shared across all domains.
 type RouterOptions struct {
-	PublicAccess            bool                     // Whether the wiki allows public read access
+	PublicAccess            PublicAccessProvider     // Current public read-access state; read per request
 	EditorLimit             int                      // Max admin+editor users allowed; 0 = unlimited
 	InjectCodeInHeader      string                   // Raw HTML/JS code to inject into the <head> tag
 	CustomStylesheet        string                   // Path to a custom CSS file (resolved by wiki before passing)
@@ -137,6 +156,10 @@ type FrontendConfig struct {
 func NewRouter(registrars []RouteRegistrar, frontendCfg FrontendConfig, opts RouterOptions) *gin.Engine {
 	if opts.MaxAssetUploadSizeBytes <= 0 {
 		opts.MaxAssetUploadSizeBytes = assets.DefaultMaxUploadSizeBytes
+	}
+
+	if opts.PublicAccess == nil {
+		opts.PublicAccess = staticPublicAccess(false)
 	}
 
 	if Environment == "production" {

--- a/internal/http/router_test.go
+++ b/internal/http/router_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/perber/wiki/internal/core/tree"
 	httpinternal "github.com/perber/wiki/internal/http"
 	httpmetrics "github.com/perber/wiki/internal/http/metrics"
+	"github.com/perber/wiki/internal/publicaccess"
 	"github.com/perber/wiki/internal/test_utils"
 	"github.com/perber/wiki/internal/wiki"
 )
@@ -54,7 +55,7 @@ func createRouterTestInstance(w *wiki.Wiki, t *testing.T) *gin.Engine {
 
 func createRouterTestInstanceWithMetricsEnabled(w *wiki.Wiki, t *testing.T) *gin.Engine {
 	return httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            false,
+		PublicAccess:            publicaccess.NewEnvManaged(false),
 		InjectCodeInHeader:      "",
 		CustomStylesheet:        "",
 		AllowInsecure:           true,
@@ -68,7 +69,7 @@ func createRouterTestInstanceWithMetricsEnabled(w *wiki.Wiki, t *testing.T) *gin
 
 func createRouterTestInstanceWithRevision(w *wiki.Wiki, t *testing.T) *gin.Engine {
 	return httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            false,
+		PublicAccess:            publicaccess.NewEnvManaged(false),
 		InjectCodeInHeader:      "",
 		CustomStylesheet:        "",
 		AllowInsecure:           true,
@@ -82,7 +83,7 @@ func createRouterTestInstanceWithRevision(w *wiki.Wiki, t *testing.T) *gin.Engin
 
 func createRouterTestInstanceWithMaxAssetUploadSize(w *wiki.Wiki, t *testing.T, maxAssetUploadSizeBytes int64) *gin.Engine {
 	return httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            false,
+		PublicAccess:            publicaccess.NewEnvManaged(false),
 		InjectCodeInHeader:      "",
 		CustomStylesheet:        "",
 		AllowInsecure:           true,
@@ -95,7 +96,7 @@ func createRouterTestInstanceWithMaxAssetUploadSize(w *wiki.Wiki, t *testing.T, 
 
 func createRouterTestInstanceWithAllowInsecure(w *wiki.Wiki, allowInsecure bool, t *testing.T) *gin.Engine {
 	return httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            false,
+		PublicAccess:            publicaccess.NewEnvManaged(false),
 		InjectCodeInHeader:      "",
 		CustomStylesheet:        "",
 		AllowInsecure:           allowInsecure,
@@ -1064,7 +1065,7 @@ func TestConfigEndpoint_IncludesMaxAssetUploadSizeBytes(t *testing.T) {
 
 	const maxAssetUploadSizeBytes int64 = 123456
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            true,
+		PublicAccess:            publicaccess.NewEnvManaged(true),
 		InjectCodeInHeader:      "",
 		AllowInsecure:           true,
 		AccessTokenTimeout:      15 * time.Minute,
@@ -1101,7 +1102,7 @@ func TestConfigEndpoint_IncludesEnableLinkRefactor(t *testing.T) {
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
 
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            true,
+		PublicAccess:            publicaccess.NewEnvManaged(true),
 		InjectCodeInHeader:      "",
 		AllowInsecure:           true,
 		AccessTokenTimeout:      15 * time.Minute,
@@ -1139,7 +1140,7 @@ func TestConfigEndpoint_IncludesEnableAPIKeyManagement(t *testing.T) {
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
 
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            true,
+		PublicAccess:            publicaccess.NewEnvManaged(true),
 		InjectCodeInHeader:      "",
 		AllowInsecure:           true,
 		AccessTokenTimeout:      15 * time.Minute,
@@ -1177,7 +1178,7 @@ func TestConfigEndpoint_EnableAPIKeyManagementDefaultsToFalse(t *testing.T) {
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
 
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            true,
+		PublicAccess:            publicaccess.NewEnvManaged(true),
 		AllowInsecure:           true,
 		AccessTokenTimeout:      15 * time.Minute,
 		RefreshTokenTimeout:     7 * 24 * time.Hour,
@@ -1212,7 +1213,7 @@ func TestConfigEndpoint_IncludesTOTPAvailable(t *testing.T) {
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
 
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            true,
+		PublicAccess:            publicaccess.NewEnvManaged(true),
 		InjectCodeInHeader:      "",
 		AllowInsecure:           true,
 		AccessTokenTimeout:      15 * time.Minute,
@@ -1250,7 +1251,7 @@ func TestConfigEndpoint_TOTPAvailableDefaultsToFalse(t *testing.T) {
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
 
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            true,
+		PublicAccess:            publicaccess.NewEnvManaged(true),
 		AllowInsecure:           true,
 		AccessTokenTimeout:      15 * time.Minute,
 		RefreshTokenTimeout:     7 * 24 * time.Hour,
@@ -1285,7 +1286,7 @@ func TestConfigEndpoint_IncludesUserManagementUrl(t *testing.T) {
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
 
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            true,
+		PublicAccess:            publicaccess.NewEnvManaged(true),
 		InjectCodeInHeader:      "",
 		AllowInsecure:           true,
 		AccessTokenTimeout:      15 * time.Minute,
@@ -1323,7 +1324,7 @@ func TestConfigEndpoint_UserManagementUrlDefaultsToEmpty(t *testing.T) {
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
 
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            true,
+		PublicAccess:            publicaccess.NewEnvManaged(true),
 		InjectCodeInHeader:      "",
 		AllowInsecure:           true,
 		AccessTokenTimeout:      15 * time.Minute,
@@ -1360,7 +1361,7 @@ func TestConfigEndpoint_IncludesLoginAndLogoutUrl(t *testing.T) {
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
 
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            true,
+		PublicAccess:            publicaccess.NewEnvManaged(true),
 		InjectCodeInHeader:      "",
 		AllowInsecure:           true,
 		AccessTokenTimeout:      15 * time.Minute,
@@ -1406,7 +1407,7 @@ func TestConfigEndpoint_LoginAndLogoutUrlDefaultToEmpty(t *testing.T) {
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
 
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            true,
+		PublicAccess:            publicaccess.NewEnvManaged(true),
 		InjectCodeInHeader:      "",
 		AllowInsecure:           true,
 		AccessTokenTimeout:      15 * time.Minute,
@@ -1450,7 +1451,7 @@ func TestConfigEndpoint_IncludesDefaultLanguage(t *testing.T) {
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
 
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            true,
+		PublicAccess:            publicaccess.NewEnvManaged(true),
 		InjectCodeInHeader:      "",
 		AllowInsecure:           true,
 		AccessTokenTimeout:      15 * time.Minute,
@@ -1488,7 +1489,7 @@ func TestConfigEndpoint_DefaultLanguageDefaultsToEmpty(t *testing.T) {
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
 
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            true,
+		PublicAccess:            publicaccess.NewEnvManaged(true),
 		InjectCodeInHeader:      "",
 		AllowInsecure:           true,
 		AccessTokenTimeout:      15 * time.Minute,
@@ -1525,7 +1526,7 @@ func TestRefactorPreviewEndpoint_UsesFrontendJSONShape(t *testing.T) {
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
 
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            false,
+		PublicAccess:            publicaccess.NewEnvManaged(false),
 		InjectCodeInHeader:      "",
 		AllowInsecure:           true,
 		AccessTokenTimeout:      15 * time.Minute,
@@ -1584,7 +1585,7 @@ func TestRefactorPreviewEndpoint_IsDisabledWhenFlagIsOff(t *testing.T) {
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
 
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            false,
+		PublicAccess:            publicaccess.NewEnvManaged(false),
 		InjectCodeInHeader:      "",
 		AllowInsecure:           true,
 		AccessTokenTimeout:      15 * time.Minute,
@@ -1607,7 +1608,7 @@ func TestRefactorApply_DoesNotPersistRevisionsWhenRevisionDisabled(t *testing.T)
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
 
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            false,
+		PublicAccess:            publicaccess.NewEnvManaged(false),
 		InjectCodeInHeader:      "",
 		AllowInsecure:           true,
 		AccessTokenTimeout:      15 * time.Minute,
@@ -1663,7 +1664,7 @@ func TestUploadAssetEndpoint_RejectsFilesExceedingConfiguredLimit(t *testing.T) 
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
 
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            false,
+		PublicAccess:            publicaccess.NewEnvManaged(false),
 		InjectCodeInHeader:      "",
 		AllowInsecure:           true,
 		AccessTokenTimeout:      15 * time.Minute,
@@ -3275,7 +3276,7 @@ func TestGetPagePermalinkEndpoint_PublicAccessAllowsUnauthenticatedReads(t *test
 	w := createWikiTestInstance(t)
 	defer test_utils.WrapCloseWithErrorCheck(w.Close, t)
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            true,
+		PublicAccess:            publicaccess.NewEnvManaged(true),
 		InjectCodeInHeader:      "",
 		CustomStylesheet:        "",
 		AllowInsecure:           true,
@@ -3984,7 +3985,7 @@ func TestRequireAdminMiddleware_BlockedWhenAuthDisabled(t *testing.T) {
 
 	// Create router with auth disabled
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            false,
+		PublicAccess:            publicaccess.NewEnvManaged(false),
 		InjectCodeInHeader:      "",
 		AllowInsecure:           true,
 		AccessTokenTimeout:      15 * time.Minute,
@@ -4481,7 +4482,7 @@ func TestAssetAccessControl(t *testing.T) {
 
 		// Create router with PublicAccess=false and AuthDisabled=false
 		router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-			PublicAccess:            false,
+			PublicAccess:            publicaccess.NewEnvManaged(false),
 			InjectCodeInHeader:      "",
 			CustomStylesheet:        "",
 			AllowInsecure:           true,
@@ -4511,7 +4512,7 @@ func TestAssetAccessControl(t *testing.T) {
 
 		// Create router with PublicAccess=false and AuthDisabled=false
 		router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-			PublicAccess:            false,
+			PublicAccess:            publicaccess.NewEnvManaged(false),
 			InjectCodeInHeader:      "",
 			CustomStylesheet:        "",
 			AllowInsecure:           true,
@@ -4550,7 +4551,7 @@ func TestAssetAccessControl(t *testing.T) {
 
 		// Create router with PublicAccess=true
 		router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-			PublicAccess:            true,
+			PublicAccess:            publicaccess.NewEnvManaged(true),
 			InjectCodeInHeader:      "",
 			CustomStylesheet:        "",
 			AllowInsecure:           true,
@@ -4586,7 +4587,7 @@ func TestAssetAccessControl(t *testing.T) {
 
 		// Create router with AuthDisabled=true
 		router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-			PublicAccess:            false,
+			PublicAccess:            publicaccess.NewEnvManaged(false),
 			InjectCodeInHeader:      "",
 			CustomStylesheet:        "",
 			AllowInsecure:           true,
@@ -4692,7 +4693,7 @@ func TestCustomStylesheetRoute(t *testing.T) {
 	}
 
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            false,
+		PublicAccess:            publicaccess.NewEnvManaged(false),
 		InjectCodeInHeader:      "",
 		CustomStylesheet:        customCSSPath,
 		AllowInsecure:           true,
@@ -4729,7 +4730,7 @@ func TestCustomStylesheetRoute_RejectsPathOutsideStorageDir(t *testing.T) {
 	}
 
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            false,
+		PublicAccess:            publicaccess.NewEnvManaged(false),
 		InjectCodeInHeader:      "",
 		CustomStylesheet:        outsideCSSPath,
 		AllowInsecure:           true,
@@ -4758,7 +4759,7 @@ func TestCustomStylesheetRoute_RejectsNonCSSFile(t *testing.T) {
 	}
 
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            false,
+		PublicAccess:            publicaccess.NewEnvManaged(false),
 		InjectCodeInHeader:      "",
 		CustomStylesheet:        textFilePath,
 		AllowInsecure:           true,
@@ -4808,7 +4809,7 @@ func TestFaviconRoute_DisablesClientCache(t *testing.T) {
 	}()
 
 	router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
-		PublicAccess:            false,
+		PublicAccess:            publicaccess.NewEnvManaged(false),
 		InjectCodeInHeader:      "",
 		CustomStylesheet:        "",
 		AllowInsecure:           true,

--- a/internal/publicaccess/errors.go
+++ b/internal/publicaccess/errors.go
@@ -1,0 +1,18 @@
+package publicaccess
+
+import sharederrors "github.com/perber/wiki/internal/core/shared/errors"
+
+// ErrCodeEnvManaged is the LocalizedError code returned when a caller tries to
+// change public access mode on an instance where it is pinned by
+// --public-access / LEAFWIKI_PUBLIC_ACCESS (or forced by --disable-auth). The
+// HTTP layer maps this code to 409 Conflict.
+const ErrCodeEnvManaged = "public_access_env_managed"
+
+func errEnvManaged() error {
+	return sharederrors.NewLocalizedError(
+		ErrCodeEnvManaged,
+		"Public access mode is set by environment configuration and cannot be changed here",
+		"public access mode is env-managed",
+		nil,
+	)
+}

--- a/internal/publicaccess/service.go
+++ b/internal/publicaccess/service.go
@@ -1,0 +1,104 @@
+// Package publicaccess owns the "public mode" flag: whether unauthenticated
+// visitors may read every page.
+//
+// It has two modes, chosen once at construction, mirroring the env- vs
+// settings-managed split internal/backup uses for git backup:
+//
+//   - env-managed (NewEnvManaged): the value is pinned by --public-access /
+//     LEAFWIKI_PUBLIC_ACCESS, or forced true by --disable-auth. Enabled()
+//     returns that fixed value, SetEnabled always fails with
+//     ErrCodeEnvManaged, and no file is ever touched. The Settings UI shows a
+//     status-only view for these instances.
+//   - settings-managed (NewSettingsManaged): the value lives in
+//     <storageDir>/public-access.json and an admin can toggle it at runtime
+//     with no restart. A missing file means disabled.
+package publicaccess
+
+import (
+	"fmt"
+	"sync"
+
+	sharederrors "github.com/perber/wiki/internal/core/shared/errors"
+)
+
+// Service is the process-wide holder of the current public-access flag. All
+// methods are safe for concurrent use.
+type Service struct {
+	mu         sync.RWMutex
+	enabled    bool
+	envManaged bool
+	store      *store // nil in env-managed mode
+}
+
+// NewEnvManaged returns a Service pinned to enabled; SetEnabled/Reload are
+// inert. Used when --public-access / LEAFWIKI_PUBLIC_ACCESS is set or
+// --disable-auth forces public mode on.
+func NewEnvManaged(enabled bool) *Service {
+	return &Service{enabled: enabled, envManaged: true}
+}
+
+// NewSettingsManaged returns a Service whose flag is read from (and written
+// back to) <storageDir>/public-access.json. The initial value is whatever the
+// file currently holds; a missing file means disabled.
+func NewSettingsManaged(storageDir string) (*Service, error) {
+	st := newStore(storageDir)
+	enabled, err := st.Load()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load public-access config: %w", err)
+	}
+	return &Service{enabled: enabled, store: st}, nil
+}
+
+// Enabled reports whether anonymous read access is currently allowed.
+func (s *Service) Enabled() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.enabled
+}
+
+// EnvManaged reports whether the flag is pinned by environment configuration
+// (and therefore read-only in the Settings UI). Immutable after construction.
+func (s *Service) EnvManaged() bool {
+	return s.envManaged
+}
+
+// SetEnabled persists a new value and updates the in-memory cache. It returns
+// a *LocalizedError with code ErrCodeEnvManaged on an env-managed instance.
+func (s *Service) SetEnabled(enabled bool) error {
+	if s.envManaged {
+		return errEnvManaged()
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.store.Save(enabled); err != nil {
+		return sharederrors.NewLocalizedError(
+			"public_access_update_failed",
+			"Failed to update public access mode",
+			"failed to persist public-access config",
+			err,
+		)
+	}
+	s.enabled = enabled
+	return nil
+}
+
+// Reload re-reads public-access.json into the in-memory cache. Called after a
+// restore swaps in a different data dir. A no-op (nil) for env-managed
+// instances, which have no file.
+func (s *Service) Reload() error {
+	if s.envManaged {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	enabled, err := s.store.Load()
+	if err != nil {
+		return fmt.Errorf("failed to reload public-access config: %w", err)
+	}
+	s.enabled = enabled
+	return nil
+}

--- a/internal/publicaccess/service_test.go
+++ b/internal/publicaccess/service_test.go
@@ -1,0 +1,193 @@
+package publicaccess
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+
+	sharederrors "github.com/perber/wiki/internal/core/shared/errors"
+)
+
+func TestService_SettingsManagedNoFile_DisabledByDefault(t *testing.T) {
+	svc, err := NewSettingsManaged(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewSettingsManaged: %v", err)
+	}
+	if svc.Enabled() {
+		t.Fatal("expected Enabled() false when public-access.json is absent")
+	}
+	if svc.EnvManaged() {
+		t.Fatal("expected EnvManaged() false for a settings-managed service")
+	}
+}
+
+func TestService_SettingsManagedSetEnabled_PersistsAcrossReconstruction(t *testing.T) {
+	dir := t.TempDir()
+
+	svc, err := NewSettingsManaged(dir)
+	if err != nil {
+		t.Fatalf("NewSettingsManaged: %v", err)
+	}
+	if err := svc.SetEnabled(true); err != nil {
+		t.Fatalf("SetEnabled(true): %v", err)
+	}
+	if !svc.Enabled() {
+		t.Fatal("expected Enabled() true right after SetEnabled(true)")
+	}
+
+	// A fresh service over the same dir must see the persisted value.
+	reopened, err := NewSettingsManaged(dir)
+	if err != nil {
+		t.Fatalf("NewSettingsManaged (reopen): %v", err)
+	}
+	if !reopened.Enabled() {
+		t.Fatal("expected persisted Enabled() true after reconstruction")
+	}
+
+	if err := reopened.SetEnabled(false); err != nil {
+		t.Fatalf("SetEnabled(false): %v", err)
+	}
+	again, err := NewSettingsManaged(dir)
+	if err != nil {
+		t.Fatalf("NewSettingsManaged (reopen 2): %v", err)
+	}
+	if again.Enabled() {
+		t.Fatal("expected persisted Enabled() false after SetEnabled(false)")
+	}
+}
+
+func TestService_SettingsManagedSetEnabled_WritesModeSixHundredJSON(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := NewSettingsManaged(dir)
+	if err != nil {
+		t.Fatalf("NewSettingsManaged: %v", err)
+	}
+	if err := svc.SetEnabled(true); err != nil {
+		t.Fatalf("SetEnabled(true): %v", err)
+	}
+
+	path := filepath.Join(dir, "public-access.json")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat public-access.json: %v", err)
+	}
+	if runtime.GOOS != "windows" {
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Fatalf("expected public-access.json mode 0600, got %o", perm)
+		}
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read public-access.json: %v", err)
+	}
+	var cfg struct {
+		Enabled bool `json:"enabled"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal public-access.json: %v", err)
+	}
+	if !cfg.Enabled {
+		t.Fatalf("expected {\"enabled\": true} on disk, got %s", data)
+	}
+}
+
+func TestService_SettingsManagedReload_PicksUpExternalFileChange(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := NewSettingsManaged(dir)
+	if err != nil {
+		t.Fatalf("NewSettingsManaged: %v", err)
+	}
+	if svc.Enabled() {
+		t.Fatal("precondition: expected disabled")
+	}
+
+	// Simulate a restore dropping in a different public-access.json.
+	if err := os.WriteFile(filepath.Join(dir, "public-access.json"), []byte(`{"enabled": true}`), 0o600); err != nil {
+		t.Fatalf("write external file: %v", err)
+	}
+	if svc.Enabled() {
+		t.Fatal("expected cache to still read false before Reload()")
+	}
+
+	if err := svc.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if !svc.Enabled() {
+		t.Fatal("expected Enabled() true after Reload() picked up the new file")
+	}
+}
+
+func TestService_SettingsManagedLoad_CorruptFileIsAnError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "public-access.json"), []byte("not json"), 0o600); err != nil {
+		t.Fatalf("write corrupt file: %v", err)
+	}
+	if _, err := NewSettingsManaged(dir); err == nil {
+		t.Fatal("expected NewSettingsManaged to fail on an unparseable public-access.json")
+	}
+}
+
+func TestService_EnvManaged_ReturnsFixedValueAndRejectsSetEnabled(t *testing.T) {
+	svc := NewEnvManaged(true)
+
+	if !svc.Enabled() {
+		t.Fatal("expected Enabled() true for NewEnvManaged(true)")
+	}
+	if !svc.EnvManaged() {
+		t.Fatal("expected EnvManaged() true")
+	}
+
+	err := svc.SetEnabled(false)
+	if err == nil {
+		t.Fatal("expected SetEnabled to fail on an env-managed service")
+	}
+	loc, ok := sharederrors.AsLocalizedError(err)
+	if !ok {
+		t.Fatalf("expected a *LocalizedError, got %T", err)
+	}
+	if loc.Code != ErrCodeEnvManaged {
+		t.Fatalf("expected error code %q, got %q", ErrCodeEnvManaged, loc.Code)
+	}
+	if !svc.Enabled() {
+		t.Fatal("expected Enabled() still true after a rejected SetEnabled")
+	}
+}
+
+func TestService_EnvManagedReload_IsANoOp(t *testing.T) {
+	svc := NewEnvManaged(false)
+	if err := svc.Reload(); err != nil {
+		t.Fatalf("Reload on env-managed should be a no-op, got %v", err)
+	}
+	if svc.Enabled() {
+		t.Fatal("expected Enabled() unchanged (false) after Reload()")
+	}
+}
+
+func TestService_EnvManagedSetEnabled_NeverWritesAFile(t *testing.T) {
+	dir := t.TempDir()
+	svc := NewEnvManaged(true)
+	_ = svc.SetEnabled(false) // rejected
+
+	if _, err := os.Stat(filepath.Join(dir, "public-access.json")); !os.IsNotExist(err) {
+		t.Fatalf("env-managed service must not create public-access.json (stat err: %v)", err)
+	}
+}
+
+func TestService_SettingsManagedConcurrentAccess_IsRaceFree(t *testing.T) {
+	svc, err := NewSettingsManaged(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewSettingsManaged: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(2)
+		go func(v int) { defer wg.Done(); _ = svc.SetEnabled(v%2 == 0) }(i)
+		go func() { defer wg.Done(); _ = svc.Enabled() }()
+	}
+	wg.Wait()
+}

--- a/internal/publicaccess/store.go
+++ b/internal/publicaccess/store.go
@@ -1,0 +1,62 @@
+package publicaccess
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/perber/wiki/internal/core/shared"
+)
+
+// store persists the settings-managed public-access flag to
+// <storageDir>/public-access.json (0600). It mirrors internal/branding's
+// BrandingStore: a missing file is not an error, it just means "disabled".
+type store struct {
+	storageDir string
+}
+
+func newStore(storageDir string) *store {
+	return &store{storageDir: storageDir}
+}
+
+func (s *store) path() string {
+	return filepath.Join(s.storageDir, "public-access.json")
+}
+
+// fileConfig is the on-disk shape. Kept deliberately minimal so future
+// runtime-toggleable options get their own file rather than accreting here.
+type fileConfig struct {
+	Enabled bool `json:"enabled"`
+}
+
+// Load reads the persisted flag. A missing file ⇒ (false, nil).
+func (s *store) Load() (bool, error) {
+	data, err := os.ReadFile(s.path())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to read public-access config: %w", err)
+	}
+
+	var cfg fileConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return false, fmt.Errorf("failed to parse public-access config: %w", err)
+	}
+	return cfg.Enabled, nil
+}
+
+// Save atomically writes the flag with 0600 perms (it carries no secret, but
+// matches the restrictive default the other data-dir config files use).
+func (s *store) Save(enabled bool) error {
+	data, err := json.MarshalIndent(fileConfig{Enabled: enabled}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal public-access config: %w", err)
+	}
+	if err := shared.WriteFileAtomic(s.path(), data, 0o600); err != nil {
+		return fmt.Errorf("failed to write public-access config: %w", err)
+	}
+	return nil
+}

--- a/internal/restore/config.go
+++ b/internal/restore/config.go
@@ -4,6 +4,7 @@ import (
 	"github.com/perber/wiki/internal/branding"
 	"github.com/perber/wiki/internal/core/auth"
 	"github.com/perber/wiki/internal/favorites"
+	"github.com/perber/wiki/internal/publicaccess"
 	"github.com/perber/wiki/internal/snapshot"
 	"github.com/perber/wiki/internal/usersettings"
 )
@@ -46,6 +47,11 @@ type Config struct {
 	// BrandingService's in-memory config cache is reloaded from the restored
 	// branding.json after the file swap.
 	BrandingService *branding.BrandingService
+	// PublicAccess's in-memory flag is reloaded from the restored
+	// public-access.json after the file swap, mirroring BrandingService. nil
+	// (and Reload is a no-op) for env-managed instances; nil-guarded anyway
+	// for test-fixture parity.
+	PublicAccess *publicaccess.Service
 	// UserResolver's own in-memory author-label cache is reloaded after
 	// AuthService.ReplaceUserStore succeeds — the live UserService pointer
 	// alone doesn't invalidate labels already cached before the restore. nil

--- a/internal/restore/manager.go
+++ b/internal/restore/manager.go
@@ -396,6 +396,16 @@ func (m *Manager) runFromZipPath(zipPath string, limits coreshared.ExtractionLim
 		return
 	}
 
+	// Public-access flag rides the same phase — it's another small
+	// in-memory reload from a data-dir JSON file. No-op for env-managed
+	// instances (they have no public-access.json).
+	if m.cfg.PublicAccess != nil {
+		if err := m.cfg.PublicAccess.Reload(); err != nil {
+			m.rollbackOrIntervene(sw, fmt.Errorf("failed to reload public-access config: %w", err))
+			return
+		}
+	}
+
 	sw.CommitAll()
 	m.cfg.WriteGate.Disengage()
 	if m.cfg.TriggerResync != nil {

--- a/internal/wiki/assets/routes.go
+++ b/internal/wiki/assets/routes.go
@@ -55,7 +55,7 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	// Static file serving for /assets with access control.
 	if r.assetsDir != "" {
 		assetsFS := gin.Dir(r.assetsDir, false)
-		if opts.PublicAccess || opts.AuthDisabled {
+		if opts.PublicAccess.Enabled() || opts.AuthDisabled {
 			ctx.Base.StaticFS("/assets", assetsFS)
 		} else {
 			assetsGroup := ctx.Base.Group("/assets")
@@ -67,7 +67,7 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 		}
 	}
 
-	if opts.PublicAccess {
+	if opts.PublicAccess.Enabled() {
 		pub := ctx.Base.Group("/api")
 		pub.GET("/pages/:id/assets", r.handleList)
 	}
@@ -80,7 +80,7 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	)
 
 	authGroup.POST("/pages/:id/assets", authmw.RequireEditorOrAdmin(), r.handleUpload(opts.MaxAssetUploadSizeBytes))
-	if !opts.PublicAccess {
+	if !opts.PublicAccess.Enabled() {
 		authGroup.GET("/pages/:id/assets", r.handleList)
 	}
 	authGroup.PUT("/pages/:id/assets/rename", authmw.RequireEditorOrAdmin(), r.handleRename)

--- a/internal/wiki/auth/routes.go
+++ b/internal/wiki/auth/routes.go
@@ -206,7 +206,8 @@ func (r *Routes) handleConfig(ctx httpinternal.RouterContext) gin.HandlerFunc {
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{
-			"publicAccess":            opts.PublicAccess,
+			"publicAccess":            opts.PublicAccess.Enabled(),
+			"publicAccessEnvManaged":  opts.PublicAccess.EnvManaged(),
 			"editorLimit":             opts.EditorLimit,
 			"hideLinkMetadataSection": opts.HideLinkMetadataSection,
 			"authDisabled":            opts.AuthDisabled,

--- a/internal/wiki/links/routes.go
+++ b/internal/wiki/links/routes.go
@@ -34,7 +34,7 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
 
-	if opts.PublicAccess {
+	if opts.PublicAccess.Enabled() {
 		pub := ctx.Base.Group("/api")
 		pub.GET("/pages/:id/links", r.handleGetLinkStatus)
 	}
@@ -46,7 +46,7 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 		security.CSRFMiddleware(ctx.CSRFCookie),
 	)
 
-	if !opts.PublicAccess {
+	if !opts.PublicAccess.Enabled() {
 		authGroup.GET("/pages/:id/links", r.handleGetLinkStatus)
 	}
 }

--- a/internal/wiki/pages/routes.go
+++ b/internal/wiki/pages/routes.go
@@ -109,7 +109,7 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
 
-	if opts.PublicAccess {
+	if opts.PublicAccess.Enabled() {
 		pub := ctx.Base.Group("/api")
 		pub.GET("/tree", r.handleGetTree)
 		pub.GET("/pages/by-path", r.handleGetByPath)
@@ -126,7 +126,7 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 		security.CSRFMiddleware(ctx.CSRFCookie),
 	)
 
-	if !opts.PublicAccess {
+	if !opts.PublicAccess.Enabled() {
 		authGroup.GET("/tree", r.handleGetTree)
 		authGroup.GET(pagesIdRoutePath, r.handleGetPage)
 		authGroup.GET("/pages/lookup", r.handleLookupPath)

--- a/internal/wiki/properties/routes.go
+++ b/internal/wiki/properties/routes.go
@@ -38,7 +38,7 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
 
-	if opts.PublicAccess {
+	if opts.PublicAccess.Enabled() {
 		pub := ctx.Base.Group("/api")
 		pub.GET("/properties", r.handleGetPropertyKeys)
 		pub.GET("/properties/pages", r.handleGetPagesByProperty)
@@ -51,7 +51,7 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 		security.CSRFMiddleware(ctx.CSRFCookie),
 	)
 
-	if !opts.PublicAccess {
+	if !opts.PublicAccess.Enabled() {
 		authGroup.GET("/properties", r.handleGetPropertyKeys)
 		authGroup.GET("/properties/pages", r.handleGetPagesByProperty)
 	}

--- a/internal/wiki/search/routes.go
+++ b/internal/wiki/search/routes.go
@@ -39,7 +39,7 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
 
-	if opts.PublicAccess {
+	if opts.PublicAccess.Enabled() {
 		pub := ctx.Base.Group("/api")
 		pub.GET("/search/status", r.handleGetIndexingStatus)
 		pub.GET("/search", r.handleSearch)
@@ -52,7 +52,7 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 		security.CSRFMiddleware(ctx.CSRFCookie),
 	)
 
-	if !opts.PublicAccess {
+	if !opts.PublicAccess.Enabled() {
 		authGroup.GET("/search/status", r.handleGetIndexingStatus)
 		authGroup.GET("/search", r.handleSearch)
 	}

--- a/internal/wiki/tags/routes.go
+++ b/internal/wiki/tags/routes.go
@@ -39,7 +39,7 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
 
-	if opts.PublicAccess {
+	if opts.PublicAccess.Enabled() {
 		pub := ctx.Base.Group("/api")
 		pub.GET("/tags", r.handleGetTags)
 		pub.GET("/tags/pages", r.handleGetPagesByTags)
@@ -52,7 +52,7 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 		security.CSRFMiddleware(ctx.CSRFCookie),
 	)
 
-	if !opts.PublicAccess {
+	if !opts.PublicAccess.Enabled() {
 		authGroup.GET("/tags", r.handleGetTags)
 		authGroup.GET("/tags/pages", r.handleGetPagesByTags)
 	}


### PR DESCRIPTION
**Stacked series 1/6 — "Public mode runtime toggle".** Merge bottom-up (this one first); GitHub retargets the next PR to `main` once this lands. The whole series is also on `feat/public-mode-toggle`.

## What

Groundwork so "public mode" (anonymous read access to every page) can later be toggled from Settings without a restart. **This PR changes no behaviour** — route registration still reads the flag once at boot.

- **`internal/publicaccess.Service`**, modelled on `internal/branding`:
  - `NewEnvManaged(bool)` — value pinned by `--public-access` / `LEAFWIKI_PUBLIC_ACCESS`, or forced on by `--disable-auth`. `SetEnabled` fails with `ErrCodeEnvManaged`; no file touched.
  - `NewSettingsManaged(dir)` — value in `<data-dir>/public-access.json` (`0600`, missing ⇒ disabled); `SetEnabled` persists + updates the cache; `Reload()` re-reads it after a restore swap.
- `RouterOptions.PublicAccess`: `bool` → `PublicAccessProvider` interface (`Enabled` / `EnvManaged`), read per request. A nil provider defaults to a fixed-false stand-in.
- `/api/config`: `publicAccess` now reports `Enabled()`; adds `publicAccessEnvManaged` so the frontend can show a status-only view.
- `cmd/leafwiki`: `buildPublicAccessService` picks env- vs settings-managed from `cmd.IsSet("public-access") || --disable-auth`.
- `internal/restore`: `Config.PublicAccess` + a `Reload()` in the branding phase so a restored `public-access.json` takes effect without a restart.

## Behaviour

None. Env-managed instances identical; settings-managed defaults to `false` = today's default. The six read-route files call `opts.PublicAccess.Enabled()` at the same registration-time branch as before.

## Tests

`internal/publicaccess` unit tests (default-disabled, persist/reload round-trip, `0600`, env-managed rejects `SetEnabled` and ignores any on-disk file). Full backend suite green. `golangci-lint` not run locally (v1.60 vs go 1.25 skew — CI runs it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
