### PR TITLE
refactor(http): centralise the public-mode auth wiring (5/6)

### DIFF
--- a/cmd/leafwiki/main.go
+++ b/cmd/leafwiki/main.go
@@ -138,9 +138,6 @@ func runServerCommand(_ context.Context, cmd *cli.Command, cfg *serverConfig) er
 	maxAssetUploadSize := mustParseByteSize(cfg.frontend.maxAssetUploadSize, "max asset upload size")
 	restoreUploadMaxSize := mustParseByteSize(cfg.backup.restoreUploadMaxSize, "restore upload max size")
 
-	// If disable-auth is set, the wiki is public regardless of --public-access.
-	publicAccess := cfg.auth.publicAccess
-
 	logoutURL := cfg.proxy.logoutURL
 	if resolved, usedDeprecated := resolveLogoutURL(logoutURL, cfg.proxy.httpRemoteUserLogoutURL); usedDeprecated {
 		slog.Default().Warn("--http-remote-user-logout-url/LEAFWIKI_HTTP_REMOTE_USER_LOGOUT_URL is deprecated, use --logout-url/LEAFWIKI_LOGOUT_URL instead")
@@ -199,7 +196,6 @@ func runServerCommand(_ context.Context, cmd *cli.Command, cfg *serverConfig) er
 	}
 
 	if cfg.auth.disableAuth {
-		publicAccess = true
 		slog.Default().Warn("Authentication disabled. Wiki is publicly accessible without authentication.")
 	}
 
@@ -215,7 +211,7 @@ func runServerCommand(_ context.Context, cmd *cli.Command, cfg *serverConfig) er
 		slog.Default().Info("Data directory created", "path", cfg.server.dataDir)
 	}
 
-	publicAccessService := buildPublicAccessService(cmd, cfg, publicAccess)
+	publicAccessService := buildPublicAccessService(cmd, cfg)
 
 	if !cfg.auth.disableAuth {
 		if cfg.auth.jwtSecret == "" {
@@ -424,12 +420,13 @@ func runServerCommand(_ context.Context, cmd *cli.Command, cfg *serverConfig) er
 // environment configuration or toggleable at runtime from Settings.
 //
 // It is env-managed when --public-access / LEAFWIKI_PUBLIC_ACCESS was supplied
-// explicitly, or when --disable-auth forces public mode on. Otherwise it is
+// explicitly, or when --disable-auth forces public mode on (both cases keep
+// today's behaviour and get a status-only Settings view). Otherwise it is
 // settings-managed, reading its initial value from
 // <data-dir>/public-access.json (absent ⇒ disabled).
-func buildPublicAccessService(cmd *cli.Command, cfg *serverConfig, resolvedPublicAccess bool) *publicaccess.Service {
+func buildPublicAccessService(cmd *cli.Command, cfg *serverConfig) *publicaccess.Service {
 	if cmd.IsSet("public-access") || cfg.auth.disableAuth {
-		return publicaccess.NewEnvManaged(resolvedPublicAccess)
+		return publicaccess.NewEnvManaged(cfg.auth.publicAccess || cfg.auth.disableAuth)
 	}
 	svc, err := publicaccess.NewSettingsManaged(cfg.server.dataDir)
 	if err != nil {

--- a/internal/http/middleware/auth/auth.go
+++ b/internal/http/middleware/auth/auth.go
@@ -20,7 +20,7 @@ type sessionOutcome struct {
 	body   gin.H // nil when user != nil
 }
 
-func abortStatus(status int, message string) sessionOutcome {
+func denied(status int, message string) sessionOutcome {
 	return sessionOutcome{status: status, body: gin.H{"error": message}}
 }
 
@@ -33,27 +33,27 @@ func resolveSession(c *gin.Context, authService *auth.AuthService, authCookies *
 	if userValue, exists := c.Get("user"); exists {
 		user, ok := userValue.(*auth.User)
 		if !ok || user == nil {
-			return abortStatus(http.StatusInternalServerError, "Invalid user context")
+			return denied(http.StatusInternalServerError, "Invalid user context")
 		}
 		return sessionOutcome{user: user}
 	}
 
 	if authDisabled {
-		return abortStatus(http.StatusUnauthorized, "User not authenticated and auth is disabled")
+		return denied(http.StatusUnauthorized, "User not authenticated and auth is disabled")
 	}
 
 	token, err := authCookies.ReadAccess(c)
 	if err != nil || token == "" {
-		return abortStatus(http.StatusUnauthorized, "Missing or invalid access token")
+		return denied(http.StatusUnauthorized, "Missing or invalid access token")
 	}
 
 	if authService == nil {
-		return abortStatus(http.StatusInternalServerError, "Authentication service unavailable")
+		return denied(http.StatusInternalServerError, "Authentication service unavailable")
 	}
 
 	user, err := authService.ValidateToken(token)
 	if err != nil {
-		return abortStatus(http.StatusUnauthorized, "Invalid or expired token")
+		return denied(http.StatusUnauthorized, "Invalid or expired token")
 	}
 
 	c.Set("user", user)

--- a/internal/http/middleware/auth/auth.go
+++ b/internal/http/middleware/auth/auth.go
@@ -9,44 +9,63 @@ import (
 
 const errUserNotAuthenticated = "User not authenticated"
 
+// sessionOutcome is the result of resolving the caller's identity for a
+// request: either a user, or the HTTP status + body a strict gate would abort
+// with. resolveSession never writes to the response, so callers can decide
+// whether a failure is fatal (RequireAuth) or may fall through to anonymous
+// access (RequireAuthOrPublicRead).
+type sessionOutcome struct {
+	user   *auth.User
+	status int   // 0 when user != nil
+	body   gin.H // nil when user != nil
+}
+
+func abortStatus(status int, message string) sessionOutcome {
+	return sessionOutcome{status: status, body: gin.H{"error": message}}
+}
+
+// resolveSession applies the standard identity resolution: a user already put
+// in context by a trusted upstream (proxy header / API key) wins; otherwise
+// the access-token cookie is validated. On success the user is stored in the
+// context. It is the single implementation shared by RequireAuth and
+// RequireAuthOrPublicRead.
+func resolveSession(c *gin.Context, authService *auth.AuthService, authCookies *AuthCookies, authDisabled bool) sessionOutcome {
+	if userValue, exists := c.Get("user"); exists {
+		user, ok := userValue.(*auth.User)
+		if !ok || user == nil {
+			return abortStatus(http.StatusInternalServerError, "Invalid user context")
+		}
+		return sessionOutcome{user: user}
+	}
+
+	if authDisabled {
+		return abortStatus(http.StatusUnauthorized, "User not authenticated and auth is disabled")
+	}
+
+	token, err := authCookies.ReadAccess(c)
+	if err != nil || token == "" {
+		return abortStatus(http.StatusUnauthorized, "Missing or invalid access token")
+	}
+
+	if authService == nil {
+		return abortStatus(http.StatusInternalServerError, "Authentication service unavailable")
+	}
+
+	user, err := authService.ValidateToken(token)
+	if err != nil {
+		return abortStatus(http.StatusUnauthorized, "Invalid or expired token")
+	}
+
+	c.Set("user", user)
+	return sessionOutcome{user: user}
+}
+
 func RequireAuth(authService *auth.AuthService, authCookies *AuthCookies, authDisabled bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		// Short-circuit only when a trusted upstream already stored a valid user.
-		if userValue, exists := c.Get("user"); exists {
-			user, ok := userValue.(*auth.User)
-			if !ok || user == nil {
-				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Invalid user context"})
-				return
-			}
-
-			c.Next()
+		if r := resolveSession(c, authService, authCookies, authDisabled); r.user == nil {
+			c.AbortWithStatusJSON(r.status, r.body)
 			return
 		}
-
-		if authDisabled {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated and auth is disabled"})
-			return
-		}
-
-		token, err := authCookies.ReadAccess(c)
-		if err != nil || token == "" {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Missing or invalid access token"})
-			return
-		}
-
-		if authService == nil {
-			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Authentication service unavailable"})
-			return
-		}
-
-		user, err := authService.ValidateToken(token)
-		if err != nil {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Invalid or expired token"})
-			return
-		}
-
-		// Store the user in context for later use
-		c.Set("user", user)
 		c.Next()
 	}
 }

--- a/internal/http/middleware/auth/require_auth_or_public.go
+++ b/internal/http/middleware/auth/require_auth_or_public.go
@@ -5,85 +5,36 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/perber/wiki/internal/core/auth"
+	"github.com/perber/wiki/internal/publicaccess"
 )
 
-// PublicReadGate reports whether unauthenticated read access ("public mode")
-// is currently allowed. It is read on every request so the flag can be
-// toggled at runtime; internal/http.PublicAccessProvider satisfies it.
-type PublicReadGate interface {
-	Enabled() bool
-}
-
 // RequireAuthOrPublicRead gates the read-only route groups that used to be
-// registered on either a bare public group or an authenticated group
-// depending on a boot-time flag. Registering them once behind this middleware
-// is what lets public mode flip without a restart.
+// registered on either a bare public group or an authenticated group depending
+// on a boot-time flag. Registering them once behind this middleware is what
+// lets public mode flip without a restart.
 //
-// It behaves exactly like RequireAuth, except that on each path where
-// RequireAuth would abort with 401 it instead calls c.Next() *anonymously*
-// when public mode is currently on. Consequences:
+// It shares resolveSession with RequireAuth, so identity resolution is
+// identical by construction. The only difference: where RequireAuth aborts
+// with 401, this middleware instead calls c.Next() *anonymously* when public
+// mode is currently on. A 500 (invalid user context, misconfigured
+// authService) still aborts regardless.
 //
-//   - user already in context (proxy header / API key / a prior mw) → passes,
-//     identical to RequireAuth.
-//   - valid session cookie → user is resolved and attached, so a logged-in
-//     editor keeps write affordances even while public mode is on. This is the
-//     one behaviour that differs from the pre-refactor public group, which ran
-//     no auth middleware at all and therefore saw every caller as anonymous.
-//   - no / invalid cookie, public mode ON  → passes anonymously.
-//   - no / invalid cookie, public mode OFF → 401, byte-for-byte as RequireAuth.
-//   - authService misconfigured (nil) with a token present → 500, as
-//     RequireAuth, regardless of public mode.
-func RequireAuthOrPublicRead(authService *auth.AuthService, authCookies *AuthCookies, authDisabled bool, public PublicReadGate) gin.HandlerFunc {
+// Consequence worth noting: a valid session cookie is resolved and attached
+// even while public mode is on, so a logged-in editor keeps write affordances.
+// The pre-refactor public group ran no auth middleware and saw every caller as
+// anonymous. No read handler currently branches on the context user, so this
+// is invisible today, but it is the intended forward-looking behaviour.
+func RequireAuthOrPublicRead(authService *auth.AuthService, authCookies *AuthCookies, authDisabled bool, public publicaccess.ReadGate) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if userValue, exists := c.Get("user"); exists {
-			user, ok := userValue.(*auth.User)
-			if !ok || user == nil {
-				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Invalid user context"})
-				return
-			}
+		r := resolveSession(c, authService, authCookies, authDisabled)
+		if r.user != nil {
 			c.Next()
 			return
 		}
-
-		publicOK := public != nil && public.Enabled()
-
-		if authDisabled {
-			// InjectPublicEditor normally sets a user before this runs when
-			// auth is disabled; this branch only trips if it didn't.
-			if publicOK {
-				c.Next()
-				return
-			}
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated and auth is disabled"})
+		if r.status == http.StatusUnauthorized && public != nil && public.Enabled() {
+			c.Next() // public mode: anonymous read is allowed
 			return
 		}
-
-		token, err := authCookies.ReadAccess(c)
-		if err != nil || token == "" {
-			if publicOK {
-				c.Next()
-				return
-			}
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Missing or invalid access token"})
-			return
-		}
-
-		if authService == nil {
-			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Authentication service unavailable"})
-			return
-		}
-
-		user, err := authService.ValidateToken(token)
-		if err != nil {
-			if publicOK {
-				c.Next()
-				return
-			}
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Invalid or expired token"})
-			return
-		}
-
-		c.Set("user", user)
-		c.Next()
+		c.AbortWithStatusJSON(r.status, r.body)
 	}
 }

--- a/internal/http/middleware/auth/require_auth_or_public_test.go
+++ b/internal/http/middleware/auth/require_auth_or_public_test.go
@@ -9,15 +9,16 @@ import (
 	"github.com/gin-gonic/gin"
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
+	"github.com/perber/wiki/internal/publicaccess"
 )
 
-// flipGate is a PublicReadGate whose value can be toggled between requests,
-// standing in for the runtime-mutable publicaccess.Service.
+// flipGate is a publicaccess.ReadGate whose value can be toggled between
+// requests, standing in for the runtime-mutable publicaccess.Service.
 type flipGate struct{ enabled bool }
 
 func (g *flipGate) Enabled() bool { return g.enabled }
 
-func newAuthOrPublicRouter(auth *coreauth.AuthService, authCookies *authmw.AuthCookies, authDisabled bool, gate authmw.PublicReadGate, inject gin.HandlerFunc) *gin.Engine {
+func newAuthOrPublicRouter(auth *coreauth.AuthService, authCookies *authmw.AuthCookies, authDisabled bool, gate publicaccess.ReadGate, inject gin.HandlerFunc) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	if inject != nil {

--- a/internal/http/registrar.go
+++ b/internal/http/registrar.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"github.com/gin-gonic/gin"
+	coreauth "github.com/perber/wiki/internal/core/auth"
 	authmiddleware "github.com/perber/wiki/internal/http/middleware/auth"
 	"github.com/perber/wiki/internal/http/middleware/security"
 )
@@ -20,6 +21,36 @@ type RouterContext struct {
 	CSRFCookie *security.CSRFCookie
 	// Opts contains the global router configuration.
 	Opts RouterOptions
+}
+
+// APIAuthGroup returns an "/api" group that always requires an authenticated
+// user: InjectPublicEditor (for --disable-auth), RequireAuth, then CSRF. This
+// is the one place that middleware chain is defined; domain registrars call it
+// instead of repeating the three .Use lines.
+func (ctx RouterContext) APIAuthGroup(authService *coreauth.AuthService) *gin.RouterGroup {
+	g := ctx.Base.Group("/api")
+	g.Use(
+		authmiddleware.InjectPublicEditor(ctx.Opts.AuthDisabled),
+		authmiddleware.RequireAuth(authService, ctx.AuthCookies, ctx.Opts.AuthDisabled),
+		security.CSRFMiddleware(ctx.CSRFCookie),
+	)
+	return g
+}
+
+// APIReadGroup returns an "/api" group for read-only endpoints that may be
+// exposed anonymously when "public mode" is on: InjectPublicEditor,
+// RequireAuthOrPublicRead (attaches the user if present; requires one only
+// when public mode is off), then CSRF (a no-op for the GET verbs these
+// endpoints use). This is the single definition of what guards public-capable
+// reads.
+func (ctx RouterContext) APIReadGroup(authService *coreauth.AuthService) *gin.RouterGroup {
+	g := ctx.Base.Group("/api")
+	g.Use(
+		authmiddleware.InjectPublicEditor(ctx.Opts.AuthDisabled),
+		authmiddleware.RequireAuthOrPublicRead(authService, ctx.AuthCookies, ctx.Opts.AuthDisabled, ctx.Opts.PublicAccess),
+		security.CSRFMiddleware(ctx.CSRFCookie),
+	)
+	return g
 }
 
 // RouteRegistrar is the interface each domain module implements to register its

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -18,6 +18,7 @@ import (
 	auth_middleware "github.com/perber/wiki/internal/http/middleware/auth"
 	"github.com/perber/wiki/internal/http/middleware/maintenance"
 	"github.com/perber/wiki/internal/http/middleware/security"
+	"github.com/perber/wiki/internal/publicaccess"
 	"github.com/perber/wiki/internal/restore"
 )
 
@@ -88,28 +89,12 @@ type HTTPRemoteUserConfig struct {
 	UserService func() *coreauth.UserService
 }
 
-// PublicAccessProvider reports the current "public mode" state (anonymous read
-// access to every page). It is read per request rather than snapshotted at
-// route-registration time so the flag can be toggled at runtime with no
-// restart. *publicaccess.Service satisfies it. EnvManaged reports whether the
-// value is pinned by environment configuration (Settings UI shows it
-// read-only); it never changes for the life of the process.
-type PublicAccessProvider interface {
-	Enabled() bool
-	EnvManaged() bool
-}
-
-// staticPublicAccess is the fallback PublicAccessProvider used when
-// RouterOptions.PublicAccess is left nil (tests, embedders that don't care).
-// It reports a fixed value and, being immutable, presents as env-managed.
-type staticPublicAccess bool
-
-func (s staticPublicAccess) Enabled() bool    { return bool(s) }
-func (s staticPublicAccess) EnvManaged() bool { return true }
-
 // RouterOptions holds global HTTP server configuration shared across all domains.
 type RouterOptions struct {
-	PublicAccess            PublicAccessProvider     // Current public read-access state; read per request
+	// PublicAccess is the current "public mode" state (anonymous read access to
+	// every page), read per request so it can be toggled at runtime with no
+	// restart. nil is treated as a fixed-false provider. See internal/publicaccess.
+	PublicAccess            publicaccess.Provider
 	EditorLimit             int                      // Max admin+editor users allowed; 0 = unlimited
 	InjectCodeInHeader      string                   // Raw HTML/JS code to inject into the <head> tag
 	CustomStylesheet        string                   // Path to a custom CSS file (resolved by wiki before passing)
@@ -159,7 +144,7 @@ func NewRouter(registrars []RouteRegistrar, frontendCfg FrontendConfig, opts Rou
 	}
 
 	if opts.PublicAccess == nil {
-		opts.PublicAccess = staticPublicAccess(false)
+		opts.PublicAccess = publicaccess.Fixed(false)
 	}
 
 	if Environment == "production" {

--- a/internal/publicaccess/provider.go
+++ b/internal/publicaccess/provider.go
@@ -1,0 +1,29 @@
+package publicaccess
+
+// Provider is the read-only view of the public-access flag that the HTTP layer
+// depends on. *Service implements it; so does the value returned by Fixed.
+// Keeping the interface here (rather than in internal/http) lets both the
+// router and the per-request auth middleware share one definition.
+type Provider interface {
+	// Enabled reports whether anonymous read access is currently allowed.
+	Enabled() bool
+	// EnvManaged reports whether the value is pinned by environment
+	// configuration and therefore read-only in the Settings UI.
+	EnvManaged() bool
+}
+
+// ReadGate is the minimal slice of Provider the per-request read gate needs
+// (see auth.RequireAuthOrPublicRead). Provider satisfies it.
+type ReadGate interface {
+	Enabled() bool
+}
+
+// Fixed returns a Provider pinned to a compile-time value, for tests and for
+// embedders that never wire a real Service. It presents as env-managed because
+// it can never change.
+func Fixed(enabled bool) Provider { return fixedProvider(enabled) }
+
+type fixedProvider bool
+
+func (f fixedProvider) Enabled() bool    { return bool(f) }
+func (f fixedProvider) EnvManaged() bool { return true }

--- a/internal/wiki/apikeys/routes.go
+++ b/internal/wiki/apikeys/routes.go
@@ -9,7 +9,6 @@ import (
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	httpinternal "github.com/perber/wiki/internal/http"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 )
 
 // Routes is the RouteRegistrar for API key management.
@@ -45,14 +44,7 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 // manage every key in the system).
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
-	base := ctx.Base
-
-	authGroup := base.Group("/api")
-	authGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	authGroup := ctx.APIAuthGroup(r.authService)
 
 	authGroup.POST("/api-keys", authmw.RequireCookieSession(), authmw.RequireAdmin(opts.AuthDisabled), r.handleCreateAPIKey)
 	authGroup.GET("/api-keys", authmw.RequireCookieSession(), authmw.RequireAdmin(opts.AuthDisabled), r.handleListAPIKeys)

--- a/internal/wiki/assets/routes.go
+++ b/internal/wiki/assets/routes.go
@@ -8,7 +8,6 @@ import (
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	httpinternal "github.com/perber/wiki/internal/http"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 )
 
 const maxMultipartMemory = 32 << 20 // 32 MiB
@@ -52,10 +51,9 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
 
-	// Static file serving for /assets. Gated per request so the
-	// public/authenticated decision follows a runtime toggle. With auth
-	// disabled InjectPublicEditor sets a user so the gate passes; with public
-	// mode on an anonymous request passes; otherwise a session is required.
+	// Static /assets files share the read gate (public mode / --disable-auth /
+	// session), but on their own path and without CSRF (GET-only static FS),
+	// so this one group is wired inline rather than via APIReadGroup.
 	if r.assetsDir != "" {
 		assetsFS := gin.Dir(r.assetsDir, false)
 		assetsGroup := ctx.Base.Group("/assets")
@@ -67,21 +65,11 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	}
 
 	// Listing a page's assets is a read: registered once, gated per request.
-	readGroup := ctx.Base.Group("/api")
-	readGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuthOrPublicRead(r.authService, ctx.AuthCookies, opts.AuthDisabled, opts.PublicAccess),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	readGroup := ctx.APIReadGroup(r.authService)
 	readGroup.GET("/pages/:id/assets", r.handleList)
 
 	// Mutations always need a real authenticated editor/admin.
-	authGroup := ctx.Base.Group("/api")
-	authGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	authGroup := ctx.APIAuthGroup(r.authService)
 	authGroup.POST("/pages/:id/assets", authmw.RequireEditorOrAdmin(), r.handleUpload(opts.MaxAssetUploadSizeBytes))
 	authGroup.PUT("/pages/:id/assets/rename", authmw.RequireEditorOrAdmin(), r.handleRename)
 	authGroup.DELETE("/pages/:id/assets/:name", authmw.RequireEditorOrAdmin(), r.handleDelete)

--- a/internal/wiki/auth/routes.go
+++ b/internal/wiki/auth/routes.go
@@ -135,12 +135,7 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	)
 	meGroup.GET("/auth/me", r.handleMe)
 
-	authGroup := ctx.Base.Group("/api")
-	authGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	authGroup := ctx.APIAuthGroup(r.authService)
 
 	authGroup.POST("/auth/logout", r.handleLogout(ctx))
 

--- a/internal/wiki/avatar/routes.go
+++ b/internal/wiki/avatar/routes.go
@@ -11,7 +11,6 @@ import (
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	httpinternal "github.com/perber/wiki/internal/http"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 )
 
 // Routes is the RouteRegistrar for the avatar domain.
@@ -43,7 +42,6 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 // RegisterRoutes implements RouteRegistrar. Any authenticated user manages
 // only their own avatar — there is no admin override (self-service only).
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
-	opts := ctx.Opts
 	base := ctx.Base
 
 	// Public avatar static file server — unauthenticated, path-traversal
@@ -51,12 +49,7 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	// AvatarImage -> AvatarFallback degrades to initials automatically.
 	base.GET("/avatars/:userId", r.handleServeAvatar)
 
-	authGroup := base.Group("/api")
-	authGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	authGroup := ctx.APIAuthGroup(r.authService)
 	authGroup.POST("/user/avatar", r.handleUploadAvatar)
 	authGroup.DELETE("/user/avatar", r.handleDeleteAvatar)
 }

--- a/internal/wiki/backup/routes.go
+++ b/internal/wiki/backup/routes.go
@@ -8,7 +8,6 @@ import (
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	httpinternal "github.com/perber/wiki/internal/http"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 )
 
 // Routes is the RouteRegistrar for the backup admin endpoints.
@@ -31,12 +30,7 @@ func NewRoutes(repo *backupSvc.Repository, scheduler *backupSvc.Scheduler, authS
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
 
-	authGroup := ctx.Base.Group("/api")
-	authGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	authGroup := ctx.APIAuthGroup(r.authService)
 
 	// Lightweight alert endpoint — any authenticated user (editors + admins).
 	// Exposes only needsIntervention bool; no sensitive config or credentials.

--- a/internal/wiki/branding/routes.go
+++ b/internal/wiki/branding/routes.go
@@ -14,7 +14,6 @@ import (
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	httpinternal "github.com/perber/wiki/internal/http"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 )
 
 // Routes is the RouteRegistrar for the branding domain.
@@ -72,12 +71,7 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	base.GET("/favicon.ico", r.handleServeCurrentFavicon)
 
 	// Auth-gated branding mutations (admin only).
-	authGroup := base.Group("/api")
-	authGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	authGroup := ctx.APIAuthGroup(r.authService)
 	authGroup.PUT("/branding", authmw.RequireAdmin(opts.AuthDisabled), r.handleUpdateBranding)
 	authGroup.POST("/branding/logo", authmw.RequireAdmin(opts.AuthDisabled), r.handleUploadLogo)
 	authGroup.POST("/branding/favicon", authmw.RequireAdmin(opts.AuthDisabled), r.handleUploadFavicon)

--- a/internal/wiki/importer/routes.go
+++ b/internal/wiki/importer/routes.go
@@ -9,7 +9,6 @@ import (
 	sharederrors "github.com/perber/wiki/internal/core/shared/errors"
 	httpinternal "github.com/perber/wiki/internal/http"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 	coreimporter "github.com/perber/wiki/internal/importer"
 )
 
@@ -62,12 +61,7 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 		r.svc.SetAssetMaxUploadSizeBytes(opts.MaxAssetUploadSizeBytes)
 	}
 
-	authGroup := ctx.Base.Group("/api")
-	authGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	authGroup := ctx.APIAuthGroup(r.authService)
 
 	authGroup.POST(importPlanRoutePath, authmw.RequireEditorOrAdmin(), r.handleCreatePlan)
 	authGroup.GET(importPlanRoutePath, authmw.RequireEditorOrAdmin(), r.handleGetPlan)

--- a/internal/wiki/instancesettings/errors.go
+++ b/internal/wiki/instancesettings/errors.go
@@ -15,6 +15,11 @@ const (
 	ErrCodeInternal = "instance_settings_internal_error"
 )
 
+// NOTE: errorResponse / errorDetail / respondWithStatusError mirror the
+// hand-rolled localized-error-to-JSON shape every feature package carries
+// (see internal/wiki/branding/errors.go and siblings). Consolidating them
+// into one shared http helper is tracked in the architecture refactoring
+// backlog, not done here.
 type errorResponse struct {
 	Error errorDetail `json:"error"`
 }

--- a/internal/wiki/instancesettings/routes.go
+++ b/internal/wiki/instancesettings/routes.go
@@ -41,7 +41,15 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
 		security.CSRFMiddleware(ctx.CSRFCookie),
 	)
-	adminGroup.PUT("/public-access", authmw.RequireAdmin(opts.AuthDisabled), r.handleSetPublicAccess)
+	// Flipping instance-wide anonymous access is a browser-session-only
+	// action, like API-key management — an API key must not be able to do it
+	// (CSRF already blocks bearer clients today, RequireCookieSession makes
+	// the intent explicit and independent of that).
+	adminGroup.PUT("/public-access",
+		authmw.RequireAdmin(opts.AuthDisabled),
+		authmw.RequireCookieSession(),
+		r.handleSetPublicAccess,
+	)
 }
 
 // ─── Handlers ───────────────────────────────────────────────────────────────

--- a/internal/wiki/instancesettings/routes.go
+++ b/internal/wiki/instancesettings/routes.go
@@ -12,7 +12,6 @@ import (
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	httpinternal "github.com/perber/wiki/internal/http"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 	"github.com/perber/wiki/internal/publicaccess"
 )
 
@@ -33,20 +32,13 @@ func NewRoutes(publicAccess *publicaccess.Service, authService *coreauth.AuthSer
 
 // RegisterRoutes implements RouteRegistrar.
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
-	opts := ctx.Opts
-
-	adminGroup := ctx.Base.Group("/api/admin/settings")
-	adminGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	adminGroup := ctx.APIAuthGroup(r.authService).Group("/admin/settings")
 	// Flipping instance-wide anonymous access is a browser-session-only
 	// action, like API-key management — an API key must not be able to do it
 	// (CSRF already blocks bearer clients today, RequireCookieSession makes
 	// the intent explicit and independent of that).
 	adminGroup.PUT("/public-access",
-		authmw.RequireAdmin(opts.AuthDisabled),
+		authmw.RequireAdmin(ctx.Opts.AuthDisabled),
 		authmw.RequireCookieSession(),
 		r.handleSetPublicAccess,
 	)

--- a/internal/wiki/links/routes.go
+++ b/internal/wiki/links/routes.go
@@ -6,8 +6,6 @@ import (
 	"github.com/gin-gonic/gin"
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	httpinternal "github.com/perber/wiki/internal/http"
-	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 )
 
 // Routes is the RouteRegistrar for the links domain.
@@ -32,16 +30,9 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 
 // RegisterRoutes implements RouteRegistrar.
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
-	opts := ctx.Opts
-
-	// Registered once, gated per request: RequireAuthOrPublicRead lets these
-	// reads flip between authenticated-only and public without a restart.
-	readGroup := ctx.Base.Group("/api")
-	readGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuthOrPublicRead(r.authService, ctx.AuthCookies, opts.AuthDisabled, opts.PublicAccess),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	// Registered once, gated per request so this read can flip between
+	// authenticated-only and public without a restart (see APIReadGroup).
+	readGroup := ctx.APIReadGroup(r.authService)
 	readGroup.GET("/pages/:id/links", r.handleGetLinkStatus)
 }
 

--- a/internal/wiki/pages/routes.go
+++ b/internal/wiki/pages/routes.go
@@ -13,7 +13,6 @@ import (
 	httpinternal "github.com/perber/wiki/internal/http"
 	"github.com/perber/wiki/internal/http/dto"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 )
 
 const (
@@ -109,14 +108,9 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
 
-	// Read routes registered once, gated per request: RequireAuthOrPublicRead
-	// lets them flip between authenticated-only and public without a restart.
-	readGroup := ctx.Base.Group("/api")
-	readGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuthOrPublicRead(r.authService, ctx.AuthCookies, opts.AuthDisabled, opts.PublicAccess),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	// Read routes registered once, gated per request so they can flip between
+	// authenticated-only and public without a restart (see APIReadGroup).
+	readGroup := ctx.APIReadGroup(r.authService)
 	readGroup.GET("/tree", r.handleGetTree)
 	readGroup.GET(pagesIdRoutePath, r.handleGetPage)
 	readGroup.GET("/pages/lookup", r.handleLookupPath)
@@ -126,12 +120,7 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 
 	// Everything below needs a real authenticated user regardless of public
 	// mode (writes, editor-gated reads, per-user favorites).
-	authGroup := ctx.Base.Group("/api")
-	authGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	authGroup := ctx.APIAuthGroup(r.authService)
 
 	authGroup.GET("/pages/slug-suggestion", authmw.RequireEditorOrAdmin(), r.handleSuggestSlug)
 	authGroup.POST("/pages", authmw.RequireEditorOrAdmin(), r.handleCreate)

--- a/internal/wiki/properties/routes.go
+++ b/internal/wiki/properties/routes.go
@@ -7,8 +7,6 @@ import (
 	"github.com/gin-gonic/gin"
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	httpinternal "github.com/perber/wiki/internal/http"
-	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 )
 
 // Routes is the RouteRegistrar for the properties domain.
@@ -36,16 +34,9 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 
 // RegisterRoutes implements RouteRegistrar.
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
-	opts := ctx.Opts
-
-	// Registered once, gated per request: RequireAuthOrPublicRead lets these
-	// reads flip between authenticated-only and public without a restart.
-	readGroup := ctx.Base.Group("/api")
-	readGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuthOrPublicRead(r.authService, ctx.AuthCookies, opts.AuthDisabled, opts.PublicAccess),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	// Registered once, gated per request so these reads can flip between
+	// authenticated-only and public without a restart (see APIReadGroup).
+	readGroup := ctx.APIReadGroup(r.authService)
 	readGroup.GET("/properties", r.handleGetPropertyKeys)
 	readGroup.GET("/properties/pages", r.handleGetPagesByProperty)
 }

--- a/internal/wiki/restore/routes.go
+++ b/internal/wiki/restore/routes.go
@@ -9,7 +9,6 @@ import (
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	httpinternal "github.com/perber/wiki/internal/http"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 	"github.com/perber/wiki/internal/restore"
 )
 
@@ -40,12 +39,7 @@ func NewRoutes(manager *restore.Manager, authService *coreauth.AuthService) *Rou
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
 
-	authGroup := ctx.Base.Group("/api")
-	authGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	authGroup := ctx.APIAuthGroup(r.authService)
 
 	adminGroup := authGroup.Group("/admin")
 	adminGroup.Use(authmw.RequireAdmin(opts.AuthDisabled))

--- a/internal/wiki/resync/routes.go
+++ b/internal/wiki/resync/routes.go
@@ -7,7 +7,6 @@ import (
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	httpinternal "github.com/perber/wiki/internal/http"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 )
 
 // Routes is the RouteRegistrar for the filesystem resync admin endpoints.
@@ -30,12 +29,7 @@ func NewRoutes(triggerUC *TriggerResyncUseCase, statusUC *GetResyncStatusUseCase
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
 
-	authGroup := ctx.Base.Group("/api")
-	authGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	authGroup := ctx.APIAuthGroup(r.authService)
 
 	adminGroup := authGroup.Group("/admin")
 	adminGroup.Use(authmw.RequireAdmin(opts.AuthDisabled))

--- a/internal/wiki/revisions/routes.go
+++ b/internal/wiki/revisions/routes.go
@@ -13,7 +13,6 @@ import (
 	httpinternal "github.com/perber/wiki/internal/http"
 	"github.com/perber/wiki/internal/http/dto"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 )
 
 // Routes is the RouteRegistrar for the revisions domain.
@@ -67,12 +66,7 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
 
-	authGroup := ctx.Base.Group("/api")
-	authGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	authGroup := ctx.APIAuthGroup(r.authService)
 
 	// Revision routes are behind the EnableRevision feature flag.
 	if opts.EnableRevision {

--- a/internal/wiki/search/routes.go
+++ b/internal/wiki/search/routes.go
@@ -8,8 +8,6 @@ import (
 	"github.com/gin-gonic/gin"
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	httpinternal "github.com/perber/wiki/internal/http"
-	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 )
 
 // Routes is the RouteRegistrar for the search domain.
@@ -37,16 +35,9 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 
 // RegisterRoutes implements RouteRegistrar.
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
-	opts := ctx.Opts
-
-	// Registered once, gated per request: RequireAuthOrPublicRead lets these
-	// reads flip between authenticated-only and public without a restart.
-	readGroup := ctx.Base.Group("/api")
-	readGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuthOrPublicRead(r.authService, ctx.AuthCookies, opts.AuthDisabled, opts.PublicAccess),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	// Registered once, gated per request so these reads can flip between
+	// authenticated-only and public without a restart (see APIReadGroup).
+	readGroup := ctx.APIReadGroup(r.authService)
 	readGroup.GET("/search/status", r.handleGetIndexingStatus)
 	readGroup.GET("/search", r.handleSearch)
 }

--- a/internal/wiki/snapshot/routes.go
+++ b/internal/wiki/snapshot/routes.go
@@ -10,7 +10,6 @@ import (
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	httpinternal "github.com/perber/wiki/internal/http"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 	snapshotSvc "github.com/perber/wiki/internal/snapshot"
 )
 
@@ -36,12 +35,7 @@ func NewRoutes(manager *snapshotSvc.Manager, scheduler *snapshotSvc.Scheduler, a
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
 
-	authGroup := ctx.Base.Group("/api")
-	authGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	authGroup := ctx.APIAuthGroup(r.authService)
 
 	adminGroup := authGroup.Group("/admin")
 	adminGroup.Use(authmw.RequireAdmin(opts.AuthDisabled))

--- a/internal/wiki/tags/routes.go
+++ b/internal/wiki/tags/routes.go
@@ -8,8 +8,6 @@ import (
 	"github.com/gin-gonic/gin"
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	httpinternal "github.com/perber/wiki/internal/http"
-	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 )
 
 // Routes is the RouteRegistrar for the tags domain.
@@ -37,16 +35,9 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 
 // RegisterRoutes implements RouteRegistrar.
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
-	opts := ctx.Opts
-
-	// Registered once, gated per request: RequireAuthOrPublicRead lets these
-	// reads flip between authenticated-only and public without a restart.
-	readGroup := ctx.Base.Group("/api")
-	readGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuthOrPublicRead(r.authService, ctx.AuthCookies, opts.AuthDisabled, opts.PublicAccess),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	// Registered once, gated per request so these reads can flip between
+	// authenticated-only and public without a restart (see APIReadGroup).
+	readGroup := ctx.APIReadGroup(r.authService)
 	readGroup.GET("/tags", r.handleGetTags)
 	readGroup.GET("/tags/pages", r.handleGetPagesByTags)
 }

--- a/internal/wiki/usersettings/routes.go
+++ b/internal/wiki/usersettings/routes.go
@@ -7,7 +7,6 @@ import (
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	httpinternal "github.com/perber/wiki/internal/http"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 )
 
 // Routes is the RouteRegistrar for the user-settings domain.
@@ -36,13 +35,7 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 // RegisterRoutes implements RouteRegistrar. Any authenticated user manages
 // only their own settings — there is no admin override.
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
-	opts := ctx.Opts
-	authGroup := ctx.Base.Group("/api")
-	authGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	authGroup := ctx.APIAuthGroup(r.authService)
 	authGroup.GET("/user-settings", r.handleGetUserSettings)
 	authGroup.PUT("/user-settings", r.handleUpdateUserSettings)
 }


### PR DESCRIPTION
**Stacked series 5/6** — base is `feat/public-mode-4-ui` (#1507). Depends on #1507.

## What

Maintainability/readability pass over what 1–4 introduced. **No behaviour change** — the route-access matrix, middleware, and toggle tests plus the full backend suite stay green. Net **−38 lines**.

- **One provider interface.** `internal/publicaccess` now owns `Provider` (`Enabled` + `EnvManaged`) and `ReadGate` (`Enabled`); `internal/http` and the auth middleware import that instead of each defining their own copy. Adds `publicaccess.Fixed(bool)` for the nil / test case, replacing `http.staticPublicAccess`.
- **One definition of each middleware chain.** New `RouterContext.APIReadGroup` / `APIAuthGroup` wrap the `InjectPublicEditor + RequireAuth[OrPublicRead] + CSRF` triple that was copy-pasted into six route files. The read-route protection is now described in exactly one place.
- **One identity-resolution implementation.** `RequireAuth` and `RequireAuthOrPublicRead` now share an unexported `resolveSession`, so *"public read"* is provably *"RequireAuth, but a 401 becomes anonymous pass-through when public mode is on"* rather than a hand-kept copy of `RequireAuth`'s body.
- **Harden the toggle endpoint** with `RequireCookieSession()` — flipping instance-wide anonymous access is browser-session-only, like API-key management (CSRF already blocked bearer clients; this makes it explicit).
- `buildPublicAccessService` owns the whole env-vs-settings decision; drops the redundant `publicAccess` local from `runServerCommand`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
