### PR TITLE
fix(settings): align Public access page layout with other settings pages

### DIFF
--- a/ui/leafwiki-ui/src/features/settings/PublicAccessSettings.tsx
+++ b/ui/leafwiki-ui/src/features/settings/PublicAccessSettings.tsx
@@ -41,65 +41,70 @@ export default function PublicAccessSettings() {
   }
 
   return (
-    <div data-testid="public-access-settings">
-      <h2 className="settings__section-title">{t('sectionTitle')}</h2>
-      <p className="settings__section-description">{t('sectionDescription')}</p>
-
-      <div className="settings__field">
-        <p className="settings__status-line">
-          {publicAccess ? (
-            <Globe className="settings__status-icon" aria-hidden />
-          ) : (
-            <Lock className="settings__status-icon" aria-hidden />
-          )}
-          {publicAccess ? t('statusOn') : t('statusOff')}
+    <div className="settings" data-testid="public-access-settings">
+      <h1 className="settings__title">{t('pageTitle')}</h1>
+      <div className="settings__section">
+        <h2 className="settings__section-title">{t('sectionTitle')}</h2>
+        <p className="settings__section-description">
+          {t('sectionDescription')}
         </p>
 
-        {envManaged ? (
-          <div
-            className="settings__notice"
-            data-testid="public-access-env-managed"
-          >
-            <strong>{t('envManagedTitle')}</strong>
-            <span>{t('envManagedDescription')}</span>
-          </div>
-        ) : publicAccess ? (
-          <Button
-            variant="outline"
-            disabled={saving}
-            onClick={() => void apply(false)}
-            data-testid="public-access-disable"
-          >
-            {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            {t('disableButton')}
-          </Button>
-        ) : (
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <Button disabled={saving} data-testid="public-access-enable">
-                {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                {t('enableButton')}
-              </Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>{t('confirmTitle')}</AlertDialogTitle>
-                <AlertDialogDescription>
-                  {t('confirmDescription')}
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>{t('cancel')}</AlertDialogCancel>
-                <AlertDialogAction
-                  onClick={() => void apply(true)}
-                  data-testid="public-access-confirm"
-                >
-                  {t('confirmAction')}
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-        )}
+        <div className="settings__field">
+          <p className="settings__status-line">
+            {publicAccess ? (
+              <Globe className="settings__status-icon" aria-hidden />
+            ) : (
+              <Lock className="settings__status-icon" aria-hidden />
+            )}
+            {publicAccess ? t('statusOn') : t('statusOff')}
+          </p>
+
+          {envManaged ? (
+            <div
+              className="settings__notice"
+              data-testid="public-access-env-managed"
+            >
+              <strong>{t('envManagedTitle')}</strong>
+              <span>{t('envManagedDescription')}</span>
+            </div>
+          ) : publicAccess ? (
+            <Button
+              variant="outline"
+              disabled={saving}
+              onClick={() => void apply(false)}
+              data-testid="public-access-disable"
+            >
+              {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {t('disableButton')}
+            </Button>
+          ) : (
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button disabled={saving} data-testid="public-access-enable">
+                  {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  {t('enableButton')}
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>{t('confirmTitle')}</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    {t('confirmDescription')}
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>{t('cancel')}</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={() => void apply(true)}
+                    data-testid="public-access-confirm"
+                  >
+                    {t('confirmAction')}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          )}
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Problem

The **Public access** settings page did not match the spacing/layout of every other settings page (Branding, Account, Backup, Snapshot, …).

`PublicAccessSettings` was the only settings screen that did not use the shared wrapper structure:

```
<div className="settings">            → mx-auto max-w-4xl, page padding
  <h1 className="settings__title">     → page heading
  <div className="settings__section">  → card: border, bg-surface, p-6, mb-6
```

Instead it rendered `settings__section-title` directly with no container and no card, so the content hugged the top-left corner with no padding and no bordered box.

## Change

- Wrap the content in `settings` + `settings__section`, matching the other settings pages.
- Add the standard `<h1 className="settings__title">` heading (`pageTitle` already exists in `en` / `de` / `es`).

Purely structural — no new CSS, no new i18n keys, no behavior change.

## Verification

- `npm run format` — clean
- `tsc --noEmit` — green
- `eslint` — green
- `PublicAccessSettings.test.tsx` — 4/4 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)