### PR TITLE
docs(readme): note shipped UI languages and welcome translation contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ docker run -p 8080:8080 -v ~/leafwiki-data:/app/data \
 - Inject HTML/JS into `<head>` for analytics or custom CSS
 - Branding: logo, favicon, site name
 - Dark mode and mobile-friendly UI
+- Translated UI — ships in English, German, and Spanish; `--default-language` picks the default. Contributions of other languages are very welcome — see [docs/i18n.md](docs/i18n.md)
 
 **Opt-in via feature flags:**
 - Revision history (`--enable-revision`)
@@ -773,3 +774,5 @@ Need help deploying LeafWiki for your team? [Business support & setup →](https
 
 Contributions, discussions, and feedback are welcome.  
 Open an issue or start a discussion on GitHub. Follow the repository to get notified about new releases.
+
+**Translations:** the UI currently ships in English, German, and Spanish. Adding another language is a self-contained contribution — [docs/i18n.md](docs/i18n.md) walks through it.


### PR DESCRIPTION
Follow-up to #1546 (merged). Adds two short README lines:

- **Features → Customization:** the UI ships in English, German, and Spanish; `--default-language` sets the default; other languages are welcome, pointing at `docs/i18n.md`.
- **Contributing:** a "Translations" note linking the same guide.

Related to #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)