### PR TITLE
refactor(http): read routes behind a runtime public-mode gate (2/6)

### DIFF
--- a/internal/http/middleware/auth/require_auth_or_public.go
+++ b/internal/http/middleware/auth/require_auth_or_public.go
@@ -1,0 +1,89 @@
+package auth
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/perber/wiki/internal/core/auth"
+)
+
+// PublicReadGate reports whether unauthenticated read access ("public mode")
+// is currently allowed. It is read on every request so the flag can be
+// toggled at runtime; internal/http.PublicAccessProvider satisfies it.
+type PublicReadGate interface {
+	Enabled() bool
+}
+
+// RequireAuthOrPublicRead gates the read-only route groups that used to be
+// registered on either a bare public group or an authenticated group
+// depending on a boot-time flag. Registering them once behind this middleware
+// is what lets public mode flip without a restart.
+//
+// It behaves exactly like RequireAuth, except that on each path where
+// RequireAuth would abort with 401 it instead calls c.Next() *anonymously*
+// when public mode is currently on. Consequences:
+//
+//   - user already in context (proxy header / API key / a prior mw) → passes,
+//     identical to RequireAuth.
+//   - valid session cookie → user is resolved and attached, so a logged-in
+//     editor keeps write affordances even while public mode is on. This is the
+//     one behaviour that differs from the pre-refactor public group, which ran
+//     no auth middleware at all and therefore saw every caller as anonymous.
+//   - no / invalid cookie, public mode ON  → passes anonymously.
+//   - no / invalid cookie, public mode OFF → 401, byte-for-byte as RequireAuth.
+//   - authService misconfigured (nil) with a token present → 500, as
+//     RequireAuth, regardless of public mode.
+func RequireAuthOrPublicRead(authService *auth.AuthService, authCookies *AuthCookies, authDisabled bool, public PublicReadGate) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if userValue, exists := c.Get("user"); exists {
+			user, ok := userValue.(*auth.User)
+			if !ok || user == nil {
+				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Invalid user context"})
+				return
+			}
+			c.Next()
+			return
+		}
+
+		publicOK := public != nil && public.Enabled()
+
+		if authDisabled {
+			// InjectPublicEditor normally sets a user before this runs when
+			// auth is disabled; this branch only trips if it didn't.
+			if publicOK {
+				c.Next()
+				return
+			}
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated and auth is disabled"})
+			return
+		}
+
+		token, err := authCookies.ReadAccess(c)
+		if err != nil || token == "" {
+			if publicOK {
+				c.Next()
+				return
+			}
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Missing or invalid access token"})
+			return
+		}
+
+		if authService == nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Authentication service unavailable"})
+			return
+		}
+
+		user, err := authService.ValidateToken(token)
+		if err != nil {
+			if publicOK {
+				c.Next()
+				return
+			}
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Invalid or expired token"})
+			return
+		}
+
+		c.Set("user", user)
+		c.Next()
+	}
+}

--- a/internal/http/middleware/auth/require_auth_or_public_test.go
+++ b/internal/http/middleware/auth/require_auth_or_public_test.go
@@ -1,0 +1,186 @@
+package auth_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	coreauth "github.com/perber/wiki/internal/core/auth"
+	authmw "github.com/perber/wiki/internal/http/middleware/auth"
+)
+
+// flipGate is a PublicReadGate whose value can be toggled between requests,
+// standing in for the runtime-mutable publicaccess.Service.
+type flipGate struct{ enabled bool }
+
+func (g *flipGate) Enabled() bool { return g.enabled }
+
+func newAuthOrPublicRouter(auth *coreauth.AuthService, authCookies *authmw.AuthCookies, authDisabled bool, gate authmw.PublicReadGate, inject gin.HandlerFunc) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	if inject != nil {
+		r.Use(inject)
+	}
+	r.Use(authmw.RequireAuthOrPublicRead(auth, authCookies, authDisabled, gate))
+	r.GET("/test", func(c *gin.Context) {
+		if v, ok := c.Get("user"); ok {
+			c.JSON(http.StatusOK, gin.H{"user": v.(*coreauth.User).Username})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"user": nil})
+	})
+	return r
+}
+
+func doGet(r http.Handler, cookie *http.Cookie) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	if cookie != nil {
+		req.AddCookie(cookie)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestRequireAuthOrPublicRead_UserAlreadyInContext_Passes(t *testing.T) {
+	authCookies := authmw.NewAuthCookies(true, time.Hour, 24*time.Hour)
+	inject := func(c *gin.Context) {
+		c.Set("user", &coreauth.User{ID: "x", Username: "proxied", Role: coreauth.RoleEditor})
+		c.Next()
+	}
+	r := newAuthOrPublicRouter(nil, authCookies, false, &flipGate{enabled: false}, inject)
+
+	w := doGet(r, nil)
+	if w.Code != http.StatusOK || w.Body.String() != `{"user":"proxied"}` {
+		t.Fatalf("expected 200 with proxied user, got %d %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequireAuthOrPublicRead_NoToken_PublicOff_Returns401(t *testing.T) {
+	authCookies := authmw.NewAuthCookies(true, time.Hour, 24*time.Hour)
+	r := newAuthOrPublicRouter(nil, authCookies, false, &flipGate{enabled: false}, nil)
+
+	w := doGet(r, nil)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+	if w.Body.String() != `{"error":"Missing or invalid access token"}` {
+		t.Fatalf("expected RequireAuth's no-token body, got %s", w.Body.String())
+	}
+}
+
+func TestRequireAuthOrPublicRead_NoToken_PublicOn_PassesAnonymously(t *testing.T) {
+	authCookies := authmw.NewAuthCookies(true, time.Hour, 24*time.Hour)
+	r := newAuthOrPublicRouter(nil, authCookies, false, &flipGate{enabled: true}, nil)
+
+	w := doGet(r, nil)
+	if w.Code != http.StatusOK || w.Body.String() != `{"user":null}` {
+		t.Fatalf("expected 200 anonymous, got %d %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequireAuthOrPublicRead_InvalidToken_PublicOff_Returns401(t *testing.T) {
+	fixture := createTestAuthFixture(t)
+	cleanupWithErrorCheck(t, "auth fixture", fixture.close)
+	authCookies := authmw.NewAuthCookies(true, time.Hour, 24*time.Hour)
+	r := newAuthOrPublicRouter(fixture.auth, authCookies, false, &flipGate{enabled: false}, nil)
+
+	w := doGet(r, &http.Cookie{Name: "leafwiki_at", Value: "bogus"})
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+	if w.Body.String() != `{"error":"Invalid or expired token"}` {
+		t.Fatalf("expected RequireAuth's invalid-token body, got %s", w.Body.String())
+	}
+}
+
+func TestRequireAuthOrPublicRead_InvalidToken_PublicOn_PassesAnonymously(t *testing.T) {
+	fixture := createTestAuthFixture(t)
+	cleanupWithErrorCheck(t, "auth fixture", fixture.close)
+	authCookies := authmw.NewAuthCookies(true, time.Hour, 24*time.Hour)
+	r := newAuthOrPublicRouter(fixture.auth, authCookies, false, &flipGate{enabled: true}, nil)
+
+	w := doGet(r, &http.Cookie{Name: "leafwiki_at", Value: "bogus"})
+	if w.Code != http.StatusOK || w.Body.String() != `{"user":null}` {
+		t.Fatalf("expected 200 anonymous for invalid token in public mode, got %d %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequireAuthOrPublicRead_ValidToken_AttachesUser_BothModes(t *testing.T) {
+	fixture := createTestAuthFixture(t)
+	cleanupWithErrorCheck(t, "auth fixture", fixture.close)
+	authCookies := authmw.NewAuthCookies(true, time.Hour, 24*time.Hour)
+	tok, err := fixture.auth.Login("admin", "adminpassword")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+
+	for _, public := range []bool{false, true} {
+		r := newAuthOrPublicRouter(fixture.auth, authCookies, false, &flipGate{enabled: public}, nil)
+		w := doGet(r, &http.Cookie{Name: "leafwiki_at", Value: tok.Token})
+		if w.Code != http.StatusOK || w.Body.String() != `{"user":"admin"}` {
+			t.Fatalf("public=%v: expected 200 with admin user attached, got %d %s", public, w.Code, w.Body.String())
+		}
+	}
+}
+
+func TestRequireAuthOrPublicRead_NilAuthServiceWithToken_Returns500(t *testing.T) {
+	authCookies := authmw.NewAuthCookies(true, time.Hour, 24*time.Hour)
+	// Even in public mode a present token with no authService is a
+	// misconfiguration, not a fall-through to anonymous.
+	r := newAuthOrPublicRouter(nil, authCookies, false, &flipGate{enabled: true}, nil)
+
+	w := doGet(r, &http.Cookie{Name: "leafwiki_at", Value: "something"})
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequireAuthOrPublicRead_AuthDisabled_NoUser_PublicOff_Returns401(t *testing.T) {
+	authCookies := authmw.NewAuthCookies(true, time.Hour, 24*time.Hour)
+	r := newAuthOrPublicRouter(nil, authCookies, true, &flipGate{enabled: false}, nil)
+
+	w := doGet(r, nil)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+	if w.Body.String() != `{"error":"User not authenticated and auth is disabled"}` {
+		t.Fatalf("expected RequireAuth's auth-disabled body, got %s", w.Body.String())
+	}
+}
+
+func TestRequireAuthOrPublicRead_NilGate_TreatedAsPublicOff(t *testing.T) {
+	authCookies := authmw.NewAuthCookies(true, time.Hour, 24*time.Hour)
+	r := newAuthOrPublicRouter(nil, authCookies, false, nil, nil)
+
+	w := doGet(r, nil)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for nil gate, got %d", w.Code)
+	}
+}
+
+// TestRequireAuthOrPublicRead_GateFlipsAtRuntime_SameRouterChangesBehaviour is
+// the "no restart" regression pin: one router, one request shape, behaviour
+// follows the gate value at request time — not a value snapshotted when the
+// route was registered.
+func TestRequireAuthOrPublicRead_GateFlipsAtRuntime_SameRouterChangesBehaviour(t *testing.T) {
+	authCookies := authmw.NewAuthCookies(true, time.Hour, 24*time.Hour)
+	gate := &flipGate{enabled: false}
+	r := newAuthOrPublicRouter(nil, authCookies, false, gate, nil)
+
+	if w := doGet(r, nil); w.Code != http.StatusUnauthorized {
+		t.Fatalf("public off: expected 401, got %d", w.Code)
+	}
+
+	gate.enabled = true
+	if w := doGet(r, nil); w.Code != http.StatusOK {
+		t.Fatalf("public on: expected 200 on the same router, got %d", w.Code)
+	}
+
+	gate.enabled = false
+	if w := doGet(r, nil); w.Code != http.StatusUnauthorized {
+		t.Fatalf("public off again: expected 401 on the same router, got %d", w.Code)
+	}
+}

--- a/internal/http/router_test.go
+++ b/internal/http/router_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -3301,6 +3302,105 @@ func TestGetPagePermalinkEndpoint_PublicAccessAllowsUnauthenticatedReads(t *test
 	}
 	if target.Path != "public-page" {
 		t.Fatalf("expected path public-page, got %q", target.Path)
+	}
+}
+
+// TestReadRouteAccessMatrix pins the PR-2 refactor that collapsed the
+// per-domain "public group vs authed group" fork into a single group gated by
+// RequireAuthOrPublicRead. It asserts the auth *decision* (401 vs. not) for
+// every read endpoint that used to be duplicated, across public on/off and
+// anonymous/authenticated — without depending on seeded business data.
+func TestReadRouteAccessMatrix(t *testing.T) {
+	buildRouter := func(t *testing.T, public bool) (*gin.Engine, *wiki.Wiki) {
+		t.Helper()
+		w := createWikiTestInstance(t)
+		t.Cleanup(func() { test_utils.WrapCloseWithErrorCheck(w.Close, t) })
+		router := httpinternal.NewRouter(w.Registrars(), w.FrontendConfig(), httpinternal.RouterOptions{
+			PublicAccess:            publicaccess.NewEnvManaged(public),
+			AllowInsecure:           true,
+			AccessTokenTimeout:      15 * time.Minute,
+			RefreshTokenTimeout:     7 * 24 * time.Hour,
+			MaxAssetUploadSizeBytes: assets.DefaultMaxUploadSizeBytes,
+		})
+		return router, w
+	}
+
+	// Every read endpoint that had a public/authed duplication before PR 2.
+	// A bogus :id is fine — we only care that the auth gate, not the handler,
+	// decides the outcome.
+	readPaths := []string{
+		"/api/tree",
+		"/api/pages/bogus-id",
+		"/api/pages/by-path?path=whatever",
+		"/api/pages/by-title?title=whatever",
+		"/api/pages/lookup?path=whatever",
+		"/api/pages/permalink/bogus-id",
+		"/api/pages/bogus-id/links",
+		"/api/pages/bogus-id/assets",
+		"/api/search?q=whatever",
+		"/api/search/status",
+		"/api/tags",
+		"/api/tags/pages?tags=whatever",
+		"/api/properties",
+		"/api/properties/pages?key=k&value=v",
+		"/assets/whatever.txt",
+	}
+
+	get := func(router http.Handler, path string, cookies []*http.Cookie) int {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		for _, c := range cookies {
+			req.AddCookie(c)
+		}
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	t.Run("PublicOff_Anonymous_Every401", func(t *testing.T) {
+		router, _ := buildRouter(t, false)
+		for _, p := range readPaths {
+			if code := get(router, p, nil); code != http.StatusUnauthorized {
+				t.Errorf("GET %s (public off, anon): want 401, got %d", p, code)
+			}
+		}
+	})
+
+	t.Run("PublicOn_Anonymous_Never401", func(t *testing.T) {
+		router, _ := buildRouter(t, true)
+		for _, p := range readPaths {
+			if code := get(router, p, nil); code == http.StatusUnauthorized {
+				t.Errorf("GET %s (public on, anon): want a non-401 business code, got 401", p)
+			}
+		}
+	})
+
+	for _, public := range []bool{false, true} {
+		public := public
+		t.Run(fmt.Sprintf("Public%v_Authenticated_Never401", public), func(t *testing.T) {
+			router, _ := buildRouter(t, public)
+			_, cookies := loginAdminAndGetCSRF(t, router)
+			for _, p := range readPaths {
+				if code := get(router, p, cookies); code == http.StatusUnauthorized {
+					t.Errorf("GET %s (public=%v, authed): want a non-401 business code, got 401", p, public)
+				}
+			}
+		})
+	}
+
+	// The collapse must not have loosened writes: an unauthenticated POST is
+	// still rejected (401 missing auth, or 403 missing CSRF) in both modes.
+	for _, public := range []bool{false, true} {
+		public := public
+		t.Run(fmt.Sprintf("Public%v_AnonymousWrite_StillRejected", public), func(t *testing.T) {
+			router, _ := buildRouter(t, public)
+			req := httptest.NewRequest(http.MethodPost, "/api/pages", strings.NewReader(`{"title":"x","slug":"x","parentId":"root"}`))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+			if rec.Code != http.StatusUnauthorized && rec.Code != http.StatusForbidden {
+				t.Errorf("POST /api/pages (public=%v, anon): want 401/403, got %d", public, rec.Code)
+			}
+		})
 	}
 }
 

--- a/internal/wiki/assets/routes.go
+++ b/internal/wiki/assets/routes.go
@@ -52,37 +52,37 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
 
-	// Static file serving for /assets with access control.
+	// Static file serving for /assets. Gated per request so the
+	// public/authenticated decision follows a runtime toggle. With auth
+	// disabled InjectPublicEditor sets a user so the gate passes; with public
+	// mode on an anonymous request passes; otherwise a session is required.
 	if r.assetsDir != "" {
 		assetsFS := gin.Dir(r.assetsDir, false)
-		if opts.PublicAccess.Enabled() || opts.AuthDisabled {
-			ctx.Base.StaticFS("/assets", assetsFS)
-		} else {
-			assetsGroup := ctx.Base.Group("/assets")
-			assetsGroup.Use(
-				authmw.InjectPublicEditor(opts.AuthDisabled),
-				authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-			)
-			assetsGroup.StaticFS("/", assetsFS)
-		}
+		assetsGroup := ctx.Base.Group("/assets")
+		assetsGroup.Use(
+			authmw.InjectPublicEditor(opts.AuthDisabled),
+			authmw.RequireAuthOrPublicRead(r.authService, ctx.AuthCookies, opts.AuthDisabled, opts.PublicAccess),
+		)
+		assetsGroup.StaticFS("/", assetsFS)
 	}
 
-	if opts.PublicAccess.Enabled() {
-		pub := ctx.Base.Group("/api")
-		pub.GET("/pages/:id/assets", r.handleList)
-	}
+	// Listing a page's assets is a read: registered once, gated per request.
+	readGroup := ctx.Base.Group("/api")
+	readGroup.Use(
+		authmw.InjectPublicEditor(opts.AuthDisabled),
+		authmw.RequireAuthOrPublicRead(r.authService, ctx.AuthCookies, opts.AuthDisabled, opts.PublicAccess),
+		security.CSRFMiddleware(ctx.CSRFCookie),
+	)
+	readGroup.GET("/pages/:id/assets", r.handleList)
 
+	// Mutations always need a real authenticated editor/admin.
 	authGroup := ctx.Base.Group("/api")
 	authGroup.Use(
 		authmw.InjectPublicEditor(opts.AuthDisabled),
 		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
 		security.CSRFMiddleware(ctx.CSRFCookie),
 	)
-
 	authGroup.POST("/pages/:id/assets", authmw.RequireEditorOrAdmin(), r.handleUpload(opts.MaxAssetUploadSizeBytes))
-	if !opts.PublicAccess.Enabled() {
-		authGroup.GET("/pages/:id/assets", r.handleList)
-	}
 	authGroup.PUT("/pages/:id/assets/rename", authmw.RequireEditorOrAdmin(), r.handleRename)
 	authGroup.DELETE("/pages/:id/assets/:name", authmw.RequireEditorOrAdmin(), r.handleDelete)
 }

--- a/internal/wiki/links/routes.go
+++ b/internal/wiki/links/routes.go
@@ -34,21 +34,15 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
 
-	if opts.PublicAccess.Enabled() {
-		pub := ctx.Base.Group("/api")
-		pub.GET("/pages/:id/links", r.handleGetLinkStatus)
-	}
-
-	authGroup := ctx.Base.Group("/api")
-	authGroup.Use(
+	// Registered once, gated per request: RequireAuthOrPublicRead lets these
+	// reads flip between authenticated-only and public without a restart.
+	readGroup := ctx.Base.Group("/api")
+	readGroup.Use(
 		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
+		authmw.RequireAuthOrPublicRead(r.authService, ctx.AuthCookies, opts.AuthDisabled, opts.PublicAccess),
 		security.CSRFMiddleware(ctx.CSRFCookie),
 	)
-
-	if !opts.PublicAccess.Enabled() {
-		authGroup.GET("/pages/:id/links", r.handleGetLinkStatus)
-	}
+	readGroup.GET("/pages/:id/links", r.handleGetLinkStatus)
 }
 
 // ─── Handlers ───────────────────────────────────────────────────────────────

--- a/internal/wiki/pages/routes.go
+++ b/internal/wiki/pages/routes.go
@@ -109,31 +109,29 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
 
-	if opts.PublicAccess.Enabled() {
-		pub := ctx.Base.Group("/api")
-		pub.GET("/tree", r.handleGetTree)
-		pub.GET("/pages/by-path", r.handleGetByPath)
-		pub.GET("/pages/by-title", r.handleFindByTitle)
-		pub.GET("/pages/lookup", r.handleLookupPath)
-		pub.GET("/pages/permalink/:id", r.handleResolvePermalink)
-		pub.GET(pagesIdRoutePath, r.handleGetPage)
-	}
+	// Read routes registered once, gated per request: RequireAuthOrPublicRead
+	// lets them flip between authenticated-only and public without a restart.
+	readGroup := ctx.Base.Group("/api")
+	readGroup.Use(
+		authmw.InjectPublicEditor(opts.AuthDisabled),
+		authmw.RequireAuthOrPublicRead(r.authService, ctx.AuthCookies, opts.AuthDisabled, opts.PublicAccess),
+		security.CSRFMiddleware(ctx.CSRFCookie),
+	)
+	readGroup.GET("/tree", r.handleGetTree)
+	readGroup.GET(pagesIdRoutePath, r.handleGetPage)
+	readGroup.GET("/pages/lookup", r.handleLookupPath)
+	readGroup.GET("/pages/by-path", r.handleGetByPath)
+	readGroup.GET("/pages/by-title", r.handleFindByTitle)
+	readGroup.GET("/pages/permalink/:id", r.handleResolvePermalink)
 
+	// Everything below needs a real authenticated user regardless of public
+	// mode (writes, editor-gated reads, per-user favorites).
 	authGroup := ctx.Base.Group("/api")
 	authGroup.Use(
 		authmw.InjectPublicEditor(opts.AuthDisabled),
 		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
 		security.CSRFMiddleware(ctx.CSRFCookie),
 	)
-
-	if !opts.PublicAccess.Enabled() {
-		authGroup.GET("/tree", r.handleGetTree)
-		authGroup.GET(pagesIdRoutePath, r.handleGetPage)
-		authGroup.GET("/pages/lookup", r.handleLookupPath)
-		authGroup.GET("/pages/by-path", r.handleGetByPath)
-		authGroup.GET("/pages/by-title", r.handleFindByTitle)
-		authGroup.GET("/pages/permalink/:id", r.handleResolvePermalink)
-	}
 
 	authGroup.GET("/pages/slug-suggestion", authmw.RequireEditorOrAdmin(), r.handleSuggestSlug)
 	authGroup.POST("/pages", authmw.RequireEditorOrAdmin(), r.handleCreate)

--- a/internal/wiki/properties/routes.go
+++ b/internal/wiki/properties/routes.go
@@ -38,23 +38,16 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
 
-	if opts.PublicAccess.Enabled() {
-		pub := ctx.Base.Group("/api")
-		pub.GET("/properties", r.handleGetPropertyKeys)
-		pub.GET("/properties/pages", r.handleGetPagesByProperty)
-	}
-
-	authGroup := ctx.Base.Group("/api")
-	authGroup.Use(
+	// Registered once, gated per request: RequireAuthOrPublicRead lets these
+	// reads flip between authenticated-only and public without a restart.
+	readGroup := ctx.Base.Group("/api")
+	readGroup.Use(
 		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
+		authmw.RequireAuthOrPublicRead(r.authService, ctx.AuthCookies, opts.AuthDisabled, opts.PublicAccess),
 		security.CSRFMiddleware(ctx.CSRFCookie),
 	)
-
-	if !opts.PublicAccess.Enabled() {
-		authGroup.GET("/properties", r.handleGetPropertyKeys)
-		authGroup.GET("/properties/pages", r.handleGetPagesByProperty)
-	}
+	readGroup.GET("/properties", r.handleGetPropertyKeys)
+	readGroup.GET("/properties/pages", r.handleGetPagesByProperty)
 }
 
 // ─── Handlers ────────────────────────────────────────────────────────────────

--- a/internal/wiki/search/routes.go
+++ b/internal/wiki/search/routes.go
@@ -39,23 +39,16 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
 
-	if opts.PublicAccess.Enabled() {
-		pub := ctx.Base.Group("/api")
-		pub.GET("/search/status", r.handleGetIndexingStatus)
-		pub.GET("/search", r.handleSearch)
-	}
-
-	authGroup := ctx.Base.Group("/api")
-	authGroup.Use(
+	// Registered once, gated per request: RequireAuthOrPublicRead lets these
+	// reads flip between authenticated-only and public without a restart.
+	readGroup := ctx.Base.Group("/api")
+	readGroup.Use(
 		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
+		authmw.RequireAuthOrPublicRead(r.authService, ctx.AuthCookies, opts.AuthDisabled, opts.PublicAccess),
 		security.CSRFMiddleware(ctx.CSRFCookie),
 	)
-
-	if !opts.PublicAccess.Enabled() {
-		authGroup.GET("/search/status", r.handleGetIndexingStatus)
-		authGroup.GET("/search", r.handleSearch)
-	}
+	readGroup.GET("/search/status", r.handleGetIndexingStatus)
+	readGroup.GET("/search", r.handleSearch)
 }
 
 // ─── Handlers ───────────────────────────────────────────────────────────────

--- a/internal/wiki/tags/routes.go
+++ b/internal/wiki/tags/routes.go
@@ -39,23 +39,16 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
 
-	if opts.PublicAccess.Enabled() {
-		pub := ctx.Base.Group("/api")
-		pub.GET("/tags", r.handleGetTags)
-		pub.GET("/tags/pages", r.handleGetPagesByTags)
-	}
-
-	authGroup := ctx.Base.Group("/api")
-	authGroup.Use(
+	// Registered once, gated per request: RequireAuthOrPublicRead lets these
+	// reads flip between authenticated-only and public without a restart.
+	readGroup := ctx.Base.Group("/api")
+	readGroup.Use(
 		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
+		authmw.RequireAuthOrPublicRead(r.authService, ctx.AuthCookies, opts.AuthDisabled, opts.PublicAccess),
 		security.CSRFMiddleware(ctx.CSRFCookie),
 	)
-
-	if !opts.PublicAccess.Enabled() {
-		authGroup.GET("/tags", r.handleGetTags)
-		authGroup.GET("/tags/pages", r.handleGetPagesByTags)
-	}
+	readGroup.GET("/tags", r.handleGetTags)
+	readGroup.GET("/tags/pages", r.handleGetPagesByTags)
 }
 
 // ─── Handlers ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
**Stacked series 2/6** — base is `feat/public-mode-1-service` (#1504). Depends on #1504.

## What

Collapses the per-domain *"public group vs. authenticated group, chosen by a boot-time flag"* fork into a single group whose access decision is made per request. This is what lets public mode flip without a restart (the toggle itself is 3/6).

- **New middleware `RequireAuthOrPublicRead`**: behaves exactly like `RequireAuth` except that, on each path where `RequireAuth` would 401, it lets the request through **anonymously** when public mode is currently on. 401/500 bodies are byte-for-byte `RequireAuth`'s when public mode is off.
- `pages` / `links` / `search` / `tags` / `properties` / `assets` routes: the six read endpoints that were double-registered are now registered **once** on a `readGroup` gated by that middleware. Writes and editor-gated reads stay on the unchanged `authGroup` with `RequireAuth`.
- `assets`: the `/assets` static mount is likewise always grouped and gated, dropping the "no middleware at all" public/auth-disabled branch.

## Behaviour

**Deliberate change:** a logged-in user's identity now attaches to read routes even while public mode is on (the pre-refactor public group ran no auth middleware). No read handler currently branches on the context user, so this is invisible today — it's forward-looking. No endpoint is reachable unauthenticated that wasn't before, in either public-mode state.

## Tests

- `require_auth_or_public_test.go`: full matrix incl. a **"gate flips at runtime, same router changes behaviour"** regression pin.
- `router_test.go` `TestReadRouteAccessMatrix`: every previously-forked read endpoint × {public on/off} × {anon/authed} — anon is 401 iff public is off; authed is never 401; an anonymous write stays rejected in both modes.

Full backend suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
