### PR TITLE
fix(ui): restore --muted as the muted-text token, add --muted-surface for fills

### DIFF
--- a/ui/leafwiki-ui/src/components/ErrorBoundary.tsx
+++ b/ui/leafwiki-ui/src/components/ErrorBoundary.tsx
@@ -69,7 +69,7 @@ export class ErrorBoundary extends Component<Props, State> {
           </Button>
         </div>
 
-        <details className="border-border bg-muted/40 w-full max-w-xl rounded-md border">
+        <details className="border-border bg-muted-surface/40 w-full max-w-xl rounded-md border">
           <summary className="text-muted-foreground cursor-pointer p-3 text-xs font-medium select-none">
             {i18next.t('errorBoundary.detailsSummary', { ns: 'common' })}
           </summary>

--- a/ui/leafwiki-ui/src/components/ui/avatar.tsx
+++ b/ui/leafwiki-ui/src/components/ui/avatar.tsx
@@ -37,7 +37,7 @@ const AvatarFallback = React.forwardRef<
   <AvatarPrimitive.Fallback
     ref={ref}
     className={cn(
-      'bg-muted flex h-full w-full items-center justify-center rounded-full',
+      'bg-muted-surface flex h-full w-full items-center justify-center rounded-full',
       className,
     )}
     {...props}

--- a/ui/leafwiki-ui/src/components/ui/dropdown-menu.tsx
+++ b/ui/leafwiki-ui/src/components/ui/dropdown-menu.tsx
@@ -161,7 +161,7 @@ const DropdownMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn('bg-muted -mx-1 my-1 h-px', className)}
+    className={cn('bg-muted-surface -mx-1 my-1 h-px', className)}
     {...props}
   />
 ))

--- a/ui/leafwiki-ui/src/components/ui/select.tsx
+++ b/ui/leafwiki-ui/src/components/ui/select.tsx
@@ -137,7 +137,7 @@ const SelectSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Separator
     ref={ref}
-    className={cn('bg-muted -mx-1 my-1 h-px', className)}
+    className={cn('bg-muted-surface -mx-1 my-1 h-px', className)}
     {...props}
   />
 ))

--- a/ui/leafwiki-ui/src/components/ui/sonner.tsx
+++ b/ui/leafwiki-ui/src/components/ui/sonner.tsx
@@ -18,7 +18,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
           actionButton:
             'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
           cancelButton:
-            'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
+            'group-[.toast]:bg-muted-surface group-[.toast]:text-muted-foreground',
         },
       }}
       {...props}

--- a/ui/leafwiki-ui/src/components/ui/tabs.tsx
+++ b/ui/leafwiki-ui/src/components/ui/tabs.tsx
@@ -12,7 +12,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      'bg-muted text-muted-foreground inline-flex h-9 items-center justify-center rounded-lg p-1',
+      'bg-muted-surface text-muted-foreground inline-flex h-9 items-center justify-center rounded-lg p-1',
       className,
     )}
     {...props}

--- a/ui/leafwiki-ui/src/features/imagepreview/ImagePreviewDialog.tsx
+++ b/ui/leafwiki-ui/src/features/imagepreview/ImagePreviewDialog.tsx
@@ -96,7 +96,7 @@ export function ImagePreviewDialog({ src, alt }: Props) {
               setNatural({ w: img.naturalWidth, h: img.naturalHeight })
             }}
             // Never scale up images beyond their natural size
-            className="bg-muted h-auto max-h-[75vh] w-auto max-w-full rounded-lg object-contain"
+            className="bg-muted-surface h-auto max-h-[75vh] w-auto max-w-full rounded-lg object-contain"
           />
         </div>
       </DialogContent>

--- a/ui/leafwiki-ui/src/features/preview/MermaidBlock.tsx
+++ b/ui/leafwiki-ui/src/features/preview/MermaidBlock.tsx
@@ -35,7 +35,7 @@ export default memo(function MermaidBlock({
         <p className="text-muted-foreground mt-2 pr-12 text-sm break-words">
           {errorMessage}
         </p>
-        <pre className="bg-muted mt-3 overflow-x-auto rounded-md p-3 text-sm">
+        <pre className="bg-muted-surface mt-3 overflow-x-auto rounded-md p-3 text-sm">
           <code>{code}</code>
         </pre>
       </div>

--- a/ui/leafwiki-ui/src/index.css
+++ b/ui/leafwiki-ui/src/index.css
@@ -72,6 +72,7 @@
   --color-markdown-toolbar-text: hsl(var(--markdown-toolbar-text));
 
   --color-muted: hsl(var(--muted));
+  --color-muted-surface: hsl(var(--muted-surface));
   --color-muted-foreground: hsl(var(--muted-foreground));
   --color-table-header-bg: hsl(var(--table-header-bg));
   --color-table-header-border: hsl(var(--table-header-border));
@@ -153,7 +154,10 @@
     --markdown-toolbar-border: 214 32% 91%;
     --markdown-toolbar-text: 215 25% 27%;
 
-    --muted: 210 40% 96%;
+    /* --muted is a *text/icon* token (consumed via `text-muted`, `border-muted`).
+       `bg-*` surfaces use --muted-surface instead — see theme-tokens.test.ts. */
+    --muted: 215 16% 47%;
+    --muted-surface: 210 40% 96%;
     --muted-foreground: 215 16% 47%;
 
     --headline-anchor-icon: 215 20% 65%;
@@ -230,8 +234,9 @@
     --markdown-toolbar-border: 220 14% 26%;
     --markdown-toolbar-text: 220 8% 78%;
 
-    /* ---- MUTED SURFACE + TEXT / ICONS ---- */
-    --muted: 222 16% 18%;
+    /* ---- MUTED TEXT / ICONS  (surface = --muted-surface) ---- */
+    --muted: 220 10% 60%;
+    --muted-surface: 222 16% 18%;
     --muted-foreground: 220 10% 60%;
 
     --headline-anchor-icon: 220 12% 65%;
@@ -3759,7 +3764,8 @@
       --markdown-toolbar-border: 214 32% 91% !important;
       --markdown-toolbar-text: 215 25% 27% !important;
 
-      --muted: 210 40% 96% !important;
+      --muted: 215 16% 47% !important;
+      --muted-surface: 210 40% 96% !important;
       --muted-foreground: 215 16% 47% !important;
 
       --headline-anchor-icon: 215 20% 65% !important;

--- a/ui/leafwiki-ui/src/lib/theme-tokens.test.ts
+++ b/ui/leafwiki-ui/src/lib/theme-tokens.test.ts
@@ -4,20 +4,27 @@ import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 /**
- * `--muted` is a *surface* token (consumed via `bg-muted`) and
- * `--muted-foreground` is a *text* token. They must never resolve to the same
- * color: when they did, `bg-muted` blocks (e.g. the shadcn `TabsList` segmented
- * toggle in the New User dialog, the sonner toast cancel button) rendered as a
- * heavy fill with their inactive label sitting on near-identical color.
+ * Token roles in `index.css`:
+ *   --muted           text/icon color, consumed via `text-muted` / `border-muted`
+ *                     (~160 usages: tree headers, chevrons, panel labels, ...).
+ *   --muted-surface   subtle fill, consumed via `bg-muted-surface`
+ *                     (shadcn TabsList / avatar / separators, sonner toast,
+ *                     Mermaid code blocks).
+ *   --muted-foreground shadcn's inactive-text color, pairs with `bg-muted-surface`.
  *
- * `index.css` defines both tokens once per theme block (`:root`, `.dark`, and
- * the forced-light `@media print` override). Pair them in document order and
- * assert each pair differs.
+ * `--muted-surface` must never resolve to the same color as `--muted-foreground`:
+ * when it did (#1541 briefly collapsed `--muted` into the fill role), `bg-muted`
+ * blocks rendered as a heavy fill with their inactive label sitting on
+ * near-identical color, and every `text-muted` in the app turned near-invisible.
+ *
+ * Each token is defined once per theme block (`:root`, `.dark`, and the
+ * forced-light `@media print` override). Pair them in document order and assert
+ * each surface/foreground pair differs.
  */
 // Vitest runs with cwd set to the package root (ui/leafwiki-ui).
 const cssText = readFileSync(resolve(process.cwd(), 'src/index.css'), 'utf8')
 
-function valuesOf(prop: 'muted' | 'muted-foreground'): string[] {
+function valuesOf(prop: 'muted-surface' | 'muted-foreground'): string[] {
   const re = new RegExp(`--${prop}:\\s*([^;!]+?)\\s*(?:!important)?;`, 'g')
   const out: string[] = []
   for (const m of cssText.matchAll(re)) {
@@ -27,18 +34,18 @@ function valuesOf(prop: 'muted' | 'muted-foreground'): string[] {
 }
 
 describe('theme tokens', () => {
-  it('defines --muted separately from --muted-foreground in every theme block', () => {
-    const muted = valuesOf('muted')
-    const mutedForeground = valuesOf('muted-foreground')
+  it('defines --muted-surface separately from --muted-foreground in every theme block', () => {
+    const surface = valuesOf('muted-surface')
+    const foreground = valuesOf('muted-foreground')
 
-    expect(muted.length).toBeGreaterThan(0)
-    expect(muted.length).toBe(mutedForeground.length)
+    expect(surface.length).toBeGreaterThan(0)
+    expect(surface.length).toBe(foreground.length)
 
-    muted.forEach((value, i) => {
+    surface.forEach((value, i) => {
       expect(
         value,
-        `--muted and --muted-foreground are identical ("${value}") in theme block #${i + 1}`,
-      ).not.toBe(mutedForeground[i])
+        `--muted-surface and --muted-foreground are identical ("${value}") in theme block #${i + 1}`,
+      ).not.toBe(foreground[i])
     })
   })
 })


### PR DESCRIPTION
## Problem

The tree sidebar (Explorer / Search tabs) and various panels rendered with near-invisible text after #1541.

In #1541 `--muted` was repointed at a light surface color to fix a few `bg-muted` blocks (New User dialog `TabsList`, sonner toast, avatar fallbacks, menu separators, Mermaid code blocks). But in this codebase `--muted` is bound to Tailwind via `--color-muted` and is used as a **text/icon color** at ~160 call sites — `text-muted` / `border-muted` on tree section headers, chevrons, panel labels, tab captions. Turning it into a near-white surface made all of that text nearly disappear.

## Fix

- Restore `--muted` to its pre-#1541 values: `215 16% 47%` (light), `220 10% 60%` (dark), and the same in the forced-light `@media print` override.
- Add a dedicated **`--muted-surface`** token (`210 40% 96%` / `222 16% 18%`) plus its `--color-muted-surface` Tailwind mapping.
- Move the ~8 genuine `bg-muted` fills to `bg-muted-surface` (`tabs`, `avatar`, `select`, `dropdown-menu`, `sonner`, `MermaidBlock`, `ImagePreviewDialog`, `ErrorBoundary`), so #1541's intent is preserved without collapsing the text role.
- `theme-tokens.test.ts` now asserts `--muted-surface != --muted-foreground` in every theme block (the pairing that must not collapse into a heavy fill), instead of `--muted != --muted-foreground` (those now intentionally share the mid-tone).

## Verification

- `npm run build` (tsc + vite) green
- `npm run format` clean
- `vitest run src/components src/lib` — 148 passing, incl. the reworked `theme-tokens.test.ts`
- Manual browser check of the Explorer/Search tree sidebar, Revision History panel and New User dialog in light + dark mode still recommended before merge.
