### PR TITLE
Reset sidebar on new browser session

### DIFF
--- a/ui/leafwiki-ui/src/stores/tree.ts
+++ b/ui/leafwiki-ui/src/stores/tree.ts
@@ -7,7 +7,7 @@ import {
 import i18next from '@/lib/i18n'
 import { FlatPageSearchItem, buildFlatPageSearchItems } from '@/lib/pageSearch'
 import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
+import { persist, createJSONStorage } from 'zustand/middleware'
 
 function buildIndexes(root: PageNode) {
   const byPath: Record<string, PageNode> = {}
@@ -297,6 +297,7 @@ export const useTreeStore = create<TreeStore>()(
     }),
     {
       name: 'leafwiki-tree-open-node-ids',
+      storage: createJSONStorage(() => sessionStorage),
       partialize: (state) => ({
         openNodeIds: state.openNodeIds,
       }),


### PR DESCRIPTION
## Related issue

Fixes #1493 

## What changed

Use sessionStorage instead of localStorage to persist sidebar section expansion state only for the current browser session.

## Checklist

- [x] I discussed the approach on the linked issue before starting (or this is a trivial fix: typo, docs, obvious one-liner)
- [x] This PR is focused on a single change
- [x] I ran `npm run format` in `ui/leafwiki-ui` (and in `e2e` if e2e tests changed)
- [x] I updated documentation if needed
