### PR TITLE
refactor(http): route every authed /api group through APIAuthGroup (6/6)

### DIFF
--- a/internal/http/middleware/auth/auth.go
+++ b/internal/http/middleware/auth/auth.go
@@ -20,7 +20,7 @@ type sessionOutcome struct {
 	body   gin.H // nil when user != nil
 }
 
-func abortStatus(status int, message string) sessionOutcome {
+func denied(status int, message string) sessionOutcome {
 	return sessionOutcome{status: status, body: gin.H{"error": message}}
 }
 
@@ -33,27 +33,27 @@ func resolveSession(c *gin.Context, authService *auth.AuthService, authCookies *
 	if userValue, exists := c.Get("user"); exists {
 		user, ok := userValue.(*auth.User)
 		if !ok || user == nil {
-			return abortStatus(http.StatusInternalServerError, "Invalid user context")
+			return denied(http.StatusInternalServerError, "Invalid user context")
 		}
 		return sessionOutcome{user: user}
 	}
 
 	if authDisabled {
-		return abortStatus(http.StatusUnauthorized, "User not authenticated and auth is disabled")
+		return denied(http.StatusUnauthorized, "User not authenticated and auth is disabled")
 	}
 
 	token, err := authCookies.ReadAccess(c)
 	if err != nil || token == "" {
-		return abortStatus(http.StatusUnauthorized, "Missing or invalid access token")
+		return denied(http.StatusUnauthorized, "Missing or invalid access token")
 	}
 
 	if authService == nil {
-		return abortStatus(http.StatusInternalServerError, "Authentication service unavailable")
+		return denied(http.StatusInternalServerError, "Authentication service unavailable")
 	}
 
 	user, err := authService.ValidateToken(token)
 	if err != nil {
-		return abortStatus(http.StatusUnauthorized, "Invalid or expired token")
+		return denied(http.StatusUnauthorized, "Invalid or expired token")
 	}
 
 	c.Set("user", user)

--- a/internal/wiki/apikeys/routes.go
+++ b/internal/wiki/apikeys/routes.go
@@ -9,7 +9,6 @@ import (
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	httpinternal "github.com/perber/wiki/internal/http"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 )
 
 // Routes is the RouteRegistrar for API key management.
@@ -45,14 +44,7 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 // manage every key in the system).
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
-	base := ctx.Base
-
-	authGroup := base.Group("/api")
-	authGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	authGroup := ctx.APIAuthGroup(r.authService)
 
 	authGroup.POST("/api-keys", authmw.RequireCookieSession(), authmw.RequireAdmin(opts.AuthDisabled), r.handleCreateAPIKey)
 	authGroup.GET("/api-keys", authmw.RequireCookieSession(), authmw.RequireAdmin(opts.AuthDisabled), r.handleListAPIKeys)

--- a/internal/wiki/auth/routes.go
+++ b/internal/wiki/auth/routes.go
@@ -135,12 +135,7 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	)
 	meGroup.GET("/auth/me", r.handleMe)
 
-	authGroup := ctx.Base.Group("/api")
-	authGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	authGroup := ctx.APIAuthGroup(r.authService)
 
 	authGroup.POST("/auth/logout", r.handleLogout(ctx))
 

--- a/internal/wiki/avatar/routes.go
+++ b/internal/wiki/avatar/routes.go
@@ -11,7 +11,6 @@ import (
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	httpinternal "github.com/perber/wiki/internal/http"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 )
 
 // Routes is the RouteRegistrar for the avatar domain.
@@ -43,7 +42,6 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 // RegisterRoutes implements RouteRegistrar. Any authenticated user manages
 // only their own avatar — there is no admin override (self-service only).
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
-	opts := ctx.Opts
 	base := ctx.Base
 
 	// Public avatar static file server — unauthenticated, path-traversal
@@ -51,12 +49,7 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	// AvatarImage -> AvatarFallback degrades to initials automatically.
 	base.GET("/avatars/:userId", r.handleServeAvatar)
 
-	authGroup := base.Group("/api")
-	authGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	authGroup := ctx.APIAuthGroup(r.authService)
 	authGroup.POST("/user/avatar", r.handleUploadAvatar)
 	authGroup.DELETE("/user/avatar", r.handleDeleteAvatar)
 }

--- a/internal/wiki/backup/routes.go
+++ b/internal/wiki/backup/routes.go
@@ -8,7 +8,6 @@ import (
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	httpinternal "github.com/perber/wiki/internal/http"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 )
 
 // Routes is the RouteRegistrar for the backup admin endpoints.
@@ -31,12 +30,7 @@ func NewRoutes(repo *backupSvc.Repository, scheduler *backupSvc.Scheduler, authS
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
 
-	authGroup := ctx.Base.Group("/api")
-	authGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	authGroup := ctx.APIAuthGroup(r.authService)
 
 	// Lightweight alert endpoint — any authenticated user (editors + admins).
 	// Exposes only needsIntervention bool; no sensitive config or credentials.

--- a/internal/wiki/branding/routes.go
+++ b/internal/wiki/branding/routes.go
@@ -14,7 +14,6 @@ import (
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	httpinternal "github.com/perber/wiki/internal/http"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 )
 
 // Routes is the RouteRegistrar for the branding domain.
@@ -72,12 +71,7 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	base.GET("/favicon.ico", r.handleServeCurrentFavicon)
 
 	// Auth-gated branding mutations (admin only).
-	authGroup := base.Group("/api")
-	authGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	authGroup := ctx.APIAuthGroup(r.authService)
 	authGroup.PUT("/branding", authmw.RequireAdmin(opts.AuthDisabled), r.handleUpdateBranding)
 	authGroup.POST("/branding/logo", authmw.RequireAdmin(opts.AuthDisabled), r.handleUploadLogo)
 	authGroup.POST("/branding/favicon", authmw.RequireAdmin(opts.AuthDisabled), r.handleUploadFavicon)

--- a/internal/wiki/importer/routes.go
+++ b/internal/wiki/importer/routes.go
@@ -9,7 +9,6 @@ import (
 	sharederrors "github.com/perber/wiki/internal/core/shared/errors"
 	httpinternal "github.com/perber/wiki/internal/http"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 	coreimporter "github.com/perber/wiki/internal/importer"
 )
 
@@ -62,12 +61,7 @@ func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 		r.svc.SetAssetMaxUploadSizeBytes(opts.MaxAssetUploadSizeBytes)
 	}
 
-	authGroup := ctx.Base.Group("/api")
-	authGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	authGroup := ctx.APIAuthGroup(r.authService)
 
 	authGroup.POST(importPlanRoutePath, authmw.RequireEditorOrAdmin(), r.handleCreatePlan)
 	authGroup.GET(importPlanRoutePath, authmw.RequireEditorOrAdmin(), r.handleGetPlan)

--- a/internal/wiki/instancesettings/errors.go
+++ b/internal/wiki/instancesettings/errors.go
@@ -15,6 +15,11 @@ const (
 	ErrCodeInternal = "instance_settings_internal_error"
 )
 
+// NOTE: errorResponse / errorDetail / respondWithStatusError mirror the
+// hand-rolled localized-error-to-JSON shape every feature package carries
+// (see internal/wiki/branding/errors.go and siblings). Consolidating them
+// into one shared http helper is tracked in the architecture refactoring
+// backlog, not done here.
 type errorResponse struct {
 	Error errorDetail `json:"error"`
 }

--- a/internal/wiki/instancesettings/routes.go
+++ b/internal/wiki/instancesettings/routes.go
@@ -12,7 +12,6 @@ import (
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	httpinternal "github.com/perber/wiki/internal/http"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 	"github.com/perber/wiki/internal/publicaccess"
 )
 
@@ -33,20 +32,13 @@ func NewRoutes(publicAccess *publicaccess.Service, authService *coreauth.AuthSer
 
 // RegisterRoutes implements RouteRegistrar.
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
-	opts := ctx.Opts
-
-	adminGroup := ctx.Base.Group("/api/admin/settings")
-	adminGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	adminGroup := ctx.APIAuthGroup(r.authService).Group("/admin/settings")
 	// Flipping instance-wide anonymous access is a browser-session-only
 	// action, like API-key management — an API key must not be able to do it
 	// (CSRF already blocks bearer clients today, RequireCookieSession makes
 	// the intent explicit and independent of that).
 	adminGroup.PUT("/public-access",
-		authmw.RequireAdmin(opts.AuthDisabled),
+		authmw.RequireAdmin(ctx.Opts.AuthDisabled),
 		authmw.RequireCookieSession(),
 		r.handleSetPublicAccess,
 	)

--- a/internal/wiki/restore/routes.go
+++ b/internal/wiki/restore/routes.go
@@ -9,7 +9,6 @@ import (
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	httpinternal "github.com/perber/wiki/internal/http"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 	"github.com/perber/wiki/internal/restore"
 )
 
@@ -40,12 +39,7 @@ func NewRoutes(manager *restore.Manager, authService *coreauth.AuthService) *Rou
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
 
-	authGroup := ctx.Base.Group("/api")
-	authGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	authGroup := ctx.APIAuthGroup(r.authService)
 
 	adminGroup := authGroup.Group("/admin")
 	adminGroup.Use(authmw.RequireAdmin(opts.AuthDisabled))

--- a/internal/wiki/resync/routes.go
+++ b/internal/wiki/resync/routes.go
@@ -7,7 +7,6 @@ import (
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	httpinternal "github.com/perber/wiki/internal/http"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 )
 
 // Routes is the RouteRegistrar for the filesystem resync admin endpoints.
@@ -30,12 +29,7 @@ func NewRoutes(triggerUC *TriggerResyncUseCase, statusUC *GetResyncStatusUseCase
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
 
-	authGroup := ctx.Base.Group("/api")
-	authGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	authGroup := ctx.APIAuthGroup(r.authService)
 
 	adminGroup := authGroup.Group("/admin")
 	adminGroup.Use(authmw.RequireAdmin(opts.AuthDisabled))

--- a/internal/wiki/revisions/routes.go
+++ b/internal/wiki/revisions/routes.go
@@ -13,7 +13,6 @@ import (
 	httpinternal "github.com/perber/wiki/internal/http"
 	"github.com/perber/wiki/internal/http/dto"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 )
 
 // Routes is the RouteRegistrar for the revisions domain.
@@ -67,12 +66,7 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
 
-	authGroup := ctx.Base.Group("/api")
-	authGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	authGroup := ctx.APIAuthGroup(r.authService)
 
 	// Revision routes are behind the EnableRevision feature flag.
 	if opts.EnableRevision {

--- a/internal/wiki/snapshot/routes.go
+++ b/internal/wiki/snapshot/routes.go
@@ -10,7 +10,6 @@ import (
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	httpinternal "github.com/perber/wiki/internal/http"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 	snapshotSvc "github.com/perber/wiki/internal/snapshot"
 )
 
@@ -36,12 +35,7 @@ func NewRoutes(manager *snapshotSvc.Manager, scheduler *snapshotSvc.Scheduler, a
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
 	opts := ctx.Opts
 
-	authGroup := ctx.Base.Group("/api")
-	authGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	authGroup := ctx.APIAuthGroup(r.authService)
 
 	adminGroup := authGroup.Group("/admin")
 	adminGroup.Use(authmw.RequireAdmin(opts.AuthDisabled))

--- a/internal/wiki/usersettings/routes.go
+++ b/internal/wiki/usersettings/routes.go
@@ -7,7 +7,6 @@ import (
 	coreauth "github.com/perber/wiki/internal/core/auth"
 	httpinternal "github.com/perber/wiki/internal/http"
 	authmw "github.com/perber/wiki/internal/http/middleware/auth"
-	"github.com/perber/wiki/internal/http/middleware/security"
 )
 
 // Routes is the RouteRegistrar for the user-settings domain.
@@ -36,13 +35,7 @@ func NewRoutes(cfg RoutesConfig) *Routes {
 // RegisterRoutes implements RouteRegistrar. Any authenticated user manages
 // only their own settings — there is no admin override.
 func (r *Routes) RegisterRoutes(ctx httpinternal.RouterContext) {
-	opts := ctx.Opts
-	authGroup := ctx.Base.Group("/api")
-	authGroup.Use(
-		authmw.InjectPublicEditor(opts.AuthDisabled),
-		authmw.RequireAuth(r.authService, ctx.AuthCookies, opts.AuthDisabled),
-		security.CSRFMiddleware(ctx.CSRFCookie),
-	)
+	authGroup := ctx.APIAuthGroup(r.authService)
 	authGroup.GET("/user-settings", r.handleGetUserSettings)
 	authGroup.PUT("/user-settings", r.handleUpdateUserSettings)
 }


### PR DESCRIPTION
**Stacked series 6/6** — base is `feat/public-mode-5-cleanup` (#1508). Depends on #1508.

## What

Opportunistic cleanup enabled by 5/6's `RouterContext` helpers. **No behaviour change** — full backend suite green. Net **−72 lines**.

- The `InjectPublicEditor + RequireAuth + CSRF` `.Use(...)` triple was open-coded in 11 more route files (avatar, auth, restore, backup, revisions, importer, usersettings, resync, apikeys, snapshot, branding) plus `instancesettings`. They now all call `ctx.APIAuthGroup(r.authService)`; nested admin groups (`.Group("/admin")`) are unchanged. **"What guards the authenticated `/api` surface" is now one function.** The `http/middleware/security` import drops out of 11 files.
- `auth.abortStatus` → `auth.denied` (it returns the deny outcome, doesn't abort).
- `instancesettings/errors.go`: note the localized-error-responder duplication (tracked in the architecture backlog, not fixed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
