### PR TITLE
fix(auth): show a readable error when password reset rejects a weak password

### DIFF
--- a/ui/leafwiki-ui/src/features/auth/SetPasswordForm.test.tsx
+++ b/ui/leafwiki-ui/src/features/auth/SetPasswordForm.test.tsx
@@ -2,6 +2,7 @@ import '@/lib/i18n'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router'
+import { toast } from 'sonner'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { SetPasswordForm } from './SetPasswordForm'
 
@@ -17,6 +18,18 @@ vi.mock('@/lib/api/auth', () => ({
 vi.mock('sonner', () => ({
   toast: { error: vi.fn(), success: vi.fn() },
 }))
+
+// The backend rejects a too-short password with this body shape, which is
+// NOT the localized-error envelope — see asApiValidationError.
+const validationErrorBody = {
+  error: 'validation_error',
+  fields: [
+    {
+      field: 'newPassword',
+      message: 'New password must be at least 8 characters long',
+    },
+  ],
+}
 
 function renderResetForm(path = '/reset-password?token=abc.def') {
   return render(
@@ -50,6 +63,7 @@ describe('SetPasswordForm reset mode', () => {
   beforeEach(() => {
     confirmPasswordResetMock.mockReset()
     acceptInviteMock.mockReset()
+    vi.mocked(toast.error).mockReset()
   })
 
   it('redirects to /login when no token is present in the URL', () => {
@@ -67,6 +81,41 @@ describe('SetPasswordForm reset mode', () => {
 
     expect(screen.getByText('Passwords do not match')).toBeInTheDocument()
     expect(confirmPasswordResetMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a too-short password inline without calling the API', async () => {
+    const user = userEvent.setup()
+    renderResetForm()
+
+    await user.type(screen.getByTestId('set-password-new'), 'short')
+    await user.type(screen.getByTestId('set-password-confirm'), 'short')
+    await user.click(screen.getByTestId('set-password-submit'))
+
+    expect(
+      screen.getByText('Password must be at least 8 characters long'),
+    ).toBeInTheDocument()
+    expect(confirmPasswordResetMock).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a readable message (not "validation_error") when the API rejects the password', async () => {
+    confirmPasswordResetMock.mockRejectedValue(validationErrorBody)
+    const user = userEvent.setup()
+    renderResetForm()
+
+    await user.type(screen.getByTestId('set-password-new'), 'a-new-password')
+    await user.type(
+      screen.getByTestId('set-password-confirm'),
+      'a-new-password',
+    )
+    await user.click(screen.getByTestId('set-password-submit'))
+
+    await waitFor(() => expect(confirmPasswordResetMock).toHaveBeenCalledOnce())
+    // handleFieldErrors renders the backend's per-field message verbatim.
+    expect(
+      await screen.findByText(validationErrorBody.fields[0].message),
+    ).toBeInTheDocument()
+    expect(screen.queryByText('validation_error')).not.toBeInTheDocument()
+    expect(toast.error).not.toHaveBeenCalledWith('validation_error')
   })
 
   it('shows a success message and does NOT navigate home on success', async () => {
@@ -103,6 +152,26 @@ describe('SetPasswordForm invite mode', () => {
   beforeEach(() => {
     confirmPasswordResetMock.mockReset()
     acceptInviteMock.mockReset()
+    vi.mocked(toast.error).mockReset()
+  })
+
+  it('surfaces a readable message (not "validation_error") when the API rejects the password', async () => {
+    acceptInviteMock.mockRejectedValue(validationErrorBody)
+    const user = userEvent.setup()
+    renderInviteForm()
+
+    await user.type(screen.getByTestId('set-password-new'), 'a-new-password')
+    await user.type(
+      screen.getByTestId('set-password-confirm'),
+      'a-new-password',
+    )
+    await user.click(screen.getByTestId('set-password-submit'))
+
+    await waitFor(() => expect(acceptInviteMock).toHaveBeenCalledOnce())
+    expect(
+      await screen.findByText(validationErrorBody.fields[0].message),
+    ).toBeInTheDocument()
+    expect(screen.queryByText('validation_error')).not.toBeInTheDocument()
   })
 
   it('calls acceptInvite and navigates home on success', async () => {

--- a/ui/leafwiki-ui/src/features/auth/SetPasswordForm.tsx
+++ b/ui/leafwiki-ui/src/features/auth/SetPasswordForm.tsx
@@ -1,16 +1,21 @@
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { acceptInvite, confirmPasswordReset } from '@/lib/api/auth'
-import { mapApiError } from '@/lib/api/errors'
+import { handleFieldErrors } from '@/lib/handleFieldErrors'
 import { useBrandingStore } from '@/stores/branding'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, Navigate, useNavigate, useSearchParams } from 'react-router'
-import { toast } from 'sonner'
 
 type SetPasswordFormProps = {
   mode: 'reset' | 'invite'
 }
+
+// Mirrors coreauth.MinPasswordLength. The backend rejects a shorter password
+// with a `validation_error` body; checking it here first spares the round
+// trip and shows a localized message (the backend's field messages are not
+// translated) — same reasoning as ChangeOwnPasswordPanel.
+const MIN_PASSWORD_LENGTH = 8
 
 // SetPasswordForm backs both /reset-password and /accept-invite: the two
 // flows share everything except which endpoint they call and what happens on
@@ -26,7 +31,7 @@ export function SetPasswordForm({ mode }: SetPasswordFormProps) {
 
   const [newPassword, setNewPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
-  const [error, setError] = useState<string | null>(null)
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
   const [loading, setLoading] = useState(false)
   const [resetSucceeded, setResetSucceeded] = useState(false)
 
@@ -38,10 +43,17 @@ export function SetPasswordForm({ mode }: SetPasswordFormProps) {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    setError(null)
+    setFieldErrors({})
 
+    if (newPassword.length < MIN_PASSWORD_LENGTH) {
+      setFieldErrors({ newPassword: t(`${ns}.passwordTooShort`) })
+      return
+    }
+
+    // The backend only ever sees `newPassword`, so the confirm-match check has
+    // no server-side counterpart and must run here.
     if (newPassword !== confirmPassword) {
-      setError(t(`${ns}.passwordsDoNotMatch`))
+      setFieldErrors({ confirmPassword: t(`${ns}.passwordsDoNotMatch`) })
       return
     }
 
@@ -56,8 +68,10 @@ export function SetPasswordForm({ mode }: SetPasswordFormProps) {
         navigate('/', { replace: true })
       }
     } catch (err) {
-      const mapped = mapApiError(err, t(`${ns}.errorFallback`))
-      toast.error(mapped.message)
+      // Routes a `validation_error` body to per-field messages (e.g. a
+      // password the backend still rejects) and falls back to a toast for
+      // anything else — an invalid/expired token, a network failure.
+      handleFieldErrors(err, setFieldErrors, t(`${ns}.errorFallback`))
     } finally {
       setLoading(false)
     }
@@ -109,6 +123,11 @@ export function SetPasswordForm({ mode }: SetPasswordFormProps) {
               data-testid="set-password-new"
               spellCheck={false}
             />
+            {fieldErrors.newPassword && (
+              <p className="text-error mt-1 text-sm">
+                {fieldErrors.newPassword}
+              </p>
+            )}
           </div>
           <div className="login__field">
             <Input
@@ -122,8 +141,12 @@ export function SetPasswordForm({ mode }: SetPasswordFormProps) {
               data-testid="set-password-confirm"
               spellCheck={false}
             />
+            {fieldErrors.confirmPassword && (
+              <p className="text-error mt-1 text-sm">
+                {fieldErrors.confirmPassword}
+              </p>
+            )}
           </div>
-          {error && <p className="text-error mb-4 text-sm">{error}</p>}
 
           <Button
             type="submit"

--- a/ui/leafwiki-ui/src/lib/api/auth.test.ts
+++ b/ui/leafwiki-ui/src/lib/api/auth.test.ts
@@ -2,7 +2,7 @@ import '@/lib/i18n'
 import { useConfigStore } from '@/stores/config'
 import { useSessionStore } from '@/stores/session'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { ensureRefresh, fetchWithAuth } from './auth'
+import { confirmPasswordReset, ensureRefresh, fetchWithAuth } from './auth'
 
 type MockResponseSpec = {
   status: number
@@ -240,5 +240,35 @@ describe('fetchWithAuth', () => {
       calledPaths(fetchMock).some((p) => p.endsWith('/api/auth/logout')),
     ).toBe(true)
     expect(useSessionStore.getState().user).toBeNull()
+  })
+})
+
+describe('confirmPasswordReset', () => {
+  it('re-throws a field-validation body untouched instead of the literal "validation_error"', async () => {
+    const body = {
+      error: 'validation_error',
+      fields: [
+        {
+          field: 'newPassword',
+          message: 'New password must be at least 8 characters long',
+        },
+      ],
+    }
+    const fetchMock = createFetchMock({
+      '/api/auth/password/reset': { status: 400, body },
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const err = await confirmPasswordReset('tok', 'short').then(
+      () => {
+        throw new Error('expected confirmPasswordReset to reject')
+      },
+      (e: unknown) => e,
+    )
+
+    // Regression: it used to arrive as new Error("validation_error"), which
+    // handleFieldErrors cannot route to a field.
+    expect(err).not.toBeInstanceOf(Error)
+    expect(err).toEqual(body)
   })
 })

--- a/ui/leafwiki-ui/src/lib/api/auth.ts
+++ b/ui/leafwiki-ui/src/lib/api/auth.ts
@@ -94,6 +94,18 @@ async function postLoginRequest<T>(path: string, body: object): Promise<T> {
       throw new ApiLocalizedError(errorBody.error)
     }
 
+    // Field-validation errors use their own body shape
+    // ({ error: 'validation_error', fields: [...] }) — re-throw it untouched
+    // so callers can surface per-field messages instead of the literal
+    // string "validation_error". Mirrors fetchWithAuth's handling.
+    if (
+      errorBody &&
+      typeof errorBody === 'object' &&
+      (errorBody as { error?: unknown }).error === 'validation_error'
+    ) {
+      throw errorBody
+    }
+
     if (
       errorBody &&
       typeof errorBody === 'object' &&

--- a/ui/leafwiki-ui/src/locales/de/auth.json
+++ b/ui/leafwiki-ui/src/locales/de/auth.json
@@ -42,7 +42,8 @@
     "successTitle": "Passwort zurückgesetzt",
     "successDescription": "Ihr Passwort wurde zurückgesetzt. Bitte melden Sie sich mit Ihrem neuen Passwort an.",
     "goToLogin": "Zur Anmeldung",
-    "passwordsDoNotMatch": "Passwörter stimmen nicht überein"
+    "passwordsDoNotMatch": "Passwörter stimmen nicht überein",
+    "passwordTooShort": "Das Passwort muss mindestens 8 Zeichen lang sein"
   },
   "acceptInvite": {
     "pageTitle": "Einladung annehmen - {{siteName}}",
@@ -53,7 +54,8 @@
     "submit": "Passwort festlegen und fortfahren",
     "submitting": "Passwort wird festgelegt...",
     "errorFallback": "Dieser Einladungslink ist möglicherweise ungültig oder abgelaufen.",
-    "passwordsDoNotMatch": "Passwörter stimmen nicht überein"
+    "passwordsDoNotMatch": "Passwörter stimmen nicht überein",
+    "passwordTooShort": "Das Passwort muss mindestens 8 Zeichen lang sein"
   },
   "apiErrors": {
     "unauthorized": "Nicht autorisiert",

--- a/ui/leafwiki-ui/src/locales/en/auth.json
+++ b/ui/leafwiki-ui/src/locales/en/auth.json
@@ -42,7 +42,8 @@
     "successTitle": "Password reset",
     "successDescription": "Your password has been reset. Please log in with your new password.",
     "goToLogin": "Go to login",
-    "passwordsDoNotMatch": "Passwords do not match"
+    "passwordsDoNotMatch": "Passwords do not match",
+    "passwordTooShort": "Password must be at least 8 characters long"
   },
   "acceptInvite": {
     "pageTitle": "Accept Invite - {{siteName}}",
@@ -53,7 +54,8 @@
     "submit": "Set password and continue",
     "submitting": "Setting password...",
     "errorFallback": "This invite link may be invalid or expired.",
-    "passwordsDoNotMatch": "Passwords do not match"
+    "passwordsDoNotMatch": "Passwords do not match",
+    "passwordTooShort": "Password must be at least 8 characters long"
   },
   "apiErrors": {
     "unauthorized": "Unauthorized",

--- a/ui/leafwiki-ui/src/locales/es/auth.json
+++ b/ui/leafwiki-ui/src/locales/es/auth.json
@@ -42,7 +42,8 @@
     "successTitle": "Contraseña restablecida",
     "successDescription": "Tu contraseña se ha restablecido. Inicia sesión con tu nueva contraseña.",
     "goToLogin": "Ir a iniciar sesión",
-    "passwordsDoNotMatch": "Las contraseñas no coinciden"
+    "passwordsDoNotMatch": "Las contraseñas no coinciden",
+    "passwordTooShort": "La contraseña debe tener al menos 8 caracteres"
   },
   "acceptInvite": {
     "pageTitle": "Aceptar Invitación - {{siteName}}",
@@ -53,7 +54,8 @@
     "submit": "Establecer contraseña y continuar",
     "submitting": "Estableciendo contraseña...",
     "errorFallback": "Es posible que este enlace de invitación no sea válido o haya caducado.",
-    "passwordsDoNotMatch": "Las contraseñas no coinciden"
+    "passwordsDoNotMatch": "Las contraseñas no coinciden",
+    "passwordTooShort": "La contraseña debe tener al menos 8 caracteres"
   },
   "apiErrors": {
     "unauthorized": "No autorizado",


### PR DESCRIPTION
## Problem

On `/reset-password` (and `/accept-invite`), submitting a new password the backend rejects — e.g. shorter than the 8-character minimum — showed a toast containing the literal string **`validation_error`** instead of a helpful message.
