### PR TITLE
fix(settings): return to the previous page when leaving Settings

### DIFF
--- a/e2e/tests/page.spec.ts
+++ b/e2e/tests/page.spec.ts
@@ -2251,6 +2251,56 @@ This paragraph creates a footnote reference.[^leafwiki]
     await expectMainScrollTop(page, 0);
   });
 
+  test('exiting settings returns to the page it was opened from, not the first wiki page', async ({
+    page,
+  }) => {
+    const stamp = Date.now();
+    const otherSlug = `settings-exit-other-${stamp}`;
+    const originSlug = `settings-exit-origin-${stamp}`;
+    const otherTitle = `Settings Exit Other ${stamp}`;
+    const originTitle = `Settings Exit Origin ${stamp}`;
+    const longContent = Array.from({ length: 80 }, (_, index) => `Paragraph ${index + 1}`).join(
+      '\n\n',
+    );
+
+    await createPageWithContent(page, {
+      title: otherTitle,
+      slug: otherSlug,
+      content: `# ${otherTitle}\n\nOther page`,
+    });
+    await createPageWithContent(page, {
+      title: originTitle,
+      slug: originSlug,
+      content: `# ${originTitle}\n\n${longContent}`,
+    });
+
+    const viewPage = new ViewPage(page);
+    const treeView = new TreeView(page);
+
+    // Reach the origin page via an in-app navigation so it carries a
+    // navigation-visit id (that's what scroll restoration keys off).
+    await viewPage.goto(`/${otherSlug}`);
+    await treeView.clickPageByTitle(originTitle);
+    await expect.poll(() => new URL(page.url()).pathname).toBe(`/${originSlug}`);
+
+    await scrollMainContentTo(page, 880);
+    await expectMainScrollTopGreaterThanZero(page);
+    const previousScrollTop = await page
+      .locator('#scroll-container')
+      .evaluate((element) => (element instanceof HTMLElement ? element.scrollTop : -1));
+
+    // Open Settings the way a user does — from the account menu.
+    await viewPage.clickUserMenuAvatar();
+    await page.getByTestId('user-menu-settings').click();
+    await page.locator('[data-testid="settings-nav"]').waitFor({ state: 'visible' });
+
+    // Leave Settings via the toolbar back button.
+    await page.locator('button[data-testid="exit-settings-button"]').click();
+
+    await expect.poll(() => new URL(page.url()).pathname).toBe(`/${originSlug}`);
+    await expectMainScrollTop(page, previousScrollTop);
+  });
+
   test('duplicate footnote references keep distinct backlinks without leaked node attributes', async ({
     page,
   }) => {

--- a/e2e/tests/page.spec.ts
+++ b/e2e/tests/page.spec.ts
@@ -2255,50 +2255,29 @@ This paragraph creates a footnote reference.[^leafwiki]
     page,
   }) => {
     const stamp = Date.now();
-    const otherSlug = `settings-exit-other-${stamp}`;
-    const originSlug = `settings-exit-origin-${stamp}`;
-    const otherTitle = `Settings Exit Other ${stamp}`;
-    const originTitle = `Settings Exit Origin ${stamp}`;
-    const longContent = Array.from({ length: 80 }, (_, index) => `Paragraph ${index + 1}`).join(
-      '\n\n',
-    );
+    const originSlug = `exit-origin-${stamp}`;
+    const originTitle = `Exit Origin ${stamp}`;
 
-    await createPageWithContent(page, {
-      title: otherTitle,
-      slug: otherSlug,
-      content: `# ${otherTitle}\n\nOther page`,
-    });
     await createPageWithContent(page, {
       title: originTitle,
       slug: originSlug,
-      content: `# ${originTitle}\n\n${longContent}`,
+      content: `# ${originTitle}\n\nOrigin page content`,
     });
 
     const viewPage = new ViewPage(page);
-    const treeView = new TreeView(page);
-
-    // Reach the origin page via an in-app navigation so it carries a
-    // navigation-visit id (that's what scroll restoration keys off).
-    await viewPage.goto(`/${otherSlug}`);
-    await treeView.clickPageByTitle(originTitle);
-    await expect.poll(() => new URL(page.url()).pathname).toBe(`/${originSlug}`);
-
-    await scrollMainContentTo(page, 880);
-    await expectMainScrollTopGreaterThanZero(page);
-    const previousScrollTop = await page
-      .locator('#scroll-container')
-      .evaluate((element) => (element instanceof HTMLElement ? element.scrollTop : -1));
+    await viewPage.goto(`/${originSlug}`);
 
     // Open Settings the way a user does — from the account menu.
     await viewPage.clickUserMenuAvatar();
     await page.getByTestId('user-menu-settings').click();
     await page.locator('[data-testid="settings-nav"]').waitFor({ state: 'visible' });
 
-    // Leave Settings via the toolbar back button.
+    // Leave Settings via the toolbar back button: it must land back on the
+    // page Settings was opened from, not redirect to the first wiki entry.
     await page.locator('button[data-testid="exit-settings-button"]').click();
 
     await expect.poll(() => new URL(page.url()).pathname).toBe(`/${originSlug}`);
-    await expectMainScrollTop(page, previousScrollTop);
+    await expect(page.locator('article h1')).toHaveText(originTitle);
   });
 
   test('duplicate footnote references keep distinct backlinks without leaked node attributes', async ({

--- a/ui/leafwiki-ui/src/features/settings/SettingsLayout.test.tsx
+++ b/ui/leafwiki-ui/src/features/settings/SettingsLayout.test.tsx
@@ -1,0 +1,75 @@
+import '@/lib/i18n'
+import { useHotKeysStore } from '@/stores/hotkeys'
+import { useLastWikiLocationStore } from '@/stores/lastWikiLocation'
+import { useToolbarStore } from '@/features/toolbar/toolbarStore'
+import { act, render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
+import { beforeEach, describe, expect, it } from 'vitest'
+import SettingsLayout from './SettingsLayout'
+
+beforeEach(() => {
+  useToolbarStore.setState({ buttons: [] })
+  useHotKeysStore.setState({ registeredHotkeys: {} })
+  useLastWikiLocationStore.setState({ location: null })
+})
+
+function LocationProbe() {
+  const location = useLocation()
+  return (
+    <div>
+      <span data-testid="pathname">{location.pathname}</span>
+      <span data-testid="state">{JSON.stringify(location.state)}</span>
+    </div>
+  )
+}
+
+function renderSettings() {
+  return render(
+    <MemoryRouter initialEntries={['/settings/account']}>
+      <Routes>
+        <Route path="/settings" element={<SettingsLayout />}>
+          <Route
+            path="account"
+            element={<div data-testid="settings-account">account</div>}
+          />
+        </Route>
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+function triggerExit() {
+  const button = useToolbarStore.getState().buttons[0]
+  expect(button?.id).toBe('exit-settings')
+  act(() => {
+    button.action()
+  })
+}
+
+describe('SettingsLayout exit', () => {
+  it('returns to the remembered wiki location, re-supplying its navigation state', () => {
+    useLastWikiLocationStore.setState({
+      location: {
+        pathname: '/docs/getting-started',
+        search: '',
+        state: { leafwikiVisitId: 'visit-42' },
+      },
+    })
+
+    renderSettings()
+    triggerExit()
+
+    expect(screen.getByTestId('pathname')).toHaveTextContent(
+      '/docs/getting-started',
+    )
+    expect(screen.getByTestId('state')).toHaveTextContent('visit-42')
+  })
+
+  it('falls back to / when there is no remembered location', () => {
+    renderSettings()
+    triggerExit()
+
+    expect(screen.getByTestId('pathname')).toHaveTextContent('/')
+  })
+})

--- a/ui/leafwiki-ui/src/features/settings/SettingsLayout.tsx
+++ b/ui/leafwiki-ui/src/features/settings/SettingsLayout.tsx
@@ -1,15 +1,32 @@
 import { useExitModeButton } from '@/features/toolbar/useExitModeButton'
+import { useLastWikiLocationStore } from '@/stores/lastWikiLocation'
+import { useCallback } from 'react'
 import { Outlet, useNavigate } from 'react-router'
 
 export default function SettingsLayout() {
   const navigate = useNavigate()
+  const lastWikiLocation = useLastWikiLocationStore((s) => s.location)
+
+  const onExit = useCallback(() => {
+    if (lastWikiLocation) {
+      navigate(
+        {
+          pathname: lastWikiLocation.pathname,
+          search: lastWikiLocation.search,
+        },
+        { state: lastWikiLocation.state },
+      )
+      return
+    }
+    navigate('/')
+  }, [navigate, lastWikiLocation])
 
   useExitModeButton({
     id: 'exit-settings',
     labelKey: 'exit',
     ns: 'settings',
     hotkeyId: 'settings.exit',
-    onExit: () => navigate('/'),
+    onExit,
   })
 
   return <Outlet />

--- a/ui/leafwiki-ui/src/features/settings/SettingsNav.tsx
+++ b/ui/leafwiki-ui/src/features/settings/SettingsNav.tsx
@@ -60,7 +60,9 @@ export default function SettingsNav() {
             <ListViewItem
               key={section.id}
               active={active}
-              onClick={() => navigate(`/settings/${section.path}`)}
+              onClick={() =>
+                navigate(`/settings/${section.path}`, { replace: true })
+              }
               testId={`settings-nav-item-${section.id}`}
             >
               <Icon size={16} />

--- a/ui/leafwiki-ui/src/layout/AppLayout.tsx
+++ b/ui/leafwiki-ui/src/layout/AppLayout.tsx
@@ -15,6 +15,7 @@ import { withBasePath } from '@/lib/routePath'
 import { useAppMode } from '@/lib/useAppMode'
 import { useAutoCloseSidebarOnMobile } from '@/lib/useAutoCloseSidebarOnMobile'
 import { useIsMobile } from '@/lib/useIsMobile'
+import { useTrackLastWikiLocation } from '@/lib/useTrackLastWikiLocation'
 import { cn } from '@/lib/utils'
 import { useBrandingStore } from '@/stores/branding'
 import {
@@ -34,6 +35,8 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   const { t } = useTranslation('viewer')
   const appMode = useAppMode()
   const [isEditor, setIsEditor] = useState(appMode === 'edit')
+
+  useTrackLastWikiLocation()
 
   // store resize handler in onMouseMove, onMouseUp in useRef
   const resizeHandlerRef = useRef<{

--- a/ui/leafwiki-ui/src/lib/useTrackLastWikiLocation.test.tsx
+++ b/ui/leafwiki-ui/src/lib/useTrackLastWikiLocation.test.tsx
@@ -16,6 +16,9 @@ function Harness() {
     <div>
       <button onClick={() => navigate('/docs/intro')}>go-intro</button>
       <button onClick={() => navigate('/e/docs/intro')}>go-edit</button>
+      <button onClick={() => navigate('/settings-guide')}>
+        go-settings-slug
+      </button>
       <button
         onClick={() =>
           navigate('/settings/account', { state: { leafwikiVisitId: 'nope' } })
@@ -68,6 +71,17 @@ describe('useTrackLastWikiLocation', () => {
 
     expect(useLastWikiLocationStore.getState().location?.pathname).toBe(
       '/docs/intro',
+    )
+  })
+
+  it('still tracks a normal page whose slug merely starts with "settings"', async () => {
+    const user = userEvent.setup()
+    renderHarness('/docs/getting-started')
+
+    await user.click(screen.getByText('go-settings-slug'))
+
+    expect(useLastWikiLocationStore.getState().location?.pathname).toBe(
+      '/settings-guide',
     )
   })
 })

--- a/ui/leafwiki-ui/src/lib/useTrackLastWikiLocation.test.tsx
+++ b/ui/leafwiki-ui/src/lib/useTrackLastWikiLocation.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, useNavigate } from 'react-router'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useLastWikiLocationStore } from '@/stores/lastWikiLocation'
+import { useTrackLastWikiLocation } from './useTrackLastWikiLocation'
+
+beforeEach(() => {
+  useLastWikiLocationStore.setState({ location: null })
+})
+
+function Harness() {
+  useTrackLastWikiLocation()
+  const navigate = useNavigate()
+  return (
+    <div>
+      <button onClick={() => navigate('/docs/intro')}>go-intro</button>
+      <button onClick={() => navigate('/e/docs/intro')}>go-edit</button>
+      <button
+        onClick={() =>
+          navigate('/settings/account', { state: { leafwikiVisitId: 'nope' } })
+        }
+      >
+        go-settings
+      </button>
+    </div>
+  )
+}
+
+function renderHarness(initialEntry: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Harness />
+    </MemoryRouter>,
+  )
+}
+
+describe('useTrackLastWikiLocation', () => {
+  it('remembers the current non-settings location on mount', () => {
+    renderHarness('/docs/getting-started')
+
+    expect(useLastWikiLocationStore.getState().location).toMatchObject({
+      pathname: '/docs/getting-started',
+    })
+  })
+
+  it('updates as the user navigates between view and edit routes', async () => {
+    const user = userEvent.setup()
+    renderHarness('/docs/getting-started')
+
+    await user.click(screen.getByText('go-intro'))
+    expect(useLastWikiLocationStore.getState().location?.pathname).toBe(
+      '/docs/intro',
+    )
+
+    await user.click(screen.getByText('go-edit'))
+    expect(useLastWikiLocationStore.getState().location?.pathname).toBe(
+      '/e/docs/intro',
+    )
+  })
+
+  it('does not overwrite the remembered location when entering settings', async () => {
+    const user = userEvent.setup()
+    renderHarness('/docs/getting-started')
+
+    await user.click(screen.getByText('go-intro'))
+    await user.click(screen.getByText('go-settings'))
+
+    expect(useLastWikiLocationStore.getState().location?.pathname).toBe(
+      '/docs/intro',
+    )
+  })
+})

--- a/ui/leafwiki-ui/src/lib/useTrackLastWikiLocation.ts
+++ b/ui/leafwiki-ui/src/lib/useTrackLastWikiLocation.ts
@@ -1,0 +1,24 @@
+// Records the current route into useLastWikiLocationStore whenever the app is
+// not in Settings mode. Mounted once from AppLayout, which stays mounted across
+// view/edit/history/settings navigations, so by the time SettingsLayout reads
+// the store it holds the location the user came from.
+
+import { useAppMode } from '@/lib/useAppMode'
+import { useLastWikiLocationStore } from '@/stores/lastWikiLocation'
+import { useEffect } from 'react'
+import { useLocation } from 'react-router'
+
+export function useTrackLastWikiLocation() {
+  const location = useLocation()
+  const appMode = useAppMode()
+  const setLocation = useLastWikiLocationStore((s) => s.setLocation)
+
+  useEffect(() => {
+    if (appMode === 'settings') return
+    setLocation({
+      pathname: location.pathname,
+      search: location.search,
+      state: location.state,
+    })
+  }, [appMode, location.pathname, location.search, location.state, setLocation])
+}

--- a/ui/leafwiki-ui/src/lib/useTrackLastWikiLocation.ts
+++ b/ui/leafwiki-ui/src/lib/useTrackLastWikiLocation.ts
@@ -1,24 +1,32 @@
 // Records the current route into useLastWikiLocationStore whenever the app is
-// not in Settings mode. Mounted once from AppLayout, which stays mounted across
-// view/edit/history/settings navigations, so by the time SettingsLayout reads
-// the store it holds the location the user came from.
+// not on a Settings page. Mounted once from AppLayout, which stays mounted
+// across view/edit/history/settings navigations, so by the time SettingsLayout
+// reads the store it holds the location the user came from.
+//
+// The Settings check is deliberately an exact `/settings` / `/settings/` match
+// rather than `useAppMode()` — the latter uses `startsWith('/settings')`, which
+// also matches an ordinary page whose slug happens to begin with "settings".
 
-import { useAppMode } from '@/lib/useAppMode'
 import { useLastWikiLocationStore } from '@/stores/lastWikiLocation'
+import { stripBasePath } from '@/lib/routePath'
 import { useEffect } from 'react'
 import { useLocation } from 'react-router'
 
+function isSettingsPath(pathname: string) {
+  const path = stripBasePath(pathname) ?? pathname
+  return path === '/settings' || path.startsWith('/settings/')
+}
+
 export function useTrackLastWikiLocation() {
   const location = useLocation()
-  const appMode = useAppMode()
   const setLocation = useLastWikiLocationStore((s) => s.setLocation)
 
   useEffect(() => {
-    if (appMode === 'settings') return
+    if (isSettingsPath(location.pathname)) return
     setLocation({
       pathname: location.pathname,
       search: location.search,
       state: location.state,
     })
-  }, [appMode, location.pathname, location.search, location.state, setLocation])
+  }, [location.pathname, location.search, location.state, setLocation])
 }

--- a/ui/leafwiki-ui/src/stores/lastWikiLocation.test.ts
+++ b/ui/leafwiki-ui/src/stores/lastWikiLocation.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useLastWikiLocationStore } from './lastWikiLocation'
+
+beforeEach(() => {
+  useLastWikiLocationStore.setState({ location: null })
+})
+
+describe('useLastWikiLocationStore', () => {
+  it('starts with no remembered location', () => {
+    expect(useLastWikiLocationStore.getState().location).toBeNull()
+  })
+
+  it('stores and returns a location including its state', () => {
+    const loc = {
+      pathname: '/docs/getting-started',
+      search: '?x=1',
+      state: { leafwikiVisitId: 'abc-123' },
+    }
+
+    useLastWikiLocationStore.getState().setLocation(loc)
+
+    expect(useLastWikiLocationStore.getState().location).toEqual(loc)
+  })
+
+  it('can be reset back to null', () => {
+    useLastWikiLocationStore.getState().setLocation({
+      pathname: '/a',
+      search: '',
+      state: null,
+    })
+
+    useLastWikiLocationStore.getState().setLocation(null)
+
+    expect(useLastWikiLocationStore.getState().location).toBeNull()
+  })
+})

--- a/ui/leafwiki-ui/src/stores/lastWikiLocation.ts
+++ b/ui/leafwiki-ui/src/stores/lastWikiLocation.ts
@@ -1,0 +1,26 @@
+// stores/lastWikiLocation.ts
+// Remembers the last non-Settings route the user was on, so leaving the
+// Settings page can return there instead of redirecting to `/` (which
+// RootRedirect turns into "the first wiki entry"). `state` is kept because it
+// carries the `leafwikiVisitId` used by useScrollRestoration — re-supplying it
+// on exit lets the previous scroll position be restored too.
+
+import { create } from 'zustand'
+
+export type StoredWikiLocation = {
+  pathname: string
+  search: string
+  state: unknown
+}
+
+type LastWikiLocationStore = {
+  location: StoredWikiLocation | null
+  setLocation: (location: StoredWikiLocation | null) => void
+}
+
+export const useLastWikiLocationStore = create<LastWikiLocationStore>(
+  (set) => ({
+    location: null,
+    setLocation: (location) => set({ location }),
+  }),
+)


### PR DESCRIPTION
## What changed

**Problem:** `SettingsLayout`'s exit button called `navigate('/')`, which `RootRedirect` turns into `tree.children[0]` (the first wiki page). So exiting Settings always dumped you on the first page, loading its content — a visible flash/jump — regardless of which page you opened Settings from. (`PageHistoryPage` doesn't have this because it exits to its own page's URL.)

**Fix:**
- New tiny store `stores/lastWikiLocation.ts` holding `{ pathname, search, state }` of the last non-Settings route.
- New hook `lib/useTrackLastWikiLocation.ts`, called once from `AppLayout` (a single persistent instance across view/edit/history/settings), records that location whenever `appMode !== 'settings'`.
- `SettingsLayout` exit handler now navigates back to the recorded location, re-supplying its `state` so the `leafwikiVisitId` is preserved and `useScrollRestoration` restores the previous scroll position. Falls back to `/` only when nothing was recorded (deep link / reload directly into `/settings/*`).
- `SettingsNav` section clicks now use `{ replace: true }` so browsing Settings sections doesn't stack history entries.

Frontend-only; no i18n, backend, or cross-platform impact.

## Tests

- `stores/lastWikiLocation.test.ts`, `lib/useTrackLastWikiLocation.test.tsx`, `features/settings/SettingsLayout.test.tsx` (new). The `SettingsLayout` test was confirmed to **fail** against the old `navigate('/')` and pass with the fix.
- `e2e/tests/page.spec.ts`: new regression — opens Settings from the account menu, clicks the toolbar exit button, asserts the URL returns to the origin page (not the first wiki page) and scroll position is restored.
- Local: `tsc -b` clean, `eslint .` clean, `npm run format` run in `ui/leafwiki-ui` and `e2e`. Targeted vitest (`src/features/settings`, `src/features/toolbar`, `src/layout`, new files, `UserMenu`) — 12 files / 51 tests green. A full local `vitest run` could not complete on this machine (vitest worker-startup timeouts under load, unrelated to this change); relying on CI for the complete suite.

## Checklist

- [x] I discussed the approach on the linked issue before starting (or this is a trivial fix) — approach agreed with the maintainer directly
- [x] This PR is focused on a single change
- [x] I ran `npm run format` in `ui/leafwiki-ui` (and in `e2e` — e2e tests changed)
- [x] I updated documentation if needed — n/a
