### PR TITLE
fix(auth): clear invitation-pending when an admin sets the password

### DIFF
--- a/internal/core/auth/user_invite_test.go
+++ b/internal/core/auth/user_invite_test.go
@@ -62,3 +62,64 @@ func TestUserService_CompleteInvite_ClearsMustSetPasswordAndSetsPassword(t *test
 		t.Fatalf("expected the new password to authenticate, got error: %v", err)
 	}
 }
+
+// An admin can also complete an invite out-of-band by setting a real password
+// through the "Change Password" dialog (PUT /api/users/:id with a password)
+// instead of the invitee clicking the emailed link. That must clear the
+// pending state too, otherwise the account shows "Invitation pending" forever
+// even though it now has a usable password.
+func TestUserService_UpdateUser_AdminSetsPasswordForInvitedUser_ClearsMustSetPassword(t *testing.T) {
+	service := setupTestUserService(t)
+
+	user, err := service.InviteUser("bob", "bob@example.com", RoleEditor)
+	if err != nil {
+		t.Fatalf("InviteUser returned error: %v", err)
+	}
+
+	updated, err := service.UpdateUser(user.ID, user.Username, user.Email, "an-admin-set-password", "")
+	if err != nil {
+		t.Fatalf("UpdateUser returned error: %v", err)
+	}
+	if updated.MustSetPassword {
+		t.Fatalf("expected MustSetPassword false on the returned user after an admin set a password")
+	}
+
+	stored, err := service.GetUserByID(user.ID)
+	if err != nil {
+		t.Fatalf("GetUserByID returned error: %v", err)
+	}
+	if stored.MustSetPassword {
+		t.Fatalf("expected MustSetPassword to be cleared in the store after an admin set a password")
+	}
+
+	if _, err := service.DoesIDAndPasswordMatch(user.ID, "an-admin-set-password"); err != nil {
+		t.Fatalf("expected the admin-set password to authenticate, got error: %v", err)
+	}
+}
+
+// A profile/role edit that does not set a password must leave an outstanding
+// invite pending — only an explicit password set completes it.
+func TestUserService_UpdateUser_NoPassword_KeepsInvitedUserPending(t *testing.T) {
+	service := setupTestUserService(t)
+
+	user, err := service.InviteUser("bob", "bob@example.com", RoleEditor)
+	if err != nil {
+		t.Fatalf("InviteUser returned error: %v", err)
+	}
+
+	updated, err := service.UpdateUser(user.ID, "bobby", user.Email, "", RoleViewer)
+	if err != nil {
+		t.Fatalf("UpdateUser returned error: %v", err)
+	}
+	if !updated.MustSetPassword {
+		t.Fatalf("expected a password-less edit to leave MustSetPassword true")
+	}
+
+	stored, err := service.GetUserByID(user.ID)
+	if err != nil {
+		t.Fatalf("GetUserByID returned error: %v", err)
+	}
+	if !stored.MustSetPassword {
+		t.Fatalf("expected MustSetPassword to persist as true after a password-less edit")
+	}
+}

--- a/internal/core/auth/user_service.go
+++ b/internal/core/auth/user_service.go
@@ -238,6 +238,20 @@ func (s *UserService) UpdateUser(id, username, email, password, role string) (*U
 		return nil, err
 	}
 
+	// An admin setting a real password out-of-band (e.g. via the "Change
+	// Password" dialog) completes an outstanding invite: the account now has a
+	// usable password, so it must stop showing as "invitation pending". This is
+	// the admin-driven equivalent of CompleteInvite, which handles the email
+	// accept flow. must_set_password lives outside UserStore.UpdateUser's
+	// UPDATE, so it has to be cleared explicitly.
+	if password != "" && user.MustSetPassword {
+		if err := s.store.SetMustSetPassword(user.ID, false); err != nil {
+			return nil, err
+		}
+		user.MustSetPassword = false
+		s.log.Info("invite completed via admin password change", "userID", user.ID)
+	}
+
 	if oldRole != user.Role {
 		s.log.Info("user role changed", "userID", user.ID, "oldRole", oldRole, "newRole", user.Role)
 	} else {


### PR DESCRIPTION
## Problem

`must_set_password` (the flag behind the **Invitation pending** pill and the **Resend invite** button in user management) was only ever cleared by `UserService.CompleteInvite`, which is reached exclusively via the emailed invite-link flow (`EmailTokenService.ConfirmInvite`).

If an admin instead set a real password for an invited user through the **Change Password** dialog (`PUT /api/users/:id` with a `password` field), the password was hashed and stored — the user could log in — but `must_set_password` stayed `true`:

- the row kept showing **Invitation pending** + **Resend invite** indefinitely, even after a fresh `GET /api/users`;
- if SMTP had since been disabled, `resendInvite` returns `ErrEmailDisabled`, so there was **no** admin-facing way to clear the state short of editing `users.db`.

`UserStore.UpdateUser`'s `UPDATE` never touched the column, and `UserService.UpdateUser` didn't either.

## Fix

`UserService.UpdateUser`: after the store write, when a non-empty `password` was supplied **and** the user still had `MustSetPassword == true`, clear it via `store.SetMustSetPassword(id, false)`, update the returned struct, and log `invite completed via admin password change`. This is the admin-driven equivalent of `CompleteInvite`.

Ordering is deliberate (password first, then flag): if the flag write fails the account can still log in and the display self-heals on the next edit. A password-less profile/role edit still leaves an outstanding invite pending.

## Tests

`internal/core/auth/user_invite_test.go`:

- `TestUserService_UpdateUser_AdminSetsPasswordForInvitedUser_ClearsMustSetPassword` — written first, confirmed failing before the fix
- `TestUserService_UpdateUser_NoPassword_KeepsInvitedUserPending` — guards the password-less edit path

Verified: `internal/core/auth`, `internal/wiki/auth`, `internal/http` suites green; `golangci-lint` v2 reports 0 issues.

## Out of scope (follow-ups)

- An outstanding invite **token** stays valid until its TTL or first use even after an admin sets the password out-of-band. Low risk (holder is the intended invitee or the admin); invalidating live invite tokens on an admin password set would be tidier.
- `ConfirmInviteUseCase.Execute` doesn't call `resolver.Reload()` after completing an invite (unlike `InviteUserUseCase`). Only affects author-name cache freshness, not the pending pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)