### PR TITLE
fix(ui): make --muted a subtle surface, not the muted-foreground color

### DIFF
--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -153,7 +153,7 @@
     --markdown-toolbar-border: 214 32% 91%;
     --markdown-toolbar-text: 215 25% 27%;
 
-    --muted: 215 16% 47%;
+    --muted: 210 40% 96%;
     --muted-foreground: 215 16% 47%;
 
     --headline-anchor-icon: 215 20% 65%;
@@ -230,8 +230,8 @@
     --markdown-toolbar-border: 220 14% 26%;
     --markdown-toolbar-text: 220 8% 78%;
 
-    /* ---- MUTED TEXT / ICONS ---- */
-    --muted: 220 10% 60%;
+    /* ---- MUTED SURFACE + TEXT / ICONS ---- */
+    --muted: 222 16% 18%;
     --muted-foreground: 220 10% 60%;
 
     --headline-anchor-icon: 220 12% 65%;
@@ -3759,7 +3759,7 @@
       --markdown-toolbar-border: 214 32% 91% !important;
       --markdown-toolbar-text: 215 25% 27% !important;
 
-      --muted: 215 16% 47% !important;
+      --muted: 210 40% 96% !important;
       --muted-foreground: 215 16% 47% !important;
 
       --headline-anchor-icon: 215 20% 65% !important;

--- a/ui/leafwiki-ui/src/lib/theme-tokens.test.ts
+++ b/ui/leafwiki-ui/src/lib/theme-tokens.test.ts
@@ -1,0 +1,44 @@
+/// <reference types="node" />
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * `--muted` is a *surface* token (consumed via `bg-muted`) and
+ * `--muted-foreground` is a *text* token. They must never resolve to the same
+ * color: when they did, `bg-muted` blocks (e.g. the shadcn `TabsList` segmented
+ * toggle in the New User dialog, the sonner toast cancel button) rendered as a
+ * heavy fill with their inactive label sitting on near-identical color.
+ *
+ * `index.css` defines both tokens once per theme block (`:root`, `.dark`, and
+ * the forced-light `@media print` override). Pair them in document order and
+ * assert each pair differs.
+ */
+// Vitest runs with cwd set to the package root (ui/leafwiki-ui).
+const cssText = readFileSync(resolve(process.cwd(), 'src/index.css'), 'utf8')
+
+function valuesOf(prop: 'muted' | 'muted-foreground'): string[] {
+  const re = new RegExp(`--${prop}:\\s*([^;!]+?)\\s*(?:!important)?;`, 'g')
+  const out: string[] = []
+  for (const m of cssText.matchAll(re)) {
+    out.push(m[1].trim().replace(/\s+/g, ' '))
+  }
+  return out
+}
+
+describe('theme tokens', () => {
+  it('defines --muted separately from --muted-foreground in every theme block', () => {
+    const muted = valuesOf('muted')
+    const mutedForeground = valuesOf('muted-foreground')
+
+    expect(muted.length).toBeGreaterThan(0)
+    expect(muted.length).toBe(mutedForeground.length)
+
+    muted.forEach((value, i) => {
+      expect(
+        value,
+        `--muted and --muted-foreground are identical ("${value}") in theme block #${i + 1}`,
+      ).not.toBe(mutedForeground[i])
+    })
+  })
+})


### PR DESCRIPTION
## Problem

The `--muted` design token (what `bg-muted` paints) was defined with the **same mid-tone value** as `--muted-foreground` in all three theme blocks of `ui/leafwiki-ui/src/index.css` (`:root`, `.dark`, and the forced-light `@media print` override):

| block | `--muted` (was) | `--muted-foreground` |
|---|---|---|
| `:root` (light) | `215 16% 47%` | `215 16% 47%` |
| `.dark` | `220 10% 60%` | `220 10% 60%` |
| `@media print` | `215 16% 47%` | `215 16% 47%` |

`--muted` is meant to be a *subtle surface*. As a mid-tone, every `bg-muted` element rendered as a heavy fill. Most visible in the **New User** dialog: the shadcn `TabsList` segmented toggle (password / invite) became a saturated bar, and its inactive `text-muted-foreground` label sat on near-identical colour and all but disappeared.

Same root cause hit the sonner toast **cancel button** (`bg-muted` + `text-muted-foreground` → invisible text), plus avatar fallbacks, Mermaid code blocks, and Select/Dropdown separators, which were all heavier than intended.

## Fix

Set `--muted` to the neutral surface already used by `--secondary` / `--accent`:
- light / print: `210 40% 96%`
- dark: `222 16% 18%`

`--muted-foreground` is unchanged. No component markup changes — `UserFormDialog`'s toggle was already correct (`w-full` + `flex-1`), it just needed the right track colour.

## Regression guard

New `ui/leafwiki-ui/src/lib/theme-tokens.test.ts` asserts `--muted` ≠ `--muted-foreground` in every theme block (fails on the old values, passes now).

## Verification

- `npx tsc --noEmit`, `npm run lint`, `npm run format` — clean
- Full Vitest suite: **80 files / 575 tests pass** (`--maxWorkers=2`)
- Manual: New User dialog toggle in light + dark — clear track, readable active pill and inactive label; spot-checked avatar fallbacks, Mermaid blocks, role dropdown separator, print preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)