### PR TITLE
fix(tree): keep the target row highlighted while deleting

### DIFF
--- a/ui/leafwiki-ui/src/features/tree/TreeNode.test.tsx
+++ b/ui/leafwiki-ui/src/features/tree/TreeNode.test.tsx
@@ -1,0 +1,126 @@
+import { DIALOG_DELETE_PAGE_CONFIRMATION } from '@/lib/registries'
+import type { PageNode } from '@/lib/api/pages'
+import { useDialogsStore } from '@/stores/dialogs'
+import { useTreeStore } from '@/stores/tree'
+import { render, screen } from '@testing-library/react'
+import type React from 'react'
+import { MemoryRouter } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TreeNode } from './TreeNode'
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('@/components/TooltipWrapper', () => ({
+  TooltipWrapper: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+// The actions menu pulls in a large dependency tree of its own (dropdown
+// primitives, favorites, page editor state, etc.) that this test doesn't
+// care about -- it only asserts on the row's delete-target highlight.
+vi.mock('./TreeNodeActionsMenu', () => ({
+  default: () => <div />,
+}))
+
+const node: PageNode = {
+  id: 'page-1',
+  title: 'Getting Started',
+  slug: 'getting-started',
+  path: 'docs/getting-started',
+  version: 'v1',
+  parentId: 'docs',
+  children: null,
+  kind: 'page',
+}
+
+const otherNode: PageNode = {
+  ...node,
+  id: 'page-2',
+  title: 'Other Page',
+  path: 'docs/other-page',
+}
+
+function renderNode(target: PageNode = node) {
+  return render(
+    <MemoryRouter>
+      <TreeNode node={target} />
+    </MemoryRouter>,
+  )
+}
+
+describe('TreeNode delete-target highlight', () => {
+  beforeEach(() => {
+    window.matchMedia = vi.fn().mockImplementation(() => ({
+      matches: false,
+      media: '(max-width: 767px)',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+
+    useDialogsStore.setState({ dialogType: null, dialogProps: null })
+    useTreeStore.setState({ activeNodeId: null, openNodeIdSet: {} })
+  })
+
+  it('has no delete-target styling when no dialog is open', () => {
+    renderNode()
+
+    const row = screen.getByTestId(`tree-node-${node.id}`)
+    expect(row).not.toHaveAttribute('data-delete-target')
+    expect(row.className).not.toContain('tree-node--delete-target')
+  })
+
+  it('stays highlighted while the delete confirmation dialog targets this node', () => {
+    useDialogsStore.setState({
+      dialogType: DIALOG_DELETE_PAGE_CONFIRMATION,
+      dialogProps: { pageId: node.id, redirectTo: '/' },
+    })
+
+    renderNode()
+
+    const row = screen.getByTestId(`tree-node-${node.id}`)
+    expect(row).toHaveAttribute('data-delete-target', 'true')
+    expect(row.className).toContain('tree-node--delete-target')
+  })
+
+  it('does not highlight a row when the dialog targets a different node', () => {
+    useDialogsStore.setState({
+      dialogType: DIALOG_DELETE_PAGE_CONFIRMATION,
+      dialogProps: { pageId: otherNode.id, redirectTo: '/' },
+    })
+
+    renderNode(node)
+
+    const row = screen.getByTestId(`tree-node-${node.id}`)
+    expect(row).not.toHaveAttribute('data-delete-target')
+    expect(row.className).not.toContain('tree-node--delete-target')
+  })
+
+  it('does not highlight the row once the dialog is closed again', () => {
+    useDialogsStore.setState({
+      dialogType: DIALOG_DELETE_PAGE_CONFIRMATION,
+      dialogProps: { pageId: node.id, redirectTo: '/' },
+    })
+    const { rerender } = renderNode()
+    expect(screen.getByTestId(`tree-node-${node.id}`)).toHaveAttribute(
+      'data-delete-target',
+      'true',
+    )
+
+    useDialogsStore.setState({ dialogType: null, dialogProps: null })
+    rerender(
+      <MemoryRouter>
+        <TreeNode node={node} />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByTestId(`tree-node-${node.id}`)).not.toHaveAttribute(
+      'data-delete-target',
+    )
+  })
+})

--- a/ui/leafwiki-ui/src/features/tree/TreeNode.tsx
+++ b/ui/leafwiki-ui/src/features/tree/TreeNode.tsx
@@ -1,6 +1,9 @@
 import { TreeViewActionButton } from '@/features/tree/TreeViewActionButton'
 import { NODE_KIND_SECTION, PageNode } from '@/lib/api/pages'
-import { DIALOG_ADD_PAGE } from '@/lib/registries'
+import {
+  DIALOG_ADD_PAGE,
+  DIALOG_DELETE_PAGE_CONFIRMATION,
+} from '@/lib/registries'
 import { createNavigationVisitState } from '@/lib/navigationVisit'
 import { useIsMobile } from '@/lib/useIsMobile'
 import { useIsReadOnly } from '@/lib/useIsReadOnly'
@@ -36,6 +39,15 @@ export const TreeNode = React.memo(function TreeNode({ node }: Props) {
   )
   const isLoggedIn = useSessionStore((s) => s.user !== null)
   const isActive = isStoreActive
+  // Keeps this row visually distinct while the delete confirmation dialog
+  // it opened is still on screen -- the "..." menu that triggered it closes
+  // immediately, which otherwise left the target row indistinguishable
+  // from any other once the dialog appeared.
+  const isDeleteTarget = useDialogsStore(
+    (s) =>
+      s.dialogType === DIALOG_DELETE_PAGE_CONFIRMATION &&
+      s.dialogProps?.pageId === node.id,
+  )
 
   const handleLinkClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
     if (
@@ -94,6 +106,7 @@ export const TreeNode = React.memo(function TreeNode({ node }: Props) {
         <span
           className={clsx('tree-node__title', {
             'tree-node__title--active': isActive,
+            'tree-node__title--delete-target': isDeleteTarget,
           })}
         >
           {node.title || t('treeActions.untitledPage')}
@@ -114,8 +127,10 @@ export const TreeNode = React.memo(function TreeNode({ node }: Props) {
           'tree-node--inactive': !isActive,
           'tree-node--dragging': isDragging,
           'tree-node--drop-inside': dropZone === 'inside',
+          'tree-node--delete-target': isDeleteTarget,
         })}
         data-testid={`tree-node-${node.id}`}
+        data-delete-target={isDeleteTarget ? 'true' : undefined}
         style={{ paddingLeft: indent }}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
@@ -133,6 +148,7 @@ export const TreeNode = React.memo(function TreeNode({ node }: Props) {
         <div
           className={clsx('tree-node__marker', {
             'tree-node__marker--active': isActive,
+            'tree-node__marker--delete-target': isDeleteTarget,
           })}
           style={{ left: markerOffset }}
         />

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -2724,12 +2724,25 @@
     @apply hover:bg-tree-node-hover;
   }
 
+  /* Keeps the row of the page a delete confirmation dialog is about to
+     remove visually distinct while that dialog is open, even though the
+     "..." menu that opened it has already closed. Takes precedence over
+     --active (defined below it) since deleting a different page than the
+     one you're currently viewing must never look ambiguous. */
+  .tree-node--delete-target {
+    @apply bg-error/10;
+  }
+
   .tree-node__marker {
     @apply bg-surface-border absolute top-0 bottom-0 w-0.5;
   }
 
   .tree-node__marker--active {
     @apply bg-brand/60;
+  }
+
+  .tree-node__marker--delete-target {
+    @apply bg-error/60;
   }
 
   .tree-node__main {
@@ -2766,6 +2779,10 @@
 
   .tree-node__title--active {
     @apply text-brand;
+  }
+
+  .tree-node__title--delete-target {
+    @apply text-error;
   }
 
   .tree-node__actions {


### PR DESCRIPTION
## Summary
Split out of #1503 at @perber's request — this is the second half of #1502: the delete confirmation dialog's target row lost all visual distinction the moment the dialog opened, since the "..." dropdown menu that triggered it closes immediately on click (clearing `openMenuNodeId`, which only ever controlled the row's hover-action visibility, not any lasting highlight).

## Changes
- `TreeNode.tsx`: derives a new `isDeleteTarget` flag straight from the dialogs store (`dialogType === DIALOG_DELETE_PAGE_CONFIRMATION && dialogProps.pageId === node.id`) rather than adding new dialog-specific state — the delete dialog already carries the target `pageId`, so this just reads state that already exists.
- `index.css`: styled with the existing error/destructive tokens (`bg-error/10`, `text-error`) rather than reusing the `--active` (currently-viewed-page) styling, since the row being deleted and the row you're currently viewing are two independent things — conflating them would be misleading when they differ. The `--delete-target` rules are placed after their `--active` counterparts so they win when both apply.
- `TreeNode.test.tsx` (new): 4 tests covering no highlight with no dialog open, highlighted when this node is the delete target, not highlighted when the dialog targets a different node, and the highlight clearing once the dialog closes.

## Testing
- `tsc -b` passes with no errors.
- New test file: 4/4 passing.
- Full suite: 527/527 passing, no regressions.

Related to #1502 (companion to #1503).

🤖 Generated with [Claude Code](https://claude.com/claude-code)