### PR TITLE
fix(print): keep page breaks from clipping article text

### DIFF
--- a/e2e/tests/print.spec.ts
+++ b/e2e/tests/print.spec.ts
@@ -1,0 +1,203 @@
+import test, { expect } from '@playwright/test';
+import LoginPage from '../pages/LoginPage';
+import ViewPage from '../pages/ViewPage';
+
+const user = process.env.E2E_ADMIN_USER || 'admin';
+const password = process.env.E2E_ADMIN_PASSWORD || 'admin';
+
+// Long enough to span several printed pages so the browser has to paginate the
+// article — that is what surfaced the clipping bug in #1531.
+function buildLongContent(): string {
+  const paragraph = Array.from(
+    { length: 6 },
+    () =>
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod ' +
+      'tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.',
+  ).join(' ');
+
+  const blocks: string[] = [];
+  for (let i = 1; i <= 40; i++) {
+    blocks.push(`## Section ${i}`);
+    blocks.push(paragraph);
+    blocks.push(paragraph);
+  }
+  return blocks.join('\n\n');
+}
+
+async function createLongPage(
+  page: import('@playwright/test').Page,
+  title: string,
+): Promise<ViewPage> {
+  const slug = title
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^\w-]/g, '');
+
+  const created = await page.evaluate(
+    async ({ pageTitle, pageSlug, content }) => {
+      function getCsrfTokenFromCookie(): string | null {
+        const hostMatch =
+          document.cookie.match(/(?:^|;\s*)__Host-leafwiki_csrf=([^;]+)/) ??
+          document.cookie.match(/(?:^|;\s*)leafwiki_csrf=([^;]+)/);
+
+        if (!hostMatch) return null;
+
+        try {
+          return decodeURIComponent(hostMatch[1]);
+        } catch {
+          return hostMatch[1];
+        }
+      }
+
+      const csrfToken = getCsrfTokenFromCookie();
+      if (!csrfToken) {
+        throw new Error('Missing CSRF token cookie for print test setup');
+      }
+
+      const createResponse = await fetch('/api/pages', {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': csrfToken,
+        },
+        body: JSON.stringify({
+          parentId: null,
+          title: pageTitle,
+          slug: pageSlug,
+          kind: 'page',
+        }),
+      });
+
+      if (!createResponse.ok) {
+        throw new Error(`Failed to create page ${pageTitle}: ${createResponse.status}`);
+      }
+
+      const createdPage = (await createResponse.json()) as {
+        id: string;
+        title: string;
+        slug: string;
+        path: string;
+        version: string;
+      };
+
+      const updateResponse = await fetch(`/api/pages/${createdPage.id}`, {
+        method: 'PUT',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': csrfToken,
+        },
+        body: JSON.stringify({
+          version: createdPage.version,
+          title: createdPage.title,
+          slug: createdPage.slug,
+          content,
+        }),
+      });
+
+      if (!updateResponse.ok) {
+        throw new Error(`Failed to update page ${createdPage.path}: ${updateResponse.status}`);
+      }
+
+      const updatedPage = (await updateResponse.json()) as typeof createdPage;
+      return { path: updatedPage.path };
+    },
+    { pageTitle: title, pageSlug: slug, content: buildLongContent() },
+  );
+
+  const viewPage = new ViewPage(page);
+  await viewPage.goto(`/${created.path}`);
+  return viewPage;
+}
+
+test.describe('Print layout', () => {
+  test.beforeEach(async ({ page }) => {
+    const loginPage = new LoginPage(page);
+    await loginPage.goto();
+    await loginPage.login(user, password);
+    const viewPage = new ViewPage(page);
+    await viewPage.expectUserLoggedIn();
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.emulateMedia({ media: null });
+    const viewPage = new ViewPage(page);
+    await viewPage.logout();
+  });
+
+  // Regression for #1531: scroll/clip containers around the article must not
+  // survive into print. Chromium refuses to fragment a box whose `overflow`
+  // is not `visible`, so any that leaked through clipped text at the page
+  // break instead of letting it flow onto the next page.
+  test('scroll containers unclip the article for pagination', async ({ page }) => {
+    await createLongPage(page, `Print Clipping Page ${Date.now()}`);
+    await page.locator('article').waitFor({ state: 'visible' });
+
+    await page.emulateMedia({ media: 'print' });
+
+    const overflow = await page.evaluate(() => {
+      const selectors = [
+        '.app-layout__main-column',
+        '#scroll-container',
+        '.page-viewer',
+        '.page-viewer__body',
+        '.page-viewer__content',
+      ];
+      return selectors.map((selector) => {
+        const el = document.querySelector(selector);
+        if (!el) return { selector, found: false, overflowX: '', overflowY: '' };
+        const style = getComputedStyle(el);
+        return {
+          selector,
+          found: true,
+          overflowX: style.overflowX,
+          overflowY: style.overflowY,
+        };
+      });
+    });
+
+    for (const entry of overflow) {
+      expect(entry.found, `${entry.selector} should be present`).toBe(true);
+      expect(entry.overflowX, `${entry.selector} overflow-x in print`).toBe('visible');
+      expect(entry.overflowY, `${entry.selector} overflow-y in print`).toBe('visible');
+    }
+  });
+
+  // Regression for #1531: headings need break hygiene so they stay attached to
+  // the text they introduce rather than being stranded at a page bottom.
+  test('headings carry print break hints', async ({ page }) => {
+    await createLongPage(page, `Print Break Hints Page ${Date.now()}`);
+    await page.locator('article h2').first().waitFor({ state: 'visible' });
+
+    await page.emulateMedia({ media: 'print' });
+
+    const heading = await page.evaluate(() => {
+      const el = document.querySelector('.page-viewer__content h2');
+      if (!el) return null;
+      const style = getComputedStyle(el);
+      return { breakAfter: style.breakAfter, breakInside: style.breakInside };
+    });
+
+    expect(heading).not.toBeNull();
+    expect(heading?.breakAfter).toBe('avoid');
+    expect(heading?.breakInside).toBe('avoid');
+  });
+
+  // The side TOC pane is navigation chrome — it must not print alongside the
+  // article (the in-flow inline TOC is already hidden for print).
+  test('side TOC pane is hidden in print', async ({ page }) => {
+    await createLongPage(page, `Print TOC Page ${Date.now()}`);
+    await page.locator('article').waitFor({ state: 'visible' });
+
+    await page.emulateMedia({ media: 'print' });
+
+    const tocDisplay = await page.evaluate(() => {
+      const el = document.querySelector('#app-toc-pane-root');
+      if (!el) return 'missing';
+      return getComputedStyle(el).display;
+    });
+
+    expect(tocDisplay === 'none' || tocDisplay === 'missing').toBe(true);
+  });
+});

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -3616,15 +3616,31 @@
       margin: 1cm;
     }
 
+    /* Neutralise every scroll/clip container between <html> and the article.
+       Chromium treats a box whose `overflow` is not `visible` as monolithic
+       (unbreakable) during pagination, so content crossing a page boundary is
+       clipped instead of flowing onto the next page — see #1531. The flex
+       `min-height`/`height` constraints from the on-screen layout have to go
+       for the same reason. */
     main,
     article,
     #root,
     .app-layout__content-wrapper,
+    .app-layout__main-column,
+    .app-layout__main-content-area,
+    .app-layout__main-content-area-editor,
     .app-layout__content-row,
     .page-viewer,
-    .page-viewer__content {
+    .page-viewer__body,
+    .page-viewer__content,
+    .page-history__preview-body,
+    .markdown-editor__preview,
+    .table-wrapper {
       background: #fff !important;
-      overflow: visible;
+      overflow: visible !important;
+      height: auto !important;
+      max-height: none !important;
+      min-height: 0 !important;
     }
 
     main {
@@ -3633,8 +3649,62 @@
       border: 0 !important;
     }
 
-    .app-layout__content-wrapper {
-      height: auto !important;
+    /* Page-break hygiene for the rendered markdown: keep a heading with the
+       text it introduces, and don't split atomic blocks down the middle. */
+    .page-viewer__content,
+    .page-history__preview-body,
+    .markdown-editor__preview {
+      orphans: 3;
+      widows: 3;
+    }
+
+    .page-viewer__content :where(h1, h2, h3, h4, h5, h6),
+    .page-history__preview-body :where(h1, h2, h3, h4, h5, h6),
+    .markdown-editor__preview :where(h1, h2, h3, h4, h5, h6) {
+      break-after: avoid;
+      break-inside: avoid;
+    }
+
+    .page-viewer__content
+      :where(
+        pre,
+        blockquote,
+        figure,
+        img,
+        tr,
+        thead,
+        .katex-display,
+        .markdown-shoutout
+      ),
+    .page-history__preview-body
+      :where(
+        pre,
+        blockquote,
+        figure,
+        img,
+        tr,
+        thead,
+        .katex-display,
+        .markdown-shoutout
+      ),
+    .markdown-editor__preview
+      :where(
+        pre,
+        blockquote,
+        figure,
+        img,
+        tr,
+        thead,
+        .katex-display,
+        .markdown-shoutout
+      ) {
+      break-inside: avoid;
+    }
+
+    .page-viewer__content :where(img),
+    .page-history__preview-body :where(img),
+    .markdown-editor__preview :where(img) {
+      max-height: 100vh;
     }
 
     html.dark,
@@ -3738,6 +3808,13 @@
     #sidebar-container,
     header,
     .sidebar-wrapper {
+      display: none !important;
+    }
+
+    /* The side TOC pane is navigation chrome, not article content — the
+       in-flow inline TOC is already `print:hidden` for the same reason. */
+    #app-toc-pane-root,
+    .app-layout__toc-pane {
       display: none !important;
     }
 


### PR DESCRIPTION
## Summary

Fixes #1531 — when printing a page (physical printer or PDF), lines of text were cut off at the bottom of a page and reappeared as slivers at the top of the next one, regardless of margin settings.

## Root cause

The `@media print` block only reset `overflow` on a subset of the layout wrappers. `.app-layout__main-column` (`overflow:hidden`), `.app-layout__content-row`, `.page-viewer__body` and `.table-wrapper` kept their on-screen scroll/clip behaviour. Chromium treats a box whose `overflow` is not `visible` as **monolithic** (unbreakable) during pagination, so content crossing a page boundary is clipped instead of flowing onto the next page.

## Changes

`ui/leafwiki-ui/src/index.css` (`@media print` only):

- Reset `overflow`/`height`/`max-height`/`min-height` on the full layout + preview ancestor chain so the article paginates as one flow (absorbs the old standalone `.app-layout__content-wrapper` height rule).
- Page-break hygiene for the rendered markdown: `orphans`/`widows: 3`; `break-after`/`break-inside: avoid` on headings; `break-inside: avoid` on `pre`, `blockquote`, `figure`, `img`, `tr`, `thead`, `.katex-display`, `.markdown-shoutout`; cap printed image height.
- Hide the side TOC pane in print (the inline TOC was already `print:hidden`).

## Tests

New `e2e/tests/print.spec.ts` (3 tests) — under `emulateMedia({ media: 'print' })` it asserts the scroll/clip ancestor chain computes `overflow: visible`, headings compute `break-after`/`break-inside: avoid`, and the TOC pane is `display: none`. Confirmed failing on `main`, passing with this change.

- `npm run format` run in `ui/leafwiki-ui` and `e2e`; lint clean in both.
- Full UI unit suite green.

## Not included

The issue's secondary ask — author-controlled manual page breaks — is a separate feature and is left out of this fix.