### PR TITLE
fix(preview): render Markdown images inline-block

### DIFF
--- a/ui/leafwiki-ui/src/features/preview/MarkdownImage.test.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownImage.test.tsx
@@ -17,6 +17,12 @@ describe('MarkdownImage', () => {
     expect(useDialogsStore.getState().dialogType).toBe(DIALOG_IMAGE_PREVIEW)
   })
 
+  it('renders inline-block so trailing text stays on the same line (#1471)', () => {
+    render(<MarkdownImage src="/assets/foo.png" alt="foo" />)
+
+    expect(screen.getByAltText('foo')).toHaveStyle({ display: 'inline-block' })
+  })
+
   it('lets the surrounding link handle the click instead of opening the preview', () => {
     render(
       <a href="https://github.com/perber/leafwiki">

--- a/ui/leafwiki-ui/src/features/preview/MarkdownImage.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MarkdownImage.tsx
@@ -74,6 +74,11 @@ export function MarkdownImage({
       src={versionedSrc}
       alt={alt}
       style={{
+        // Tailwind's preflight resets images to `display: block`, which forces
+        // a line break between an image and any text that follows it on the
+        // same Markdown line (`![alt](img) text`). Keep Markdown images inline
+        // so trailing/leading text stays on the same line (#1471).
+        display: 'inline-block',
         ...style,
         cursor: 'zoom-in',
       }}


### PR DESCRIPTION
## What

Rendered Markdown images are now `display: inline-block` instead of the `display: block` that Tailwind's preflight applies to all images.

## Why

`![alt](img) text` on a single Markdown line was rendered with a line break between the image and the following text, because the `<img>` is a block-level box. Same for text *preceding* an image on the same line.

Root cause: `@import 'tailwindcss'` (Tailwind v4) pulls in the preflight reset `img { display: block; vertical-align: middle; }`, and the project's own image rule in `index.css` only overrides `height`/`max-width`, not `display`.

## Change

- `MarkdownImage.tsx`: add `display: 'inline-block'` to the rendered `<img>` style. Placed before the caller's `...style` spread so an explicit author style still wins. `vertical-align: middle` from the preflight is untouched, so standalone images (image alone in a paragraph) look exactly as before.
- `MarkdownImage.test.tsx`: regression test — fails before the change, passes after.

`MarkdownImage` is only consumed by `MarkdownPreview`, so this covers the page viewer, the editor preview and the history preview in one place. The `index.css` rule was left alone to avoid a second source of truth.

## Not in scope

Two follow-on points raised in the issue thread are standard CommonMark behaviour, not this bug:
- A single newline between two `![img](x) TEXT` lines is a soft break (space); separate lines need a blank line or a hard break.
- A blank line between them produces normal `prose` paragraph spacing.

## Verification

- `vitest run src/features/preview/` — 84 passed
- `tsc --noEmit` — clean
- `npm run lint` — clean
- `npm run format` — no changes

Fixes #1471

🤖 Generated with [Claude Code](https://claude.com/claude-code)