### PR TITLE
fix(usersettings): accept Spanish (es) as a UI language

### DIFF
--- a/internal/usersettings/language.go
+++ b/internal/usersettings/language.go
@@ -8,6 +8,7 @@ import "sort"
 var allowedLanguages = map[string]bool{
 	DefaultLanguage: true,
 	"de":            true,
+	"es":            true,
 }
 
 // IsAllowedLanguage reports whether lang is a language UserSettings accepts.

--- a/internal/usersettings/language_test.go
+++ b/internal/usersettings/language_test.go
@@ -7,14 +7,14 @@ import (
 
 func TestAllowedLanguages_ReturnsSortedShippedCodes(t *testing.T) {
 	got := AllowedLanguages()
-	want := []string{"de", "en"}
+	want := []string{"de", "en", "es"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("expected %v, got %v", want, got)
 	}
 }
 
 func TestIsAllowedLanguage_AcceptsShippedCodesAndRejectsUnknownOnes(t *testing.T) {
-	for _, lang := range []string{"en", "de"} {
+	for _, lang := range []string{"en", "de", "es"} {
 		if !IsAllowedLanguage(lang) {
 			t.Errorf("expected %q to be allowed", lang)
 		}

--- a/internal/usersettings/usersettings_service_test.go
+++ b/internal/usersettings/usersettings_service_test.go
@@ -97,6 +97,32 @@ func TestUserSettingsService_Get_StoreUnavailable_PropagatesOriginalErrorCode(t 
 	}
 }
 
+// TestUserSettingsService_Update_SpanishLanguage_Persists is the regression
+// test for the frontend/backend sync gap: the "feat(i18n): add Spanish
+// translation" contribution shipped ui/leafwiki-ui/src/locales/es/ (so
+// "Español" shows up in the picker) but never extended allowedLanguages, so
+// saving the choice failed validation and the UI snapped back with an error.
+func TestUserSettingsService_Update_SpanishLanguage_Persists(t *testing.T) {
+	svc := newTestService(t)
+
+	lang := "es"
+	updated, err := svc.Update("user-1", UserSettingsPatch{Language: &lang})
+	if err != nil {
+		t.Fatalf("Update (es): %v", err)
+	}
+	if updated.Language != lang {
+		t.Fatalf("expected Language=%q, got %+v", lang, updated)
+	}
+
+	got, err := svc.Get("user-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Language != lang {
+		t.Fatalf("expected persisted Language=%q, got %+v", lang, got)
+	}
+}
+
 func TestUserSettingsService_Update_InvalidLanguage_ReturnsValidationError(t *testing.T) {
 	svc := newTestService(t)
 


### PR DESCRIPTION
## Problem

Selecting **Español** in Account → Preferences throws an error: an error toast ("Could not update language setting") appears and the language snaps back to the previous one. Spanish is offered in the picker but can't actually be used.

## Root cause

Frontend and backend are out of sync on the shipped locale set.

- The `feat(i18n): add Spanish translation` contribution (`7c725ea2`) added `ui/leafwiki-ui/src/locales/es/` only. The frontend discovers locales by glob, so **"Español" shows up in the language picker** and `i18next.changeLanguage('es')` is applied optimistically.
- On save, the frontend PUTs `{ language: "es" }` to `/api/user-settings`. `UserSettingsService.Update` validates the code against a hardcoded allow-list in `internal/usersettings/language.go` that only contains `en` and `de`, so it returns a `validation_error` ("Language must be one of: de, en").
- The frontend catches it, shows the error toast, and rolls the language back.

The comment in `language.go` already says this list must be kept in sync with `ui/leafwiki-ui/src/locales/` whenever a locale is added — that step was missed in the Spanish PR.

## Change

- Add `"es"` to `allowedLanguages` in `internal/usersettings/language.go`.
- Regression tests, written failing first:
  - `TestAllowedLanguages_*` / `TestIsAllowedLanguage_*` now include `es` (the "keep in sync" guard).
  - `TestUserSettingsService_Update_SpanishLanguage_Persists` pins the user-facing behaviour: `Update` with `es` succeeds and persists.

Backend-only; the frontend already ships and applies the `es` locale. `es` has full key parity with `en` across all namespace files (verified; `src/lib/i18n.test.ts` enforces it in CI).

## Verification

- `go test ./internal/usersettings/... ./internal/wiki/usersettings/... ./internal/http/...` — green
- `go build ./...` / `go vet ./internal/usersettings/...` — clean

Follow-up to #789.

🤖 Generated with [Claude Code](https://claude.com/claude-code)